### PR TITLE
fix: resolve all CI failures — fmt, clippy, and dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,13 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    ignore:
+      # rand 0.9+ incompatible with ed25519-dalek (requires rand ~0.8)
+      - dependency-name: "rand"
+        versions: [">=0.9"]
+      # bincode 2.0+ has breaking API changes not yet migrated
+      - dependency-name: "bincode"
+        versions: [">=2.0"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/binding/src/physical_shard.rs
+++ b/binding/src/physical_shard.rs
@@ -113,9 +113,10 @@ impl ProvenanceTracker {
         rf_proof: RfFingerprint,
         commitment: QuantumCommitment,
     ) -> Result<(), ProvenanceTrackerError> {
-        let anchor = self.anchors.get_mut(&item_id).ok_or_else(|| {
-            ProvenanceTrackerError::NotFound(format!("{:?}", &item_id[..4]))
-        })?;
+        let anchor = self
+            .anchors
+            .get_mut(&item_id)
+            .ok_or_else(|| ProvenanceTrackerError::NotFound(format!("{:?}", &item_id[..4])))?;
 
         if anchor.is_destroyed() {
             return Err(ProvenanceTrackerError::Destroyed(format!(
@@ -138,9 +139,10 @@ impl ProvenanceTracker {
         rf_proof: RfFingerprint,
         commitment: QuantumCommitment,
     ) -> Result<(), ProvenanceTrackerError> {
-        let anchor = self.anchors.get_mut(&item_id).ok_or_else(|| {
-            ProvenanceTrackerError::NotFound(format!("{:?}", &item_id[..4]))
-        })?;
+        let anchor = self
+            .anchors
+            .get_mut(&item_id)
+            .ok_or_else(|| ProvenanceTrackerError::NotFound(format!("{:?}", &item_id[..4])))?;
 
         if anchor.is_destroyed() {
             return Err(ProvenanceTrackerError::Destroyed(format!(
@@ -169,9 +171,10 @@ impl ProvenanceTracker {
         item_id: [u8; 32],
         current_rf: &[u8; 32],
     ) -> Result<(), ProvenanceTrackerError> {
-        let anchor = self.anchors.get(&item_id).ok_or_else(|| {
-            ProvenanceTrackerError::NotFound(format!("{:?}", &item_id[..4]))
-        })?;
+        let anchor = self
+            .anchors
+            .get(&item_id)
+            .ok_or_else(|| ProvenanceTrackerError::NotFound(format!("{:?}", &item_id[..4])))?;
 
         // Check RF fingerprint
         if !anchor.rf_fingerprint.verify(current_rf) {
@@ -257,10 +260,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(tracker.item_count(), 1);
-        assert_eq!(
-            tracker.current_holder(item_id),
-            Some("did:omnia:factory")
-        );
+        assert_eq!(tracker.current_holder(item_id), Some("did:omnia:factory"));
     }
 
     #[test]

--- a/binding/src/provenance.rs
+++ b/binding/src/provenance.rs
@@ -278,13 +278,16 @@ impl ProvenanceLog {
     /// payload. Returns an error if the version is unsupported.
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, bincode::Error> {
         if bytes.is_empty() {
-            return Err(Box::new(bincode::ErrorKind::Custom("Empty state bytes".into())));
+            return Err(Box::new(bincode::ErrorKind::Custom(
+                "Empty state bytes".into(),
+            )));
         }
         let version = bytes[0];
         if version != Self::PROVENANCE_LOG_VERSION {
-            return Err(Box::new(bincode::ErrorKind::Custom(
-                format!("Unsupported provenance log version: {}", version),
-            )));
+            return Err(Box::new(bincode::ErrorKind::Custom(format!(
+                "Unsupported provenance log version: {}",
+                version
+            ))));
         }
         bincode::deserialize(&bytes[1..])
     }
@@ -293,8 +296,8 @@ impl ProvenanceLog {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::rf_fingerprint::RfFingerprint;
     use crate::quantum_commit::QuantumCommitment;
+    use crate::rf_fingerprint::RfFingerprint;
 
     fn test_rf(did: &str) -> RfFingerprint {
         RfFingerprint::stub(did, [0x55u8; 32])
@@ -362,10 +365,7 @@ mod tests {
             test_anchor(),
         );
 
-        log.verify(
-            test_rf("did:omnia:alice"),
-            test_commitment(b"verification"),
-        );
+        log.verify(test_rf("did:omnia:alice"), test_commitment(b"verification"));
 
         assert_eq!(log.len(), 2);
         assert_eq!(log.events[1].event_type, ProvenanceEventType::Verified);
@@ -382,10 +382,7 @@ mod tests {
             test_anchor(),
         );
 
-        log.destroy(
-            test_rf("did:omnia:alice"),
-            test_commitment(b"destruction"),
-        );
+        log.destroy(test_rf("did:omnia:alice"), test_commitment(b"destruction"));
 
         assert_eq!(log.len(), 2);
         assert_eq!(log.events[1].event_type, ProvenanceEventType::Destroyed);

--- a/binding/src/quantum_commit.rs
+++ b/binding/src/quantum_commit.rs
@@ -68,20 +68,15 @@ pub struct PqPublicKey {
 }
 
 /// Whether we are in the classical-only, hybrid, or post-quantum phase.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub enum CommitmentPhase {
     /// Phase 1: Only classical (Ed25519) signatures are verified.
+    #[default]
     ClassicalOnly,
     /// Phase 2: Both classical and PQC signatures must verify.
     Hybrid,
     /// Phase 3: Only PQC signatures are verified.
     PostQuantum,
-}
-
-impl Default for CommitmentPhase {
-    fn default() -> Self {
-        Self::ClassicalOnly
-    }
 }
 
 impl QuantumCommitment {
@@ -96,11 +91,7 @@ impl QuantumCommitment {
     /// * `data` — The raw data being committed
     /// * `classical_sig` — Ed25519 signature over the data hash (64 bytes)
     /// * `committed_at` — Causal timestamp for the commitment
-    pub fn new_classical(
-        data: &[u8],
-        classical_sig: Vec<u8>,
-        committed_at: VectorClock,
-    ) -> Self {
+    pub fn new_classical(data: &[u8], classical_sig: Vec<u8>, committed_at: VectorClock) -> Self {
         let hash = blake3::hash(data);
         Self {
             dilithium_sig: Vec::new(),

--- a/binding/tests/provenance_chain.rs
+++ b/binding/tests/provenance_chain.rs
@@ -6,7 +6,7 @@
 //! Layer's ProvenanceTracker works alongside the existing PhysicalShard.
 
 use omnia_binding::{
-    CommitmentPhase, PhysicalAnchor, ProvenanceLog, ProvenanceTracker, PqPublicKey,
+    CommitmentPhase, PhysicalAnchor, PqPublicKey, ProvenanceLog, ProvenanceTracker,
     QuantumCommitment, RfFingerprint,
 };
 use omnia_substrate::VectorClock;

--- a/economics/src/economics_shard.rs
+++ b/economics/src/economics_shard.rs
@@ -140,7 +140,9 @@ impl EconomicsState {
                 did,
                 proposal_id,
                 choice,
-            } => self.governance.vote(did, proposal_id, choice.clone(), current_epoch),
+            } => self
+                .governance
+                .vote(did, proposal_id, choice.clone(), current_epoch),
             EconomicsOp::RegisterDid { did } => {
                 self.quota.register_did(did);
                 Ok(())
@@ -178,13 +180,16 @@ impl EconomicsState {
     /// payload. Returns an error if the version is unsupported.
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, bincode::Error> {
         if bytes.is_empty() {
-            return Err(Box::new(bincode::ErrorKind::Custom("Empty state bytes".into())));
+            return Err(Box::new(bincode::ErrorKind::Custom(
+                "Empty state bytes".into(),
+            )));
         }
         let version = bytes[0];
         if version != Self::ECONOMICS_STATE_VERSION {
-            return Err(Box::new(bincode::ErrorKind::Custom(
-                format!("Unsupported economics state version: {}", version),
-            )));
+            return Err(Box::new(bincode::ErrorKind::Custom(format!(
+                "Unsupported economics state version: {}",
+                version
+            ))));
         }
         bincode::deserialize(&bytes[1..])
     }

--- a/economics/src/governance.rs
+++ b/economics/src/governance.rs
@@ -48,7 +48,12 @@ pub struct Proposal {
 
 impl Proposal {
     /// Create a new proposal.
-    pub fn new(id: String, description: String, created_at_epoch: u64, expires_at_epoch: u64) -> Self {
+    pub fn new(
+        id: String,
+        description: String,
+        created_at_epoch: u64,
+        expires_at_epoch: u64,
+    ) -> Self {
         Self {
             id,
             description,
@@ -72,7 +77,9 @@ impl Proposal {
 
     /// Get total participation (sum of all vote weights).
     pub fn total_participation(&self) -> u64 {
-        self.votes_for.saturating_add(self.votes_against).saturating_add(self.votes_abstain)
+        self.votes_for
+            .saturating_add(self.votes_against)
+            .saturating_add(self.votes_abstain)
     }
 }
 

--- a/economics/src/quota.rs
+++ b/economics/src/quota.rs
@@ -57,9 +57,9 @@ impl QuotaSystem {
     /// If the DID is already registered, this is a no-op — the existing
     /// token and balance are preserved.
     pub fn register_did(&mut self, did: &str) {
-        self.tokens
-            .entry(did.to_string())
-            .or_insert_with(|| UbcToken::new(did.to_string(), self.default_quota, self.current_epoch));
+        self.tokens.entry(did.to_string()).or_insert_with(|| {
+            UbcToken::new(did.to_string(), self.default_quota, self.current_epoch)
+        });
     }
 
     /// Advance to the next epoch, resetting all UBC balances.

--- a/economics/tests/ubc_lifecycle.rs
+++ b/economics/tests/ubc_lifecycle.rs
@@ -10,8 +10,8 @@
 //! 7. Reputation decay for inactive voters
 
 use omnia_economics::{
-    EconomicsError, EconomicsOp, EconomicsState, QuotaSystem, UbcToken,
-    UsefulWorkProof, UsefulWorkType, VoteChoice, DEFAULT_UBC_QUOTA,
+    EconomicsError, EconomicsOp, EconomicsState, QuotaSystem, UbcToken, UsefulWorkProof,
+    UsefulWorkType, VoteChoice, DEFAULT_UBC_QUOTA,
 };
 
 /// Helper: create a non-zero result hash.
@@ -41,7 +41,13 @@ fn test_ubc_spend_success() {
 fn test_ubc_spend_insufficient() {
     let mut token = UbcToken::new("did:omnia:alice".to_string(), 100, 0);
     let result = token.spend(200);
-    assert!(matches!(result, Err(EconomicsError::InsufficientUbc { have: 100, need: 200 })));
+    assert!(matches!(
+        result,
+        Err(EconomicsError::InsufficientUbc {
+            have: 100,
+            need: 200
+        })
+    ));
 }
 
 #[test]
@@ -89,10 +95,16 @@ fn test_quota_system_register_and_spend() {
     system.register_did("did:omnia:alice");
 
     assert!(system.is_registered("did:omnia:alice"));
-    assert_eq!(system.balance_of("did:omnia:alice"), Some(DEFAULT_UBC_QUOTA));
+    assert_eq!(
+        system.balance_of("did:omnia:alice"),
+        Some(DEFAULT_UBC_QUOTA)
+    );
 
     assert!(system.spend("did:omnia:alice", 300).is_ok());
-    assert_eq!(system.balance_of("did:omnia:alice"), Some(DEFAULT_UBC_QUOTA - 300));
+    assert_eq!(
+        system.balance_of("did:omnia:alice"),
+        Some(DEFAULT_UBC_QUOTA - 300)
+    );
 }
 
 #[test]
@@ -107,11 +119,17 @@ fn test_quota_system_advance_epoch() {
     let mut system = QuotaSystem::default_system();
     system.register_did("did:omnia:alice");
     system.spend("did:omnia:alice", 800).unwrap();
-    assert_eq!(system.balance_of("did:omnia:alice"), Some(DEFAULT_UBC_QUOTA - 800));
+    assert_eq!(
+        system.balance_of("did:omnia:alice"),
+        Some(DEFAULT_UBC_QUOTA - 800)
+    );
 
     system.advance_epoch();
     assert_eq!(system.current_epoch, 1);
-    assert_eq!(system.balance_of("did:omnia:alice"), Some(DEFAULT_UBC_QUOTA));
+    assert_eq!(
+        system.balance_of("did:omnia:alice"),
+        Some(DEFAULT_UBC_QUOTA)
+    );
 }
 
 #[test]
@@ -121,7 +139,10 @@ fn test_quota_system_reward() {
     system.spend("did:omnia:alice", 500).unwrap();
 
     system.reward("did:omnia:alice", 200).unwrap();
-    assert_eq!(system.balance_of("did:omnia:alice"), Some(DEFAULT_UBC_QUOTA - 500 + 200));
+    assert_eq!(
+        system.balance_of("did:omnia:alice"),
+        Some(DEFAULT_UBC_QUOTA - 500 + 200)
+    );
 }
 
 #[test]
@@ -150,7 +171,10 @@ fn test_useful_work_proof_zero_compute_units() {
         0,
         vec![1, 2, 3, 4],
     );
-    assert!(matches!(proof.validate(), Err(EconomicsError::WorkProofInvalid)));
+    assert!(matches!(
+        proof.validate(),
+        Err(EconomicsError::WorkProofInvalid)
+    ));
 }
 
 #[test]
@@ -183,7 +207,8 @@ fn test_governance_decay() {
     assert_eq!(gov.effective_weight("did:omnia:alice", 0), 10);
 
     // After voting at epoch 0, then 1 epoch of inactivity
-    gov.vote("did:omnia:alice", "prop1", VoteChoice::For, 0).ok();
+    gov.vote("did:omnia:alice", "prop1", VoteChoice::For, 0)
+        .ok();
     // Now last_active = 0, current_epoch = 1
     // inactive = 1, decay = 10 * 0.9^1 = 9
     assert_eq!(gov.effective_weight("did:omnia:alice", 1), 9);
@@ -199,15 +224,18 @@ fn test_governance_voting() {
 
     let mut gov = GovernanceState::new(0.1);
     gov.set_weight("did:omnia:alice", 100); // weight = 10
-    gov.set_weight("did:omnia:bob", 400);   // weight = 20
+    gov.set_weight("did:omnia:bob", 400); // weight = 20
 
-    gov.create_proposal("prop1".into(), "Test proposal".into(), 10, 0).unwrap();
+    gov.create_proposal("prop1".into(), "Test proposal".into(), 10, 0)
+        .unwrap();
 
     // Alice votes For (weight 10)
-    gov.vote("did:omnia:alice", "prop1", VoteChoice::For, 0).unwrap();
+    gov.vote("did:omnia:alice", "prop1", VoteChoice::For, 0)
+        .unwrap();
 
     // Bob votes Against (weight 20)
-    gov.vote("did:omnia:bob", "prop1", VoteChoice::Against, 0).unwrap();
+    gov.vote("did:omnia:bob", "prop1", VoteChoice::Against, 0)
+        .unwrap();
 
     let proposal = gov.get_proposal("prop1").unwrap();
     assert_eq!(proposal.votes_for, 10);
@@ -222,7 +250,8 @@ fn test_governance_expired_proposal() {
     let mut gov = GovernanceState::new(0.1);
     gov.set_weight("did:omnia:alice", 100);
 
-    gov.create_proposal("prop1".into(), "Expires soon".into(), 5, 0).unwrap();
+    gov.create_proposal("prop1".into(), "Expires soon".into(), 5, 0)
+        .unwrap();
 
     // Voting after expiration fails
     let result = gov.vote("did:omnia:alice", "prop1", VoteChoice::For, 6);
@@ -250,15 +279,40 @@ fn test_economics_state_full_lifecycle() {
     let epoch = state.current_epoch();
 
     // Step 1: Register two DIDs
-    state.apply(&EconomicsOp::RegisterDid { did: "did:omnia:alice".into() }, epoch).unwrap();
-    state.apply(&EconomicsOp::RegisterDid { did: "did:omnia:bob".into() }, epoch).unwrap();
+    state
+        .apply(
+            &EconomicsOp::RegisterDid {
+                did: "did:omnia:alice".into(),
+            },
+            epoch,
+        )
+        .unwrap();
+    state
+        .apply(
+            &EconomicsOp::RegisterDid {
+                did: "did:omnia:bob".into(),
+            },
+            epoch,
+        )
+        .unwrap();
 
     assert_eq!(state.balance_of("did:omnia:alice"), Some(DEFAULT_UBC_QUOTA));
     assert_eq!(state.balance_of("did:omnia:bob"), Some(DEFAULT_UBC_QUOTA));
 
     // Step 2: Alice spends UBC
-    state.apply(&EconomicsOp::SpendUbc { did: "did:omnia:alice".into(), amount: 300 }, epoch).unwrap();
-    assert_eq!(state.balance_of("did:omnia:alice"), Some(DEFAULT_UBC_QUOTA - 300));
+    state
+        .apply(
+            &EconomicsOp::SpendUbc {
+                did: "did:omnia:alice".into(),
+                amount: 300,
+            },
+            epoch,
+        )
+        .unwrap();
+    assert_eq!(
+        state.balance_of("did:omnia:alice"),
+        Some(DEFAULT_UBC_QUOTA - 300)
+    );
 
     // Step 3: Alice submits useful work for a reward
     let proof = UsefulWorkProof::new(
@@ -270,8 +324,19 @@ fn test_economics_state_full_lifecycle() {
         500, // 500 compute units → 500 UBC reward
         vec![1, 2, 3, 4],
     );
-    state.apply(&EconomicsOp::SubmitWork { did: "did:omnia:alice".into(), proof }, epoch).unwrap();
-    assert_eq!(state.balance_of("did:omnia:alice"), Some(DEFAULT_UBC_QUOTA - 300 + 500));
+    state
+        .apply(
+            &EconomicsOp::SubmitWork {
+                did: "did:omnia:alice".into(),
+                proof,
+            },
+            epoch,
+        )
+        .unwrap();
+    assert_eq!(
+        state.balance_of("did:omnia:alice"),
+        Some(DEFAULT_UBC_QUOTA - 300 + 500)
+    );
 
     // Step 4: Advance epoch — balances reset
     state.apply(&EconomicsOp::AdvanceEpoch, 0).unwrap();
@@ -280,33 +345,48 @@ fn test_economics_state_full_lifecycle() {
     assert_eq!(state.balance_of("did:omnia:bob"), Some(DEFAULT_UBC_QUOTA));
 
     // Step 5: Create a governance proposal
-    state.apply(&EconomicsOp::CreateProposal {
-        id: "prop1".into(),
-        description: "Increase UBC quota".into(),
-        expires_at_epoch: 5,
-    }, 1).unwrap();
+    state
+        .apply(
+            &EconomicsOp::CreateProposal {
+                id: "prop1".into(),
+                description: "Increase UBC quota".into(),
+                expires_at_epoch: 5,
+            },
+            1,
+        )
+        .unwrap();
 
     // Step 6: Set voting weights and vote
     // Note: set_weight sets last_active=0, so at epoch 1 there is 1 epoch of
     // inactivity decay (10%). Alice's effective weight = 10 * 0.9 = 9,
     // Bob's effective weight = 20 * 0.9 = 18.
     state.governance.set_weight("did:omnia:alice", 100); // base weight = 10
-    state.governance.set_weight("did:omnia:bob", 400);   // base weight = 20
+    state.governance.set_weight("did:omnia:bob", 400); // base weight = 20
 
-    state.apply(&EconomicsOp::Vote {
-        did: "did:omnia:alice".into(),
-        proposal_id: "prop1".into(),
-        choice: VoteChoice::For,
-    }, 1).unwrap();
+    state
+        .apply(
+            &EconomicsOp::Vote {
+                did: "did:omnia:alice".into(),
+                proposal_id: "prop1".into(),
+                choice: VoteChoice::For,
+            },
+            1,
+        )
+        .unwrap();
 
-    state.apply(&EconomicsOp::Vote {
-        did: "did:omnia:bob".into(),
-        proposal_id: "prop1".into(),
-        choice: VoteChoice::Against,
-    }, 1).unwrap();
+    state
+        .apply(
+            &EconomicsOp::Vote {
+                did: "did:omnia:bob".into(),
+                proposal_id: "prop1".into(),
+                choice: VoteChoice::Against,
+            },
+            1,
+        )
+        .unwrap();
 
     let proposal = state.governance.get_proposal("prop1").unwrap();
-    assert_eq!(proposal.votes_for, 9);   // 10 * 0.9^1 = 9
+    assert_eq!(proposal.votes_for, 9); // 10 * 0.9^1 = 9
     assert_eq!(proposal.votes_against, 18); // 20 * 0.9^1 = 18
     assert!(!proposal.passes());
 }
@@ -314,13 +394,31 @@ fn test_economics_state_full_lifecycle() {
 #[test]
 fn test_economics_serialization_roundtrip() {
     let mut state = EconomicsState::new();
-    state.apply(&EconomicsOp::RegisterDid { did: "did:omnia:alice".into() }, 0).unwrap();
-    state.apply(&EconomicsOp::SpendUbc { did: "did:omnia:alice".into(), amount: 100 }, 0).unwrap();
+    state
+        .apply(
+            &EconomicsOp::RegisterDid {
+                did: "did:omnia:alice".into(),
+            },
+            0,
+        )
+        .unwrap();
+    state
+        .apply(
+            &EconomicsOp::SpendUbc {
+                did: "did:omnia:alice".into(),
+                amount: 100,
+            },
+            0,
+        )
+        .unwrap();
 
     let bytes = state.to_bytes();
     let restored = EconomicsState::from_bytes(&bytes).unwrap();
 
-    assert_eq!(restored.balance_of("did:omnia:alice"), Some(DEFAULT_UBC_QUOTA - 100));
+    assert_eq!(
+        restored.balance_of("did:omnia:alice"),
+        Some(DEFAULT_UBC_QUOTA - 100)
+    );
 }
 
 #[test]
@@ -331,7 +429,10 @@ fn test_quota_system_double_register_no_op() {
 
     // Re-registering should not reset the balance
     system.register_did("did:omnia:alice");
-    assert_eq!(system.balance_of("did:omnia:alice"), Some(DEFAULT_UBC_QUOTA - 500));
+    assert_eq!(
+        system.balance_of("did:omnia:alice"),
+        Some(DEFAULT_UBC_QUOTA - 500)
+    );
 }
 
 #[test]
@@ -339,7 +440,8 @@ fn test_governance_duplicate_proposal() {
     use omnia_economics::GovernanceState;
 
     let mut gov = GovernanceState::new(0.1);
-    gov.create_proposal("prop1".into(), "First".into(), 10, 0).unwrap();
+    gov.create_proposal("prop1".into(), "First".into(), 10, 0)
+        .unwrap();
 
     let result = gov.create_proposal("prop1".into(), "Duplicate".into(), 10, 0);
     assert!(matches!(result, Err(EconomicsError::DuplicateProposal(_))));

--- a/shards/src/biological/state.rs
+++ b/shards/src/biological/state.rs
@@ -56,7 +56,12 @@ impl BiologicalState {
     /// Apply a biological operation, mutating state.
     pub fn apply(&mut self, op: &BiologicalOp, vc: &VectorClock) -> Result<(), ShardError> {
         match op {
-            BiologicalOp::GrantAccess { subject, consumer, scope, expires_at } => {
+            BiologicalOp::GrantAccess {
+                subject,
+                consumer,
+                scope,
+                expires_at,
+            } => {
                 let key = (*subject, *consumer);
                 self.consent_registry.insert(
                     key,
@@ -73,22 +78,27 @@ impl BiologicalState {
             }
             BiologicalOp::RevokeAccess { subject, consumer } => {
                 let key = (*subject, *consumer);
-                let record = self
-                    .consent_registry
-                    .get_mut(&key)
-                    .ok_or_else(|| ShardError::ValidationFailed("Consent record not found".into()))?;
+                let record = self.consent_registry.get_mut(&key).ok_or_else(|| {
+                    ShardError::ValidationFailed("Consent record not found".into())
+                })?;
                 record.revoked = true;
                 Ok(())
             }
-            BiologicalOp::QueryWithZkProof { subject, consumer, zk_proof, .. } => {
+            BiologicalOp::QueryWithZkProof {
+                subject,
+                consumer,
+                zk_proof,
+                ..
+            } => {
                 let key = (*subject, *consumer);
-                let record = self
-                    .consent_registry
-                    .get(&key)
-                    .ok_or_else(|| ShardError::ValidationFailed("No consent for this query".into()))?;
+                let record = self.consent_registry.get(&key).ok_or_else(|| {
+                    ShardError::ValidationFailed("No consent for this query".into())
+                })?;
 
                 if record.revoked {
-                    return Err(ShardError::ValidationFailed("Consent has been revoked".into()));
+                    return Err(ShardError::ValidationFailed(
+                        "Consent has been revoked".into(),
+                    ));
                 }
 
                 // In a real implementation, verify the ZK proof here.

--- a/shards/src/biological/validator.rs
+++ b/shards/src/biological/validator.rs
@@ -3,10 +3,10 @@
 //! Pre-flight validation for biological operations, including ZK-proof
 //! validation stubs.
 
-use crate::payload::ShardOp;
-use crate::shard::ShardError;
 use super::ops::BiologicalOp;
 use super::state::BiologicalState;
+use crate::payload::ShardOp;
+use crate::shard::ShardError;
 
 /// Validator for the Biological shard.
 pub struct BiologicalValidator;
@@ -15,7 +15,12 @@ impl BiologicalValidator {
     /// Validate a biological operation against the given state.
     pub fn validate(state: &BiologicalState, op: &BiologicalOp) -> Result<(), ShardError> {
         match op {
-            BiologicalOp::GrantAccess { subject, consumer, scope, .. } => {
+            BiologicalOp::GrantAccess {
+                subject,
+                consumer,
+                scope,
+                ..
+            } => {
                 if scope.is_empty() {
                     return Err(ShardError::InvalidOperation("Scope cannot be empty".into()));
                 }
@@ -25,16 +30,24 @@ impl BiologicalValidator {
             BiologicalOp::RevokeAccess { subject, consumer } => {
                 let key = (*subject, *consumer);
                 if !state.consent_registry.contains_key(&key) {
-                    return Err(ShardError::ValidationFailed("Consent record not found".into()));
+                    return Err(ShardError::ValidationFailed(
+                        "Consent record not found".into(),
+                    ));
                 }
                 Ok(())
             }
-            BiologicalOp::QueryWithZkProof { subject, consumer, .. } => {
+            BiologicalOp::QueryWithZkProof {
+                subject, consumer, ..
+            } => {
                 let key = (*subject, *consumer);
                 match state.consent_registry.get(&key) {
                     Some(record) if !record.revoked => Ok(()),
-                    Some(_) => Err(ShardError::ValidationFailed("Consent has been revoked".into())),
-                    None => Err(ShardError::ValidationFailed("No consent for this query".into())),
+                    Some(_) => Err(ShardError::ValidationFailed(
+                        "Consent has been revoked".into(),
+                    )),
+                    None => Err(ShardError::ValidationFailed(
+                        "No consent for this query".into(),
+                    )),
                 }
             }
         }

--- a/shards/src/computational/state.rs
+++ b/shards/src/computational/state.rs
@@ -59,7 +59,11 @@ impl ComputationalState {
     /// Apply a computational operation, mutating state.
     pub fn apply(&mut self, op: &ComputationalOp, vc: &VectorClock) -> Result<(), ShardError> {
         match op {
-            ComputationalOp::SubmitTask { task_id, spec, reward } => {
+            ComputationalOp::SubmitTask {
+                task_id,
+                spec,
+                reward,
+            } => {
                 if self.tasks.contains_key(task_id) {
                     return Err(ShardError::StateConflict(format!(
                         "Task already exists: {:?}",

--- a/shards/src/computational/validator.rs
+++ b/shards/src/computational/validator.rs
@@ -2,10 +2,10 @@
 //!
 //! Pre-flight validation for computational operations.
 
-use crate::payload::ShardOp;
-use crate::shard::ShardError;
 use super::ops::ComputationalOp;
 use super::state::ComputationalState;
+use crate::payload::ShardOp;
+use crate::shard::ShardError;
 
 /// Validator for the Computational shard.
 pub struct ComputationalValidator;
@@ -23,24 +23,20 @@ impl ComputationalValidator {
                 }
                 Ok(())
             }
-            ComputationalOp::SubmitProof { task_id, .. } => {
-                match state.tasks.get(task_id) {
-                    Some(task) if task.status == super::state::TaskStatus::Submitted => Ok(()),
-                    Some(_) => Err(ShardError::InvalidOperation(
-                        "Task is not in Submitted status".into(),
-                    )),
-                    None => Err(ShardError::ValidationFailed("Task not found".into())),
-                }
-            }
-            ComputationalOp::VerifyProof { task_id } => {
-                match state.tasks.get(task_id) {
-                    Some(task) if task.status == super::state::TaskStatus::Proved => Ok(()),
-                    Some(_) => Err(ShardError::InvalidOperation(
-                        "Task is not in Proved status".into(),
-                    )),
-                    None => Err(ShardError::ValidationFailed("Task not found".into())),
-                }
-            }
+            ComputationalOp::SubmitProof { task_id, .. } => match state.tasks.get(task_id) {
+                Some(task) if task.status == super::state::TaskStatus::Submitted => Ok(()),
+                Some(_) => Err(ShardError::InvalidOperation(
+                    "Task is not in Submitted status".into(),
+                )),
+                None => Err(ShardError::ValidationFailed("Task not found".into())),
+            },
+            ComputationalOp::VerifyProof { task_id } => match state.tasks.get(task_id) {
+                Some(task) if task.status == super::state::TaskStatus::Proved => Ok(()),
+                Some(_) => Err(ShardError::InvalidOperation(
+                    "Task is not in Proved status".into(),
+                )),
+                None => Err(ShardError::ValidationFailed("Task not found".into())),
+            },
         }
     }
 

--- a/shards/src/financial/state.rs
+++ b/shards/src/financial/state.rs
@@ -14,8 +14,8 @@ use std::collections::HashMap;
 use omnia_substrate::{Event, VectorClock};
 use serde::{Deserialize, Serialize};
 
-use crate::shard::ShardError;
 use super::ops::{AccountId, FinancialOp};
+use crate::shard::ShardError;
 
 /// A single account's balance with causal tracking.
 ///
@@ -118,10 +118,9 @@ impl FinancialState {
                 let vc = &event.vector_clock;
 
                 // Debit the sender
-                let from_balance = self
-                    .balances
-                    .get_mut(&from)
-                    .ok_or_else(|| ShardError::ValidationFailed("Sender account not found".into()))?;
+                let from_balance = self.balances.get_mut(&from).ok_or_else(|| {
+                    ShardError::ValidationFailed("Sender account not found".into())
+                })?;
 
                 if from_balance.value() < *amount {
                     return Err(ShardError::ValidationFailed("Insufficient balance".into()));
@@ -129,20 +128,14 @@ impl FinancialState {
                 from_balance.decrement(*amount, vc)?;
 
                 // Credit the recipient
-                let to_balance = self
-                    .balances
-                    .entry(*to)
-                    .or_insert_with(AccountBalance::new);
+                let to_balance = self.balances.entry(*to).or_default();
                 to_balance.increment(*amount, vc);
 
                 Ok(())
             }
             FinancialOp::Mint { to, amount } => {
                 let vc = &event.vector_clock;
-                let balance = self
-                    .balances
-                    .entry(*to)
-                    .or_insert_with(AccountBalance::new);
+                let balance = self.balances.entry(*to).or_default();
                 balance.increment(*amount, vc);
                 self.total_supply += amount;
                 Ok(())
@@ -184,13 +177,16 @@ impl FinancialState {
     /// payload. Returns an error if the version is unsupported.
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, bincode::Error> {
         if bytes.is_empty() {
-            return Err(Box::new(bincode::ErrorKind::Custom("Empty state bytes".into())));
+            return Err(Box::new(bincode::ErrorKind::Custom(
+                "Empty state bytes".into(),
+            )));
         }
         let version = bytes[0];
         if version != Self::FINANCIAL_STATE_VERSION {
-            return Err(Box::new(bincode::ErrorKind::Custom(
-                format!("Unsupported financial state version: {}", version),
-            )));
+            return Err(Box::new(bincode::ErrorKind::Custom(format!(
+                "Unsupported financial state version: {}",
+                version
+            ))));
         }
         bincode::deserialize(&bytes[1..])
     }

--- a/shards/src/financial/validator.rs
+++ b/shards/src/financial/validator.rs
@@ -4,10 +4,10 @@
 //! actually mutating state. This is used for pre-flight checks and for
 //! rejecting invalid operations before they enter the consensus pipeline.
 
-use crate::payload::ShardOp;
-use crate::shard::ShardError;
 use super::ops::FinancialOp;
 use super::state::FinancialState;
+use crate::payload::ShardOp;
+use crate::shard::ShardError;
 
 /// Validator for the Financial shard.
 ///
@@ -90,7 +90,10 @@ mod tests {
     }
 
     /// Helper: create a signed event from the given keypair with the given payload.
-    fn make_signed_event(keypair: &omnia_substrate::crypto::NodeKeypair, payload: Vec<u8>) -> Event {
+    fn make_signed_event(
+        keypair: &omnia_substrate::crypto::NodeKeypair,
+        payload: Vec<u8>,
+    ) -> Event {
         let creator = keypair.verifying_key().to_bytes();
         let vc = VectorClock::with_node(creator, 1);
         let mut event = Event::new(creator, 0, vc, None, None, payload);
@@ -101,7 +104,9 @@ mod tests {
     /// Helper: create a FinancialState with a single account having the given balance.
     fn state_with_balance(account: AccountId, balance: u64) -> FinancialState {
         let mut state = FinancialState::new();
-        state.balances.insert(account, AccountBalance::with_balance(balance));
+        state
+            .balances
+            .insert(account, AccountBalance::with_balance(balance));
         state.total_supply = balance;
         state
     }
@@ -399,10 +404,7 @@ mod tests {
         let event = make_signed_event(&keypair, vec![1]);
 
         let result = state.apply(&mint, &event);
-        assert!(
-            result.is_ok(),
-            "Mint to new account should succeed"
-        );
+        assert!(result.is_ok(), "Mint to new account should succeed");
 
         // Account should now exist with the minted balance
         assert_eq!(state.balance_of(&new_account), 200);
@@ -572,7 +574,10 @@ mod tests {
         // For Burn, the event's creator_pubkey doesn't matter — Burn takes `from` from the op
         let keypair2 = generate_keypair();
         let burn_event = make_signed_event(&keypair2, vec![1]);
-        assert!(state.apply(&burn, &burn_event).is_ok(), "Burn should succeed");
+        assert!(
+            state.apply(&burn, &burn_event).is_ok(),
+            "Burn should succeed"
+        );
         assert_eq!(state.balance_of(&sender_pubkey), 20);
 
         // Now try to transfer 50 — should fail (only 20 left)

--- a/shards/src/identity/agent.rs
+++ b/shards/src/identity/agent.rs
@@ -125,12 +125,8 @@ impl AgentCapability {
             ) => r1 >= r2 && d2.iter().all(|d| d1.contains(d)),
 
             (
-                ContractExecution {
-                    contract_types: t1,
-                },
-                ContractExecution {
-                    contract_types: t2,
-                },
+                ContractExecution { contract_types: t1 },
+                ContractExecution { contract_types: t2 },
             ) => t2.iter().all(|t| t1.contains(t)),
 
             (
@@ -142,10 +138,7 @@ impl AgentCapability {
                 },
             ) => a >= b,
 
-            (
-                GovernanceVote { max_weight: a },
-                GovernanceVote { max_weight: b },
-            ) => a >= b,
+            (GovernanceVote { max_weight: a }, GovernanceVote { max_weight: b }) => a >= b,
 
             _ => false,
         }

--- a/shards/src/identity/did.rs
+++ b/shards/src/identity/did.rs
@@ -100,7 +100,10 @@ mod tests {
 
     #[test]
     fn test_invalid_hex() {
-        let invalid = format!("{}{}", DID_PREFIX, "ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ");
+        let invalid = format!(
+            "{}{}",
+            DID_PREFIX, "ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ"
+        );
         assert!(validate_did(&invalid).is_err());
     }
 

--- a/shards/src/identity/state.rs
+++ b/shards/src/identity/state.rs
@@ -104,12 +104,9 @@ impl IdentityState {
                 Ok(())
             }
             IdentityOp::UpdateDid { did, updates } => {
-                let doc = self
-                    .dids
-                    .get_mut(did)
-                    .ok_or_else(|| {
-                        ShardError::ValidationFailed(format!("DID not found: {}", did))
-                    })?;
+                let doc = self.dids.get_mut(did).ok_or_else(|| {
+                    ShardError::ValidationFailed(format!("DID not found: {}", did))
+                })?;
 
                 for update in updates {
                     match update {
@@ -134,10 +131,7 @@ impl IdentityState {
             }
             IdentityOp::RecoverDid { did, shares } => {
                 let config = self.recovery_registry.get(did).ok_or_else(|| {
-                    ShardError::ValidationFailed(format!(
-                        "No recovery config for DID: {}",
-                        did
-                    ))
+                    ShardError::ValidationFailed(format!("No recovery config for DID: {}", did))
                 })?;
 
                 if shares.len() < config.threshold as usize {
@@ -185,8 +179,7 @@ impl IdentityState {
                         agent.did
                     )));
                 }
-                self.agent_registry
-                    .insert(agent.did.clone(), agent.clone());
+                self.agent_registry.insert(agent.did.clone(), agent.clone());
                 Ok(())
             }
             IdentityOp::EnrollBiometric {
@@ -206,10 +199,7 @@ impl IdentityState {
             }
             IdentityOp::VerifyBiometric { did, template } => {
                 let anchor = self.biometric_registry.get(did).ok_or_else(|| {
-                    ShardError::ValidationFailed(format!(
-                        "No biometric enrolled for DID: {}",
-                        did
-                    ))
+                    ShardError::ValidationFailed(format!("No biometric enrolled for DID: {}", did))
                 })?;
                 if !anchor.verify(template) {
                     return Err(ShardError::ValidationFailed(
@@ -220,10 +210,7 @@ impl IdentityState {
             }
             IdentityOp::RevokeAgent { agent_did } => {
                 let agent = self.agent_registry.get_mut(agent_did).ok_or_else(|| {
-                    ShardError::ValidationFailed(format!(
-                        "Agent not found: {}",
-                        agent_did
-                    ))
+                    ShardError::ValidationFailed(format!("Agent not found: {}", agent_did))
                 })?;
                 agent.revoke();
                 Ok(())
@@ -281,16 +268,9 @@ impl IdentityState {
     }
 
     /// Verify a biometric template against the stored commitment.
-    pub fn verify_biometric(
-        &self,
-        did: &str,
-        fresh_template: &[u8],
-    ) -> Result<bool, ShardError> {
+    pub fn verify_biometric(&self, did: &str, fresh_template: &[u8]) -> Result<bool, ShardError> {
         let anchor = self.biometric_registry.get(did).ok_or_else(|| {
-            ShardError::ValidationFailed(format!(
-                "No biometric enrolled for DID: {}",
-                did
-            ))
+            ShardError::ValidationFailed(format!("No biometric enrolled for DID: {}", did))
         })?;
         Ok(anchor.verify(fresh_template))
     }
@@ -321,16 +301,9 @@ impl IdentityState {
     }
 
     /// Recover a DID secret using Shamir's Secret Sharing.
-    pub fn recover_did(
-        &self,
-        did: &str,
-        shares: &[RecoveryShare],
-    ) -> Result<Vec<u8>, ShardError> {
+    pub fn recover_did(&self, did: &str, shares: &[RecoveryShare]) -> Result<Vec<u8>, ShardError> {
         let config = self.recovery_registry.get(did).ok_or_else(|| {
-            ShardError::ValidationFailed(format!(
-                "No recovery config for DID: {}",
-                did
-            ))
+            ShardError::ValidationFailed(format!("No recovery config for DID: {}", did))
         })?;
         if shares.len() < config.threshold as usize {
             return Err(ShardError::ValidationFailed(format!(
@@ -339,16 +312,12 @@ impl IdentityState {
                 config.threshold
             )));
         }
-        ShamirRecovery::reconstruct(shares).ok_or_else(|| {
-            ShardError::ValidationFailed("Recovery reconstruction failed".into())
-        })
+        ShamirRecovery::reconstruct(shares)
+            .ok_or_else(|| ShardError::ValidationFailed("Recovery reconstruction failed".into()))
     }
 
     /// Register an AI agent identity.
-    pub fn register_agent(
-        &mut self,
-        agent: AgentIdentity,
-    ) -> Result<(), ShardError> {
+    pub fn register_agent(&mut self, agent: AgentIdentity) -> Result<(), ShardError> {
         if self.agent_registry.contains_key(&agent.did) {
             return Err(ShardError::StateConflict(format!(
                 "Agent already exists: {}",

--- a/shards/src/identity/validator.rs
+++ b/shards/src/identity/validator.rs
@@ -3,10 +3,10 @@
 //! Pre-flight validation for DID operations. Checks whether an operation
 //! would succeed without actually mutating state.
 
-use crate::payload::ShardOp;
-use crate::shard::ShardError;
 use super::ops::IdentityOp;
 use super::state::IdentityState;
+use crate::payload::ShardOp;
+use crate::shard::ShardError;
 
 /// Validator for the Identity shard.
 pub struct IdentityValidator;

--- a/shards/src/lib.rs
+++ b/shards/src/lib.rs
@@ -46,8 +46,8 @@ pub mod cross_shard;
 pub mod economics_shard;
 pub mod financial;
 pub mod identity;
-pub mod physical;
 pub mod payload;
+pub mod physical;
 pub mod router;
 pub mod shard;
 
@@ -59,21 +59,20 @@ pub use router::ShardRouter;
 pub use shard::{Shard, ShardError, ShardId};
 
 // Re-export shard-specific types for convenience
+pub use biological::{BiologicalOp, BiologicalState, BiologicalValidator, ConsentRecord};
+pub use computational::{ComputationalOp, ComputationalState, ComputationalValidator, TaskStatus};
 pub use financial::{
-    AccountBalance as FinancialAccountBalance, FinancialOp, FinancialState,
-    FinancialValidator,
+    AccountBalance as FinancialAccountBalance, FinancialOp, FinancialState, FinancialValidator,
 };
 pub use identity::{
-    AgentCapability, AgentIdentity, BiometricAnchor, Did, DidDocument, DidError, DidUpdate,
-    IdentityOp, IdentityState, IdentityValidator, RecoveryConfig, RecoveryShare, ShamirRecovery,
-    DID_METHOD, DID_PREFIX, format_did,
+    format_did, AgentCapability, AgentIdentity, BiometricAnchor, Did, DidDocument, DidError,
+    DidUpdate, IdentityOp, IdentityState, IdentityValidator, RecoveryConfig, RecoveryShare,
+    ShamirRecovery, DID_METHOD, DID_PREFIX,
 };
-pub use computational::{ComputationalOp, ComputationalState, ComputationalValidator, TaskStatus};
 pub use physical::{PhysicalOp, PhysicalState, PhysicalValidator, ProvenanceEvent};
-pub use biological::{BiologicalOp, BiologicalState, BiologicalValidator, ConsentRecord};
 
-use std::collections::HashMap;
 use omnia_substrate::Event;
+use std::collections::HashMap;
 
 // ---------------------------------------------------------------------------
 // Economics shard implementation
@@ -108,26 +107,33 @@ impl EconomicsShardState {
         match op {
             EconomicsOp::MintUbc { did, amount } => {
                 if *amount == 0 {
-                    return Err(ShardError::ValidationFailed("Mint amount must be > 0".into()));
+                    return Err(ShardError::ValidationFailed(
+                        "Mint amount must be > 0".into(),
+                    ));
                 }
                 *self.balances.entry(did.clone()).or_insert(0) += amount;
                 Ok(())
             }
             EconomicsOp::SpendUbc { did, amount } => {
                 if *amount == 0 {
-                    return Err(ShardError::ValidationFailed("Spend amount must be > 0".into()));
+                    return Err(ShardError::ValidationFailed(
+                        "Spend amount must be > 0".into(),
+                    ));
                 }
                 let balance = self.balances.get(did).copied().unwrap_or(0);
                 if balance < *amount {
-                    return Err(ShardError::ValidationFailed(
-                        format!("Insufficient UBC: have {}, need {}", balance, amount)
-                    ));
+                    return Err(ShardError::ValidationFailed(format!(
+                        "Insufficient UBC: have {}, need {}",
+                        balance, amount
+                    )));
                 }
                 self.balances.insert(did.clone(), balance - amount);
                 Ok(())
             }
             EconomicsOp::RegisterDid { did } => {
-                self.balances.entry(did.clone()).or_insert(self.default_quota);
+                self.balances
+                    .entry(did.clone())
+                    .or_insert(self.default_quota);
                 Ok(())
             }
             EconomicsOp::AdvanceEpoch => {
@@ -140,7 +146,10 @@ impl EconomicsShardState {
             }
             EconomicsOp::SubmitWork { did, .. } => {
                 // Simplified: reward 100 UBC for any submitted work
-                *self.balances.entry(did.clone()).or_insert(self.default_quota) += 100;
+                *self
+                    .balances
+                    .entry(did.clone())
+                    .or_insert(self.default_quota) += 100;
                 Ok(())
             }
             EconomicsOp::CreateProposal { .. } | EconomicsOp::Vote { .. } => {
@@ -204,17 +213,15 @@ impl Shard for EconomicsShard {
 
     fn validate(&self, op: &ShardOp) -> Result<(), ShardError> {
         match op {
-            ShardOp::Economics(econ_op) => {
-                match econ_op {
-                    EconomicsOp::SpendUbc { amount, .. } if *amount == 0 => {
-                        Err(ShardError::ValidationFailed("Spend amount must be > 0".into()))
-                    }
-                    EconomicsOp::MintUbc { amount, .. } if *amount == 0 => {
-                        Err(ShardError::ValidationFailed("Mint amount must be > 0".into()))
-                    }
-                    _ => Ok(()),
-                }
-            }
+            ShardOp::Economics(econ_op) => match econ_op {
+                EconomicsOp::SpendUbc { amount, .. } if *amount == 0 => Err(
+                    ShardError::ValidationFailed("Spend amount must be > 0".into()),
+                ),
+                EconomicsOp::MintUbc { amount, .. } if *amount == 0 => Err(
+                    ShardError::ValidationFailed("Mint amount must be > 0".into()),
+                ),
+                _ => Ok(()),
+            },
             _ => Err(ShardError::InvalidOperation(
                 "Economics shard received non-Economics operation".into(),
             )),

--- a/shards/src/payload.rs
+++ b/shards/src/payload.rs
@@ -6,14 +6,14 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::shard::ShardId;
-use crate::cross_shard::CrossShardMessage;
-use crate::financial::ops::FinancialOp;
-use crate::computational::ops::ComputationalOp;
-use crate::physical::ops::PhysicalOp;
 use crate::biological::ops::BiologicalOp;
-use crate::identity::ops::IdentityOp;
+use crate::computational::ops::ComputationalOp;
+use crate::cross_shard::CrossShardMessage;
 use crate::economics_shard::EconomicsOp;
+use crate::financial::ops::FinancialOp;
+use crate::identity::ops::IdentityOp;
+use crate::physical::ops::PhysicalOp;
+use crate::shard::ShardId;
 
 /// The top-level payload that wraps every shard operation.
 ///

--- a/shards/src/physical/state.rs
+++ b/shards/src/physical/state.rs
@@ -43,7 +43,11 @@ impl PhysicalState {
     /// Apply a physical operation, mutating state.
     pub fn apply(&mut self, op: &PhysicalOp, vc: &VectorClock) -> Result<(), ShardError> {
         match op {
-            PhysicalOp::AnchorItem { item_id, owner, metadata } => {
+            PhysicalOp::AnchorItem {
+                item_id,
+                owner,
+                metadata,
+            } => {
                 if self.provenance.contains_key(item_id) {
                     return Err(ShardError::StateConflict(format!(
                         "Item already anchored: {:?}",

--- a/shards/src/physical/validator.rs
+++ b/shards/src/physical/validator.rs
@@ -3,10 +3,10 @@
 //! Pre-flight validation for physical asset operations, especially
 //! ownership verification for transfers.
 
-use crate::payload::ShardOp;
-use crate::shard::ShardError;
 use super::ops::PhysicalOp;
 use super::state::PhysicalState;
+use crate::payload::ShardOp;
+use crate::shard::ShardError;
 
 /// Validator for the Physical shard.
 pub struct PhysicalValidator;

--- a/shards/src/router.rs
+++ b/shards/src/router.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 use omnia_substrate::Event;
 
 use crate::cross_shard::CrossShardMessage;
-use crate::payload::{ShardPayload, ShardOp};
+use crate::payload::{ShardOp, ShardPayload};
 use crate::shard::{Shard, ShardError, ShardId};
 
 /// Routes shard events to the appropriate shard handler.
@@ -106,9 +106,10 @@ impl ShardRouter {
         let creator = event.creator_pubkey;
         let last_nonce = self.last_nonces.get(&creator).copied().unwrap_or(0);
         if payload.nonce <= last_nonce {
-            return Err(ShardError::ValidationFailed(
-                format!("Replay detected: nonce {} <= last {}", payload.nonce, last_nonce)
-            ));
+            return Err(ShardError::ValidationFailed(format!(
+                "Replay detected: nonce {} <= last {}",
+                payload.nonce, last_nonce
+            )));
         }
         self.last_nonces.insert(creator, payload.nonce);
 

--- a/shards/tests/cross_shard.rs
+++ b/shards/tests/cross_shard.rs
@@ -17,7 +17,11 @@ fn test_node(id: u8) -> NodeId {
 }
 
 /// Create a signed event with the given payload, creator, and keypair.
-fn create_test_event_with_keypair(creator: NodeId, payload: Vec<u8>, keypair: &NodeKeypair) -> Event {
+fn create_test_event_with_keypair(
+    creator: NodeId,
+    payload: Vec<u8>,
+    keypair: &NodeKeypair,
+) -> Event {
     let vc = VectorClock::with_node(creator, 1);
     let mut event = Event::new(creator, 0, vc, None, None, payload);
     event.sign_with_keypair(keypair);
@@ -51,8 +55,11 @@ fn test_financial_transfer_lifecycle() {
         operation: ShardOp::Financial(mint_op),
         nonce: 1,
     };
-    let mint_event = create_test_event_with_keypair(test_node(1), mint_payload.to_bytes(), &sender_keypair);
-    router.route_event(&mint_event).expect("Mint should succeed");
+    let mint_event =
+        create_test_event_with_keypair(test_node(1), mint_payload.to_bytes(), &sender_keypair);
+    router
+        .route_event(&mint_event)
+        .expect("Mint should succeed");
 
     // Transfer tokens from sender to recipient
     // The sender's account is identified by event.creator_pubkey
@@ -65,8 +72,11 @@ fn test_financial_transfer_lifecycle() {
         operation: ShardOp::Financial(transfer_op),
         nonce: 2,
     };
-    let transfer_event = create_test_event_with_keypair(test_node(1), transfer_payload.to_bytes(), &sender_keypair);
-    router.route_event(&transfer_event).expect("Transfer should succeed");
+    let transfer_event =
+        create_test_event_with_keypair(test_node(1), transfer_payload.to_bytes(), &sender_keypair);
+    router
+        .route_event(&transfer_event)
+        .expect("Transfer should succeed");
 
     // Check that we can mint to the same account again
     let mint_op2 = FinancialOp::Mint {
@@ -79,7 +89,9 @@ fn test_financial_transfer_lifecycle() {
         nonce: 3,
     };
     let mint_event2 = create_test_event(test_node(1), mint_payload2.to_bytes());
-    router.route_event(&mint_event2).expect("Second mint should succeed");
+    router
+        .route_event(&mint_event2)
+        .expect("Second mint should succeed");
 }
 
 #[test]
@@ -122,7 +134,9 @@ fn test_identity_did_lifecycle() {
         nonce: 1,
     };
     let create_event = create_test_event(owner, create_payload.to_bytes());
-    router.route_event(&create_event).expect("Create DID should succeed");
+    router
+        .route_event(&create_event)
+        .expect("Create DID should succeed");
 
     // Try to create the same DID again (should fail)
     let doc2 = omnia_shards::DidDocument::new(did.clone(), owner, 2000);
@@ -212,7 +226,9 @@ fn test_burn_operation() {
         nonce: 1,
     };
     let mint_event = create_test_event(minter, mint_payload.to_bytes());
-    router.route_event(&mint_event).expect("Mint should succeed");
+    router
+        .route_event(&mint_event)
+        .expect("Mint should succeed");
 
     // Burn some tokens
     let burn_op = FinancialOp::Burn {
@@ -225,7 +241,9 @@ fn test_burn_operation() {
         nonce: 2,
     };
     let burn_event = create_test_event(minter, burn_payload.to_bytes());
-    router.route_event(&burn_event).expect("Burn should succeed");
+    router
+        .route_event(&burn_event)
+        .expect("Burn should succeed");
 
     // Try to burn more than the balance
     let overburn_op = FinancialOp::Burn {

--- a/shards/tests/financial_adversarial.rs
+++ b/shards/tests/financial_adversarial.rs
@@ -7,7 +7,7 @@
 
 use omnia_shards::{FinancialOp, FinancialState, FinancialValidator, ShardError};
 use omnia_substrate::crypto::generate_keypair;
-use omnia_substrate::{Event, NodeKeypair, NodeId, VectorClock};
+use omnia_substrate::{Event, NodeId, NodeKeypair, VectorClock};
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -64,7 +64,9 @@ fn test_double_spend_attack() {
     // Transfer 100 from A to B — should succeed
     let transfer1 = FinancialOp::Transfer { to: b, amount: 100 };
     let event1 = make_signed_event(&kp_a, 1, node);
-    state.apply(&transfer1, &event1).expect("first transfer should succeed");
+    state
+        .apply(&transfer1, &event1)
+        .expect("first transfer should succeed");
     assert_eq!(state.balance_of(&a), 0);
     assert_eq!(state.balance_of(&b), 100);
 
@@ -161,8 +163,12 @@ fn test_replay_attack_nonce_bypass() {
     // Apply the same transfer to both states
     let transfer = FinancialOp::Transfer { to: b, amount: 75 };
     let event1 = make_signed_event(&kp_a, 1, node);
-    state1.apply(&transfer, &event1).expect("transfer in state1");
-    state2.apply(&transfer, &event1).expect("transfer in state2");
+    state1
+        .apply(&transfer, &event1)
+        .expect("transfer in state1");
+    state2
+        .apply(&transfer, &event1)
+        .expect("transfer in state2");
 
     // Both states must be identical — deterministic
     assert_eq!(state1.balance_of(&a), state2.balance_of(&a));
@@ -207,12 +213,16 @@ fn test_concurrent_transfers_balance_consistency() {
     // Transfer 60 from A to B
     let transfer1 = FinancialOp::Transfer { to: b, amount: 60 };
     let event1 = make_signed_event(&kp_a, 1, node);
-    state.apply(&transfer1, &event1).expect("transfer A->B should succeed");
+    state
+        .apply(&transfer1, &event1)
+        .expect("transfer A->B should succeed");
 
     // Transfer 40 from A to C
     let transfer2 = FinancialOp::Transfer { to: c, amount: 40 };
     let event2 = make_signed_event(&kp_a, 2, node);
-    state.apply(&transfer2, &event2).expect("transfer A->C should succeed");
+    state
+        .apply(&transfer2, &event2)
+        .expect("transfer A->C should succeed");
 
     // Verify final balances
     assert_eq!(state.balance_of(&a), 0, "A should have 0");
@@ -326,11 +336,17 @@ fn test_burn_insufficient_balance() {
     state.apply(&mint_op, &event0).expect("mint should succeed");
 
     // Attempt to burn 50 — more than A holds
-    let burn_op = FinancialOp::Burn { from: a, amount: 50 };
+    let burn_op = FinancialOp::Burn {
+        from: a,
+        amount: 50,
+    };
 
     // Validator should catch it
     let val_result = FinancialValidator::validate(&state, &burn_op);
-    assert!(val_result.is_err(), "validator should reject oversized burn");
+    assert!(
+        val_result.is_err(),
+        "validator should reject oversized burn"
+    );
     match val_result.unwrap_err() {
         ShardError::ValidationFailed(msg) => {
             assert!(
@@ -380,7 +396,10 @@ fn test_total_supply_consistency() {
     state
         .apply(&FinancialOp::Mint { to: b, amount: 300 }, &event1)
         .expect("mint B");
-    assert_eq!(state.total_supply, 800, "second mint should add to total_supply");
+    assert_eq!(
+        state.total_supply, 800,
+        "second mint should add to total_supply"
+    );
 
     // Transfer 200 from A to C — should NOT change total_supply
     let event2 = make_signed_event(&kp_a, 2, node);
@@ -395,7 +414,13 @@ fn test_total_supply_consistency() {
     // Burn 100 from B — should reduce total_supply
     let event3 = make_signed_event(&kp_b, 3, node);
     state
-        .apply(&FinancialOp::Burn { from: b, amount: 100 }, &event3)
+        .apply(
+            &FinancialOp::Burn {
+                from: b,
+                amount: 100,
+            },
+            &event3,
+        )
         .expect("burn from B");
     assert_eq!(
         state.total_supply, 700,
@@ -413,11 +438,7 @@ fn test_total_supply_consistency() {
     );
 
     // Verify sum of all balances equals total_supply
-    let sum_balances: u64 = state
-        .balances
-        .values()
-        .map(|ab| ab.value())
-        .sum();
+    let sum_balances: u64 = state.balances.values().map(|ab| ab.value()).sum();
     assert_eq!(
         sum_balances, state.total_supply,
         "sum of balances must equal total_supply"
@@ -452,11 +473,14 @@ fn test_transfer_to_self() {
     // Transfer from A to A — should succeed with no net balance change
     let transfer = FinancialOp::Transfer { to: a, amount: 50 };
     let event1 = make_signed_event(&kp_a, 1, node);
-    state.apply(&transfer, &event1).expect("self-transfer should succeed");
+    state
+        .apply(&transfer, &event1)
+        .expect("self-transfer should succeed");
 
     // Balance should be unchanged (debit 50, credit 50)
     assert_eq!(
-        state.balance_of(&a), 100,
+        state.balance_of(&a),
+        100,
         "self-transfer should not change balance"
     );
 
@@ -467,5 +491,9 @@ fn test_transfer_to_self() {
     );
 
     // No double-counting: the balance entry for A should exist exactly once
-    assert_eq!(state.balances.len(), 1, "A should have exactly one balance entry");
+    assert_eq!(
+        state.balances.len(),
+        1,
+        "A should have exactly one balance entry"
+    );
 }

--- a/shards/tests/identity_hardening.rs
+++ b/shards/tests/identity_hardening.rs
@@ -116,9 +116,7 @@ fn test_full_identity_lifecycle() {
 
     // 3. Create recovery shares
     let secret = b"master_secret_key_32_bytes_long";
-    let shares = state
-        .create_recovery_shares(&did, secret, 3, 5)
-        .unwrap();
+    let shares = state.create_recovery_shares(&did, secret, 3, 5).unwrap();
     assert_eq!(shares.len(), 5);
 
     // 4. Recover with 3 shares
@@ -269,7 +267,10 @@ fn test_agent_revocation_disables_capabilities() {
         .unwrap();
 
     // Agent should have capability before revocation
-    let agent = state.agent_registry.get("did:omnia:agent:compute1").unwrap();
+    let agent = state
+        .agent_registry
+        .get("did:omnia:agent:compute1")
+        .unwrap();
     assert!(agent.has_capability(&AgentCapability::ComputeProof {
         max_compute_units: 500,
     }));
@@ -285,7 +286,10 @@ fn test_agent_revocation_disables_capabilities() {
         .unwrap();
 
     // Agent should NOT have capability after revocation
-    let agent = state.agent_registry.get("did:omnia:agent:compute1").unwrap();
+    let agent = state
+        .agent_registry
+        .get("did:omnia:agent:compute1")
+        .unwrap();
     assert!(!agent.has_capability(&AgentCapability::ComputeProof {
         max_compute_units: 500,
     }));

--- a/shards/tests/layer2_integration.rs
+++ b/shards/tests/layer2_integration.rs
@@ -12,8 +12,8 @@
 use std::sync::{Arc, Mutex};
 
 use omnia_shards::{
-    FinancialOp, FinancialShard, FinancialState, IdentityOp, IdentityShard, IdentityState,
-    ShardId, ShardOp, ShardPayload, ShardRouter,
+    FinancialOp, FinancialShard, FinancialState, IdentityOp, IdentityShard, IdentityState, ShardId,
+    ShardOp, ShardPayload, ShardRouter,
 };
 use omnia_substrate::{crypto::generate_keypair, Event, NodeId, Substrate, SubstrateConfig};
 

--- a/substrate/src/causal_graph.rs
+++ b/substrate/src/causal_graph.rs
@@ -10,8 +10,8 @@
 //! - Topological ordering for deterministic event sequencing
 //! - Diff calculation for efficient synchronization
 
-use crate::event::{Event, EventHeader, EventId, EventStatus};
-use crate::vector_clock::{CausalOrder, NodeId, VectorClock};
+use crate::event::{Event, EventId, EventStatus};
+use crate::vector_clock::{NodeId, VectorClock};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet, VecDeque};
 use thiserror::Error;
@@ -26,27 +26,39 @@ const MAX_TIPS: usize = 10_000;
 #[derive(Error, Debug, Clone, PartialEq)]
 pub enum CausalGraphError {
     #[error("Event {0} already exists in graph")]
+    /// Event already exists in the graph
     DuplicateEvent(String),
     #[error("Parent event {0} not found")]
+    /// Parent event referenced but not found
     MissingParent(String),
     #[error("Cycle detected — cannot add event {0}")]
+    /// Adding this event would create a cycle
     CycleDetected(String),
     #[error("Maximum ancestry depth exceeded starting from {0}")]
+    /// Ancestry traversal exceeded maximum depth
     MaxDepthExceeded(String),
     #[error("Invalid event: {0}")]
+    /// Event failed validation
     InvalidEvent(String),
     #[error("Graph integrity check failed: {0}")]
+    /// Graph integrity violation
     IntegrityError(String),
 }
 
 /// Statistics about the causal graph
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct GraphStats {
+    /// Total number of events in the graph
     pub total_events: usize,
+    /// Number of current tip events
     pub tip_count: usize,
+    /// Number of distinct creator nodes
     pub node_count: usize,
+    /// Maximum depth of any event
     pub max_depth: usize,
+    /// Number of finalized events
     pub finalized_events: usize,
+    /// Number of pending events
     pub pending_events: usize,
 }
 
@@ -98,10 +110,9 @@ impl CausalGraph {
 
         // Check for duplicate
         if self.events.contains_key(&event_id) {
-            return Err(CausalGraphError::DuplicateEvent(format!(
-                "{}",
-                hex::encode(&event_id[..8])
-            )));
+            return Err(CausalGraphError::DuplicateEvent(
+                hex::encode(&event_id[..8]).to_string(),
+            ));
         }
 
         // Validate event hash
@@ -133,18 +144,16 @@ impl CausalGraph {
         // Check for cycles
         if let Some(sp) = event.self_parent {
             if self.is_ancestor_of(&event_id, &sp)? {
-                return Err(CausalGraphError::CycleDetected(format!(
-                    "{}",
-                    hex::encode(&event_id[..8])
-                )));
+                return Err(CausalGraphError::CycleDetected(
+                    hex::encode(&event_id[..8]).to_string(),
+                ));
             }
         }
         if let Some(op) = event.other_parent {
             if self.is_ancestor_of(&event_id, &op)? {
-                return Err(CausalGraphError::CycleDetected(format!(
-                    "{}",
-                    hex::encode(&event_id[..8])
-                )));
+                return Err(CausalGraphError::CycleDetected(
+                    hex::encode(&event_id[..8]).to_string(),
+                ));
             }
         }
 
@@ -266,10 +275,9 @@ impl CausalGraph {
         while let Some(current_id) = queue.pop_front() {
             depth += 1;
             if depth > MAX_ANCESTRY_DEPTH {
-                return Err(CausalGraphError::MaxDepthExceeded(format!(
-                    "{}",
-                    hex::encode(&descendant[..8])
-                )));
+                return Err(CausalGraphError::MaxDepthExceeded(
+                    hex::encode(&descendant[..8]).to_string(),
+                ));
             }
 
             if let Some(event) = self.events.get(&current_id) {
@@ -298,10 +306,9 @@ impl CausalGraph {
         while let Some(current_id) = queue.pop_front() {
             depth += 1;
             if depth > MAX_ANCESTRY_DEPTH {
-                return Err(CausalGraphError::MaxDepthExceeded(format!(
-                    "{}",
-                    hex::encode(&event_id[..8])
-                )));
+                return Err(CausalGraphError::MaxDepthExceeded(
+                    hex::encode(&event_id[..8]).to_string(),
+                ));
             }
 
             if let Some(event) = self.events.get(&current_id) {
@@ -504,7 +511,8 @@ impl CausalGraph {
         ids.sort();
 
         // Build Merkle tree bottom-up
-        let mut level: Vec<[u8; 32]> = ids.iter()
+        let mut level: Vec<[u8; 32]> = ids
+            .iter()
             .map(|id| blake3::hash(&**id).as_bytes().to_owned())
             .collect();
 
@@ -538,7 +546,8 @@ impl CausalGraph {
         let pos = ids.iter().position(|&id| id == event_id)?;
         let mut proof = Vec::new();
         let mut index = pos;
-        let mut level: Vec<[u8; 32]> = ids.iter()
+        let mut level: Vec<[u8; 32]> = ids
+            .iter()
             .map(|id| blake3::hash(&**id).as_bytes().to_owned())
             .collect();
 
@@ -581,7 +590,9 @@ impl CausalGraph {
     /// memory. This is called after events have been committed to L1
     /// and are no longer needed for consensus.
     pub fn prune_old_events(&mut self, min_depth: usize) {
-        let to_prune: Vec<EventId> = self.depths.iter()
+        let to_prune: Vec<EventId> = self
+            .depths
+            .iter()
             .filter(|(_, &depth)| depth < min_depth)
             .map(|(id, _)| *id)
             .collect();
@@ -690,8 +701,11 @@ impl Default for CausalGraph {
 /// A read-only snapshot of the causal graph
 #[derive(Clone, Debug)]
 pub struct GraphSnapshot {
+    /// All events in the snapshot
     pub events: HashMap<EventId, Event>,
+    /// Current tip event IDs
     pub tips: Vec<EventId>,
+    /// Frontier vector clock
     pub frontier: VectorClock,
 }
 
@@ -1069,7 +1083,11 @@ mod tests {
     }
 
     /// Helper: verify a Merkle proof against a known root.
-    fn verify_merkle_proof(event_id: &EventId, proof: &[( [u8; 32], bool)], root: &[u8; 32]) -> bool {
+    fn verify_merkle_proof(
+        event_id: &EventId,
+        proof: &[([u8; 32], bool)],
+        root: &[u8; 32],
+    ) -> bool {
         let leaf = blake3::hash(event_id).as_bytes().to_owned();
         let mut current = leaf;
         for (sibling, sibling_is_right) in proof {
@@ -1113,15 +1131,23 @@ mod tests {
         );
 
         // Verify some payloads were actually cleared
-        let size_before_prune: usize = ids.iter()
+        let size_before_prune: usize = ids
+            .iter()
             .map(|id| graph.get(id).unwrap().payload.len())
             .sum();
         // Some events should have empty payloads (pruned) and some shouldn't
-        let pruned_count = ids.iter()
+        let pruned_count = ids
+            .iter()
             .filter(|id| graph.get(id).unwrap().payload.is_empty())
             .count();
-        assert!(pruned_count > 0, "No events were pruned — test is ineffective");
-        assert!(pruned_count < ids.len(), "All events were pruned — test is ineffective");
+        assert!(
+            pruned_count > 0,
+            "No events were pruned — test is ineffective"
+        );
+        assert!(
+            pruned_count < ids.len(),
+            "All events were pruned — test is ineffective"
+        );
     }
 
     /// Test that merkle_proof() still produces valid proofs for events
@@ -1140,7 +1166,8 @@ mod tests {
         let root = graph.state_root();
 
         // Find events that were NOT pruned (payload still present)
-        let unpruned_ids: Vec<EventId> = ids.iter()
+        let unpruned_ids: Vec<EventId> = ids
+            .iter()
             .filter(|id| !graph.get(id).unwrap().payload.is_empty())
             .copied()
             .collect();
@@ -1149,7 +1176,8 @@ mod tests {
 
         // Verify Merkle proofs for all unpruned events
         for id in &unpruned_ids {
-            let proof = graph.merkle_proof(id)
+            let proof = graph
+                .merkle_proof(id)
                 .expect("merkle_proof should return Some for existing event");
             assert!(
                 verify_merkle_proof(id, &proof, &root),
@@ -1183,7 +1211,8 @@ mod tests {
         assert_eq!(root_before, root_after);
 
         // Find events that WERE pruned (payload cleared)
-        let pruned_ids: Vec<EventId> = ids.iter()
+        let pruned_ids: Vec<EventId> = ids
+            .iter()
             .filter(|id| graph.get(id).unwrap().payload.is_empty())
             .copied()
             .collect();
@@ -1192,7 +1221,8 @@ mod tests {
 
         // Verify Merkle proofs still work for pruned events
         for id in &pruned_ids {
-            let proof = graph.merkle_proof(id)
+            let proof = graph
+                .merkle_proof(id)
                 .expect("merkle_proof should return Some for pruned event still in graph");
             assert!(
                 verify_merkle_proof(id, &proof, &root_after),

--- a/substrate/src/consensus.rs
+++ b/substrate/src/consensus.rs
@@ -18,12 +18,11 @@
 //! - **Committed**: A famous witness and all its causal ancestors
 
 use crate::causal_graph::CausalGraph;
-use crate::event::{Event, EventId, EventStatus};
+use crate::event::{Event, EventId};
 use crate::vector_clock::{NodeId, VectorClock};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use thiserror::Error;
-use tracing::{debug, info, trace};
 
 /// Supermajority threshold (>2/3)
 /// For N nodes, we need 2*N/3 + 1 for Byzantine fault tolerance
@@ -71,7 +70,10 @@ pub enum ConsensusState {
     /// Event has enough acknowledgments (optimistic)
     Acknowledged,
     /// Event is a witness in a round
-    Witness { round: u64 },
+    Witness {
+        /// The consensus round number
+        round: u64,
+    },
     /// Event is famous (seen by supermajority)
     Famous,
     /// Event is committed (final)
@@ -79,7 +81,7 @@ pub enum ConsensusState {
 }
 
 /// Information about a node's participation in consensus
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct NodeConsensusInfo {
     /// Current round for this node
     pub current_round: u64,
@@ -91,19 +93,6 @@ pub struct NodeConsensusInfo {
     pub events_committed: u64,
     /// Last event ID from this node
     pub last_event: Option<EventId>,
-}
-
-impl Default for NodeConsensusInfo {
-    fn default() -> Self {
-        Self {
-            current_round: 0,
-            // Starts at 0 so that `round >= last_witness_round` is true for round 0
-            last_witness_round: 0,
-            events_created: 0,
-            events_committed: 0,
-            last_event: None,
-        }
-    }
 }
 
 /// The consensus engine
@@ -125,7 +114,7 @@ pub struct ConsensusEngine {
     /// Total events committed
     committed_count: u64,
     /// The last finalized vector clock
-    last_finalized: VectorClock,
+    _last_finalized: VectorClock,
 }
 
 impl ConsensusEngine {
@@ -139,7 +128,7 @@ impl ConsensusEngine {
             fame_status: HashMap::new(),
             node_info: HashMap::new(),
             committed_count: 0,
-            last_finalized: VectorClock::new(),
+            _last_finalized: VectorClock::new(),
         }
     }
 
@@ -452,11 +441,17 @@ impl ConsensusEngine {
 /// Consensus statistics
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ConsensusStats {
+    /// Total number of events being tracked
     pub total_tracked: usize,
+    /// Number of committed events
     pub committed: u64,
+    /// Highest round reached across all nodes
     pub current_max_round: u64,
+    /// Event counts by consensus state
     pub by_state: HashMap<String, usize>,
+    /// Total number of consensus nodes
     pub total_nodes: usize,
+    /// Supermajority threshold
     pub threshold: usize,
 }
 
@@ -464,12 +459,16 @@ pub struct ConsensusStats {
 #[derive(Error, Debug, Clone)]
 pub enum ConsensusError {
     #[error("Graph error: {0}")]
+    /// Error from the causal graph
     GraphError(String),
     #[error("Event not found: {0:?}")]
+    /// Event not found in consensus state
     EventNotFound(EventId),
     #[error("Invalid state transition")]
+    /// Invalid state transition attempted
     InvalidStateTransition,
     #[error("Not enough nodes for consensus (need at least 4, got {0})")]
+    /// Insufficient nodes for Byzantine fault tolerance
     InsufficientNodes(usize),
 }
 

--- a/substrate/src/crdt/g_counter.rs
+++ b/substrate/src/crdt/g_counter.rs
@@ -69,7 +69,7 @@ impl GCounter {
         let mut hasher = Sha256::new();
         for (node, count) in &self.counts {
             hasher.update(node);
-            hasher.update(&count.to_le_bytes());
+            hasher.update(count.to_le_bytes());
         }
         hasher.finalize().into()
     }
@@ -109,16 +109,15 @@ mod tests {
     /// Strategy for generating arbitrary GCounter states.
     /// Produces a GCounter by applying a random sequence of increments.
     fn gcounter_strategy() -> impl Strategy<Value = GCounter> {
-        prop::collection::vec((any::<u8>(), 1u64..1000), 0..20)
-            .prop_map(|increments| {
-                let mut counter = GCounter::new();
-                for (node_byte, amount) in increments {
-                    let mut node_id = [0u8; 32];
-                    node_id[0] = node_byte;
-                    counter.increment(node_id, amount);
-                }
-                counter
-            })
+        prop::collection::vec((any::<u8>(), 1u64..1000), 0..20).prop_map(|increments| {
+            let mut counter = GCounter::new();
+            for (node_byte, amount) in increments {
+                let mut node_id = [0u8; 32];
+                node_id[0] = node_byte;
+                counter.increment(node_id, amount);
+            }
+            counter
+        })
     }
 
     #[test]

--- a/substrate/src/crdt/lww_register.rs
+++ b/substrate/src/crdt/lww_register.rs
@@ -130,9 +130,9 @@ impl<T: Clone + Serialize> LwwRegister<T> {
     /// Compute state hash
     pub fn state_hash(&self) -> [u8; 32] {
         let mut hasher = Sha256::new();
-        hasher.update(&self.timestamp.to_le_bytes());
-        hasher.update(&self.node_id);
-        hasher.update(&self.version.to_le_bytes());
+        hasher.update(self.timestamp.to_le_bytes());
+        hasher.update(self.node_id);
+        hasher.update(self.version.to_le_bytes());
         if let Some(ref val) = self.value {
             let bytes = serde_json::to_vec(val).unwrap_or_default();
             hasher.update(&bytes);
@@ -201,14 +201,15 @@ mod tests {
     /// Strategy for generating arbitrary LwwRegister<u64> states.
     /// Uses `set_with_meta` for deterministic control over timestamp, node_id, and version.
     fn lww_strategy() -> impl Strategy<Value = LwwRegister<u64>> {
-        (any::<u64>(), 0u64..10000, any::<u8>(), 0u64..100)
-            .prop_map(|(value, timestamp, node_byte, version)| {
+        (any::<u64>(), 0u64..10000, any::<u8>(), 0u64..100).prop_map(
+            |(value, timestamp, node_byte, version)| {
                 let mut node_id = [0u8; 32];
                 node_id[0] = node_byte;
                 let mut reg = LwwRegister::new(node_id);
                 reg.set_with_meta(value, timestamp, node_id, version);
                 reg
-            })
+            },
+        )
     }
 
     #[test]

--- a/substrate/src/crdt/mod.rs
+++ b/substrate/src/crdt/mod.rs
@@ -100,6 +100,7 @@ pub trait CvRDT: Clone {
 /// Op-based CRDTs replicate only the operations, not full state.
 /// More efficient for large data structures but require reliable broadcast.
 pub trait CmRDT {
+    /// The operation type for this CRDT
     type Operation;
 
     /// Apply an operation to this CRDT
@@ -132,6 +133,7 @@ pub struct AccountBalance {
 }
 
 impl AccountBalance {
+    /// Create a new account balance
     pub fn new() -> Self {
         Self {
             counter: GCounter::new(),
@@ -140,12 +142,14 @@ impl AccountBalance {
         }
     }
 
+    /// Increment the balance for a node
     pub fn increment(&mut self, node_id: NodeId, amount: u64) {
         self.counter.increment(node_id, amount);
         self.last_updater = Some(node_id);
         let _ = self.vector_clock.increment(node_id);
     }
 
+    /// Get the total balance value
     pub fn value(&self) -> u64 {
         self.counter.value()
     }

--- a/substrate/src/crdt/or_set.rs
+++ b/substrate/src/crdt/or_set.rs
@@ -140,7 +140,7 @@ impl<T: Clone + Ord + Hash + Serialize> OrSet<T> {
             hasher.update(&elem_bytes);
             for (node, seq) in tokens {
                 hasher.update(node);
-                hasher.update(&seq.to_le_bytes());
+                hasher.update(seq.to_le_bytes());
             }
         }
         hasher.finalize().into()
@@ -187,20 +187,19 @@ mod tests {
     /// Strategy for generating arbitrary OrSet<u32> states.
     /// Produces an OrSet by applying a random sequence of add/remove operations.
     fn orset_strategy() -> impl Strategy<Value = OrSet<u32>> {
-        prop::collection::vec((any::<u8>(), any::<bool>(), any::<u32>()), 0..20)
-            .prop_map(|ops| {
-                let mut set: OrSet<u32> = OrSet::new();
-                for (node_byte, is_add, element) in ops {
-                    let mut node_id = [0u8; 32];
-                    node_id[0] = node_byte;
-                    if is_add {
-                        set.add(node_id, element);
-                    } else {
-                        set.remove(&element);
-                    }
+        prop::collection::vec((any::<u8>(), any::<bool>(), any::<u32>()), 0..20).prop_map(|ops| {
+            let mut set: OrSet<u32> = OrSet::new();
+            for (node_byte, is_add, element) in ops {
+                let mut node_id = [0u8; 32];
+                node_id[0] = node_byte;
+                if is_add {
+                    set.add(node_id, element);
+                } else {
+                    set.remove(&element);
                 }
-                set
-            })
+            }
+            set
+        })
     }
 
     /// Compare two OrSets by their observable elements (ignoring internal sequence counter).

--- a/substrate/src/event.rs
+++ b/substrate/src/event.rs
@@ -109,12 +109,19 @@ pub struct Event {
 /// Lightweight event header for efficient gossip
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct EventHeader {
+    /// Event identifier
     pub id: EventId,
+    /// Creator node identifier
     pub creator: NodeId,
+    /// Sequence number from the creator
     pub sequence: u64,
+    /// Wall-clock timestamp
     pub timestamp: u64,
+    /// Vector clock for causal ordering
     pub vector_clock: VectorClock,
+    /// Hash of the creator's previous event
     pub self_parent: Option<EventId>,
+    /// Hash of an event from another node
     pub other_parent: Option<EventId>,
 }
 
@@ -132,6 +139,7 @@ pub struct EventRequest {
 /// Response to an event request
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct EventBatch {
+    /// Events in the batch
     pub events: Vec<Event>,
     /// Whether there are more events available
     pub has_more: bool,
@@ -183,18 +191,18 @@ impl Event {
     /// Includes creator_pubkey in the hash input for binding.
     fn compute_hash(&self) -> EventId {
         let mut hasher = Sha256::new();
-        hasher.update(&self.creator);
-        hasher.update(&self.sequence.to_le_bytes());
-        hasher.update(&self.timestamp.to_le_bytes());
-        hasher.update(&self.vector_clock.to_bytes());
+        hasher.update(self.creator);
+        hasher.update(self.sequence.to_le_bytes());
+        hasher.update(self.timestamp.to_le_bytes());
+        hasher.update(self.vector_clock.to_bytes());
         if let Some(sp) = self.self_parent {
-            hasher.update(&sp);
+            hasher.update(sp);
         }
         if let Some(op) = self.other_parent {
-            hasher.update(&op);
+            hasher.update(op);
         }
         hasher.update(&self.payload);
-        hasher.update(&self.creator_pubkey);
+        hasher.update(self.creator_pubkey);
         hasher.finalize().into()
     }
 
@@ -338,24 +346,34 @@ impl EventHeader {
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum EventValidationError {
     #[error("Event hash does not match content")]
+    /// Hash integrity check failed
     InvalidHash,
     #[error("Event signature is invalid")]
+    /// Cryptographic signature is invalid
     InvalidSignature,
     #[error("Event has been rejected")]
+    /// Event was previously rejected
     RejectedEvent,
     #[error("Failed to deserialize event")]
+    /// Deserialization failed
     DeserializationError,
     #[error("Event timestamp is too far in the future")]
+    /// Timestamp exceeds allowed drift
     FutureTimestamp,
     #[error("Event timestamp is unreasonably old")]
+    /// Timestamp is too old
     AncientTimestamp,
     #[error("Event is unsigned (zero signature or pubkey)")]
+    /// Event has no valid signature
     UnsignedEvent,
     #[error("Event parent references form a cycle")]
+    /// Parent references create a cycle
     CircularParentReference,
     #[error("Event references a non-existent parent")]
+    /// Referenced parent does not exist
     MissingParent,
     #[error("Event has obviously invalid data (zero amount)")]
+    /// Obviously invalid data detected
     ZeroAmount,
 }
 
@@ -700,10 +718,7 @@ mod tests {
     #[test]
     fn test_circular_parent_reference_error_variant() {
         let err = EventValidationError::CircularParentReference;
-        assert_eq!(
-            format!("{}", err),
-            "Event parent references form a cycle"
-        );
+        assert_eq!(format!("{}", err), "Event parent references form a cycle");
     }
 
     /// Test that the new MissingParent error variant exists and is constructible.

--- a/substrate/src/gossip.rs
+++ b/substrate/src/gossip.rs
@@ -21,14 +21,22 @@ const MAX_EVENTS_PER_GOSSIP: usize = 100;
 const MAX_PENDING_EVENTS: usize = 100_000;
 const DEFAULT_PARTITION_THRESHOLD_MS: u64 = 3000;
 
+/// Configuration for the gossip protocol
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GossipConfig {
+    /// Interval between gossip rounds in milliseconds
     pub interval_ms: u64,
+    /// Maximum events per gossip message
     pub max_events_per_message: usize,
+    /// Number of peers to gossip to per round
     pub fanout: usize,
+    /// Timeout for peer responses in milliseconds
     pub peer_timeout_ms: u64,
+    /// Whether to use eager push strategy
     pub eager_push: bool,
+    /// Maximum number of pending events
     pub max_pending: usize,
+    /// Random seed for peer selection
     pub seed: u64,
     /// Bootstrap peer addresses to dial on startup.
     /// Stored as strings (multiaddr format, e.g. "/ip4/1.2.3.4/udp/4001/quic")
@@ -61,37 +69,60 @@ impl Default for GossipConfig {
     }
 }
 
+/// Gossip protocol statistics
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct GossipStats {
+    /// Number of gossip rounds initiated
     pub rounds_initiated: u64,
+    /// Number of gossip rounds received
     pub rounds_received: u64,
+    /// Number of events sent
     pub events_sent: u64,
+    /// Number of events received
     pub events_received: u64,
+    /// Number of events accepted into the graph
     pub events_accepted: u64,
+    /// Number of events rejected
     pub events_rejected: u64,
     /// Number of events rejected specifically due to invalid signatures.
     pub messages_rejected_invalid_sig: u64,
+    /// Number of syncs completed
     pub syncs_completed: u64,
+    /// Average events per sync operation
     pub avg_events_per_sync: f64,
+    /// Time since last sync in milliseconds
     pub time_since_last_sync_ms: u64,
+    /// Number of known peers
     pub known_peers: usize,
+    /// Total bytes sent
     pub bytes_sent: u64,
+    /// Total bytes received
     pub bytes_received: u64,
 }
 
+/// A digest of gossip state for efficient synchronization
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct GossipDigest {
+    /// Node identifier
     pub node_id: NodeId,
+    /// Frontier vector clock
     pub frontier: VectorClock,
+    /// Number of events known
     pub event_count: usize,
+    /// Recent event ID prefixes
     pub recent_events: Vec<[u8; 8]>,
 }
 
+/// Messages in the gossip protocol
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum GossipMessage {
+    /// State digest for synchronization
     Digest(GossipDigest),
+    /// Request for missing events
     Request(EventRequest),
+    /// Batch of events
     Events(EventBatch),
+    /// Acknowledgment of received events
     Ack(Vec<[u8; 32]>),
 }
 
@@ -116,6 +147,7 @@ pub struct GossipProtocol {
     network_cmd_tx: Option<mpsc::Sender<NetworkCommand>>,
     // Network event receiver — drained into pending_events by
     // process_pending_events() so that p2p events flow through consensus.
+    /// Network event receiver
     pub network_rx: Option<mpsc::Receiver<NetworkEvent>>,
     pending_events: VecDeque<Event>,
     recent_gossip: HashSet<[u8; 32]>,
@@ -130,6 +162,7 @@ pub struct GossipProtocol {
 }
 
 impl GossipProtocol {
+    /// Create a new gossip protocol instance
     pub fn new(node_id: NodeId, config: GossipConfig, graph: Arc<RwLock<CausalGraph>>) -> Self {
         Self {
             node_id,
@@ -201,12 +234,14 @@ impl GossipProtocol {
         );
     }
 
+    /// Stop the gossip protocol
     pub fn stop(&mut self) {
         self.running = false;
         self.network_cmd_tx = None;
         info!("Gossip protocol stopped");
     }
 
+    /// Check if the gossip protocol is running
     pub fn is_running(&self) -> bool {
         self.running
     }
@@ -244,6 +279,7 @@ impl GossipProtocol {
         Ok(())
     }
 
+    /// Get gossip protocol statistics
     pub fn stats(&self) -> &GossipStats {
         &self.stats
     }
@@ -372,7 +408,7 @@ impl GossipProtocol {
         // This avoids borrow-checker conflicts between the mutable borrow
         // on network_rx and immutable borrows on other self fields.
         enum DrainedEvent {
-            Gossip { event: Event, source: PeerId },
+            Gossip { event: Box<Event>, source: PeerId },
             PeerConnected(PeerId),
             PeerDisconnected(PeerId),
         }
@@ -389,7 +425,7 @@ impl GossipProtocol {
                     }) => match Event::from_bytes(&data) {
                         Ok(event) => {
                             drained.push(DrainedEvent::Gossip {
-                                event,
+                                event: Box::new(event),
                                 source: propagation_source,
                             });
                         }
@@ -442,7 +478,7 @@ impl GossipProtocol {
 
                     if !self.seen_events.contains(&event.id) {
                         self.seen_events.insert(event.id);
-                        self.pending_events.push_back(event);
+                        self.pending_events.push_back(*event);
                         self.stats.events_received += 1;
                     }
                 }
@@ -491,17 +527,23 @@ fn extract_peer_id_from_multiaddr(addr: &Multiaddr) -> Option<PeerId> {
     })
 }
 
+/// Errors from the gossip protocol
 #[derive(Error, Debug, Clone)]
 pub enum GossipError {
     #[error("Graph error: {0}")]
+    /// Error from the causal graph
     GraphError(String),
     #[error("Network error: {0}")]
+    /// Network communication error
     NetworkError(String),
     #[error("Serialization error: {0}")]
+    /// Serialization/deserialization error
     SerializationError(String),
     #[error("Protocol not running")]
+    /// Protocol is not running
     NotRunning,
     #[error("Event validation failed: {0}")]
+    /// Event validation failed
     ValidationFailed(String),
 }
 
@@ -709,9 +751,7 @@ mod tests {
     #[test]
     fn test_gossip_config_bootstrap_peers_custom() {
         let config = GossipConfig {
-            bootstrap_peers: vec![
-                "/ip4/1.2.3.4/udp/4001/quic/p2p/12D3KooWABSApKz".to_string()
-            ],
+            bootstrap_peers: vec!["/ip4/1.2.3.4/udp/4001/quic/p2p/12D3KooWABSApKz".to_string()],
             ..Default::default()
         };
         assert_eq!(config.bootstrap_peers.len(), 1);
@@ -743,16 +783,23 @@ mod tests {
             protocol.last_seen.insert(PeerId::random(), Instant::now());
         }
 
-        assert!(!protocol.detect_partition(), "All peers recently seen => no partition");
+        assert!(
+            !protocol.detect_partition(),
+            "All peers recently seen => no partition"
+        );
     }
 
     #[test]
     fn test_detect_partition_with_silent_peers() {
         let graph = Arc::new(RwLock::new(CausalGraph::new()));
-        let mut protocol = GossipProtocol::new(node(1), GossipConfig {
-            partition_threshold_ms: 100,
-            ..Default::default()
-        }, graph);
+        let mut protocol = GossipProtocol::new(
+            node(1),
+            GossipConfig {
+                partition_threshold_ms: 100,
+                ..Default::default()
+            },
+            graph,
+        );
 
         // Add 3 peers: 2 silent (>100ms ago), 1 recent
         // 2/3 silent => 2*3 > 3 => 6 > 3 => partition detected
@@ -769,10 +816,14 @@ mod tests {
     #[test]
     fn test_detect_partition_below_threshold() {
         let graph = Arc::new(RwLock::new(CausalGraph::new()));
-        let mut protocol = GossipProtocol::new(node(1), GossipConfig {
-            partition_threshold_ms: 100,
-            ..Default::default()
-        }, graph);
+        let mut protocol = GossipProtocol::new(
+            node(1),
+            GossipConfig {
+                partition_threshold_ms: 100,
+                ..Default::default()
+            },
+            graph,
+        );
 
         // Add 3 peers: 1 silent, 2 recent
         // 1/3 silent => 1*3 > 3? 3 > 3 => false => no partition
@@ -783,16 +834,23 @@ mod tests {
         protocol.last_seen.insert(PeerId::random(), now);
         protocol.last_seen.insert(PeerId::random(), now);
 
-        assert!(!protocol.detect_partition(), "1/3 peers silent => not enough for partition");
+        assert!(
+            !protocol.detect_partition(),
+            "1/3 peers silent => not enough for partition"
+        );
     }
 
     #[test]
     fn test_partition_event_transitions() {
         let graph = Arc::new(RwLock::new(CausalGraph::new()));
-        let mut protocol = GossipProtocol::new(node(1), GossipConfig {
-            partition_threshold_ms: 100,
-            ..Default::default()
-        }, graph);
+        let mut protocol = GossipProtocol::new(
+            node(1),
+            GossipConfig {
+                partition_threshold_ms: 100,
+                ..Default::default()
+            },
+            graph,
+        );
 
         // Initially healthy
         assert_eq!(protocol.check_partition(), None);
@@ -804,7 +862,10 @@ mod tests {
         }
 
         // Should detect partition
-        assert_eq!(protocol.check_partition(), Some(GossipEvent::PartitionDetected));
+        assert_eq!(
+            protocol.check_partition(),
+            Some(GossipEvent::PartitionDetected)
+        );
 
         // Already in partition state — no new event
         assert_eq!(protocol.check_partition(), None);
@@ -816,7 +877,10 @@ mod tests {
         }
 
         // Should detect healing
-        assert_eq!(protocol.check_partition(), Some(GossipEvent::PartitionHealed));
+        assert_eq!(
+            protocol.check_partition(),
+            Some(GossipEvent::PartitionHealed)
+        );
 
         // Already healthy — no new event
         assert_eq!(protocol.check_partition(), None);

--- a/substrate/src/lib.rs
+++ b/substrate/src/lib.rs
@@ -38,7 +38,10 @@ pub use event::{
     Event, EventBatch, EventHeader, EventId, EventRequest, EventStatus, EventValidationError,
     MAX_EVENT_AGE_MS, MAX_TIMESTAMP_DRIFT_MS,
 };
-pub use gossip::{GossipConfig, GossipDigest, GossipError, GossipEvent, GossipMessage, GossipProtocol, GossipStats};
+pub use gossip::{
+    GossipConfig, GossipDigest, GossipError, GossipEvent, GossipMessage, GossipProtocol,
+    GossipStats,
+};
 pub use network::{NetworkCommand, NetworkEvent, OmniaBehaviour, OmniaNetwork};
 pub use vector_clock::{CausalOrder, NodeId, VectorClock, VectorClockError};
 
@@ -86,16 +89,22 @@ pub trait EventProcessor: Send + Sync {
 #[derive(Error, Debug)]
 pub enum SubstrateError {
     #[error("Vector clock error: {0}")]
+    /// Vector clock error
     VectorClock(#[from] VectorClockError),
     #[error("Causal graph error: {0}")]
+    /// Causal graph error
     CausalGraph(#[from] CausalGraphError),
     #[error("Event validation error: {0}")]
+    /// Event validation error
     EventValidation(#[from] EventValidationError),
     #[error("Gossip error: {0}")]
+    /// Gossip protocol error
     Gossip(#[from] GossipError),
     #[error("Consensus error: {0}")]
+    /// Consensus engine error
     Consensus(#[from] ConsensusError),
     #[error("Configuration error: {0}")]
+    /// Configuration error
     Config(String),
 }
 
@@ -105,13 +114,18 @@ pub type Result<T> = std::result::Result<T, SubstrateError>;
 /// Configuration for the entire substrate layer
 #[derive(Debug, Clone)]
 pub struct SubstrateConfig {
+    /// Unique identifier for this node
     pub node_id: NodeId,
+    /// Gossip protocol configuration
     pub gossip: GossipConfig,
+    /// Consensus engine configuration
     pub consensus: ConsensusConfig,
+    /// Total number of nodes in the network
     pub total_nodes: usize,
 }
 
 impl SubstrateConfig {
+    /// Create a new substrate configuration with default settings
     pub fn new(node_id: NodeId) -> Self {
         let total_nodes = 4;
         Self {
@@ -125,6 +139,7 @@ impl SubstrateConfig {
         }
     }
 
+    /// Create a substrate configuration with a custom network size
     pub fn with_network_size(node_id: NodeId, total_nodes: usize) -> Self {
         Self {
             node_id,
@@ -159,6 +174,7 @@ pub struct Substrate {
 }
 
 impl Substrate {
+    /// Create a new Substrate runtime with the given configuration
     pub fn new(config: SubstrateConfig) -> Self {
         let graph = std::sync::Arc::new(tokio::sync::RwLock::new(CausalGraph::new()));
         let consensus = ConsensusEngine::new(config.consensus.clone());
@@ -174,6 +190,7 @@ impl Substrate {
         }
     }
 
+    /// Initialize the gossip protocol
     pub fn init_gossip(&mut self) {
         self.gossip = Some(GossipProtocol::new(
             self.config.node_id,
@@ -182,6 +199,7 @@ impl Substrate {
         ));
     }
 
+    /// Start the substrate runtime
     pub async fn start(&mut self) {
         self.running = true;
         if let Some(ref mut gossip) = self.gossip {
@@ -189,6 +207,7 @@ impl Substrate {
         }
     }
 
+    /// Stop the substrate runtime
     pub fn stop(&mut self) {
         self.running = false;
         if let Some(ref mut gossip) = self.gossip {
@@ -252,15 +271,16 @@ impl Substrate {
         }
     }
 
-    /// Start with network and run main loop.
-    pub async fn start_with_network(&mut self, network: network::OmniaNetwork) {
+    /// Start with network and run main loop
+    pub async fn start_with_network(&mut self, network: OmniaNetwork) {
         if let Some(ref mut gossip) = self.gossip {
             gossip.start_with_network(network).await;
         }
         self.run().await;
     }
 
-    pub async fn submit_event(&mut self, mut event: Event) -> Result<()> {
+    /// Submit an event to the substrate for processing
+    pub async fn submit_event(&mut self, event: Event) -> Result<()> {
         event.validate().map_err(SubstrateError::from)?;
 
         {
@@ -287,22 +307,27 @@ impl Substrate {
         Ok(())
     }
 
-    pub async fn graph(&self) -> tokio::sync::RwLockReadGuard<CausalGraph> {
+    /// Get read access to the causal graph
+    pub async fn graph(&self) -> tokio::sync::RwLockReadGuard<'_, CausalGraph> {
         self.graph.read().await
     }
 
+    /// Get consensus statistics
     pub fn consensus_stats(&self) -> consensus::ConsensusStats {
         self.consensus.stats()
     }
 
+    /// Get gossip protocol statistics
     pub fn gossip_stats(&self) -> Option<&GossipStats> {
         self.gossip.as_ref().map(|g| g.stats())
     }
 
+    /// Check if an event has been finalized
     pub fn is_finalized(&self, event_id: &EventId) -> bool {
         self.consensus.is_committed(event_id)
     }
 
+    /// Get all finalized event IDs
     pub fn finalized_events(&self) -> Vec<EventId> {
         self.consensus.get_committed()
     }
@@ -367,10 +392,14 @@ impl Substrate {
     }
 }
 
+/// Statistics about the substrate runtime
 #[derive(Debug, Clone)]
 pub struct SubstrateStats {
+    /// Graph statistics
     pub graph: GraphStats,
+    /// Consensus statistics
     pub consensus: consensus::ConsensusStats,
+    /// Whether the substrate is running
     pub running: bool,
 }
 

--- a/substrate/src/network.rs
+++ b/substrate/src/network.rs
@@ -4,6 +4,11 @@
 //! and request-response for sync operations. Uses tokio::sync primitives exclusively
 //! — never std::sync::Mutex across await points.
 
+// The libp2p NetworkBehaviour derive macro generates an event enum without
+// doc comments on its variants, which triggers missing_docs. Allow it here
+// since we cannot annotate the derived code directly.
+#![allow(missing_docs)]
+
 use libp2p::{
     gossipsub::{self, IdentTopic, MessageAuthenticity, ValidationMode},
     identity, Multiaddr, PeerId, StreamProtocol, Swarm, SwarmBuilder,
@@ -14,21 +19,32 @@ use tokio::sync::mpsc;
 /// Events emitted by the network layer.
 #[derive(Debug)]
 pub enum NetworkEvent {
+    /// A peer has connected
     PeerConnected(PeerId),
+    /// A peer has disconnected
     PeerDisconnected(PeerId),
+    /// A direct message was received from a peer
     MessageReceived(PeerId, Vec<u8>),
+    /// A gossipsub message was received
     GossipReceived {
+        /// The topic the message was published to
         topic: String,
+        /// The message payload
         data: Vec<u8>,
+        /// The peer that propagated the message
         propagation_source: PeerId,
     },
 }
 
 /// Combined libp2p behaviour for Omnia.
+#[allow(missing_docs)]
 #[derive(libp2p::swarm::NetworkBehaviour)]
 pub struct OmniaBehaviour {
+    /// GossipSub event propagation behaviour
     pub gossipsub: gossipsub::Behaviour,
+    /// mDNS peer discovery behaviour
     pub mdns: libp2p::mdns::tokio::Behaviour,
+    /// Request-response sync behaviour
     pub req_res: libp2p::request_response::cbor::Behaviour<Vec<u8>, Vec<u8>>,
 }
 
@@ -36,11 +52,24 @@ pub struct OmniaBehaviour {
 #[derive(Debug)]
 pub enum NetworkCommand {
     /// Publish data to a gossipsub topic.
-    Publish { topic: String, data: Vec<u8> },
+    Publish {
+        /// Topic to publish to
+        topic: String,
+        /// Data payload
+        data: Vec<u8>,
+    },
     /// Subscribe to a gossipsub topic.
-    Subscribe { topic: String },
+    Subscribe {
+        /// Topic to subscribe to
+        topic: String,
+    },
     /// Dial a specific peer at the given address.
-    Dial { peer_id: PeerId, addr: Multiaddr },
+    Dial {
+        /// Peer to dial
+        peer_id: PeerId,
+        /// Address to dial
+        addr: Multiaddr,
+    },
 }
 
 /// The Omnia P2P network handle.
@@ -49,6 +78,7 @@ pub struct OmniaNetwork {
     swarm: Swarm<OmniaBehaviour>,
     local_peer_id: PeerId,
     event_tx: mpsc::Sender<NetworkEvent>,
+    /// Network event receiver
     pub event_rx: Option<mpsc::Receiver<NetworkEvent>>,
     known_peers: HashMap<PeerId, Multiaddr>,
 }
@@ -114,10 +144,12 @@ impl OmniaNetwork {
         })
     }
 
+    /// Get the local peer ID
     pub fn local_peer_id(&self) -> PeerId {
         self.local_peer_id
     }
 
+    /// Dial a peer at the given address
     pub fn dial(
         &mut self,
         peer_id: PeerId,
@@ -128,11 +160,13 @@ impl OmniaNetwork {
         Ok(())
     }
 
+    /// Subscribe to a gossipsub topic
     pub fn subscribe(&mut self, topic: &str) -> Result<bool, gossipsub::SubscriptionError> {
         let topic = IdentTopic::new(topic);
         self.swarm.behaviour_mut().gossipsub.subscribe(&topic)
     }
 
+    /// Publish data to a gossipsub topic
     pub fn publish(&mut self, topic: &str, data: Vec<u8>) -> Result<(), gossipsub::PublishError> {
         let topic = IdentTopic::new(topic);
         self.swarm.behaviour_mut().gossipsub.publish(topic, data)?;
@@ -159,10 +193,7 @@ impl OmniaNetwork {
     ///
     /// Event consumption (graph insertion + consensus) is handled by
     /// GossipProtocol::process_pending_events(), not here.
-    pub async fn run_with_commands(
-        &mut self,
-        mut cmd_rx: mpsc::Receiver<NetworkCommand>,
-    ) {
+    pub async fn run_with_commands(&mut self, mut cmd_rx: mpsc::Receiver<NetworkCommand>) {
         use futures::StreamExt;
         loop {
             tokio::select! {

--- a/substrate/src/vector_clock.rs
+++ b/substrate/src/vector_clock.rs
@@ -24,11 +24,17 @@ pub type LogicalClock = u64;
 #[derive(Error, Debug, Clone, PartialEq)]
 pub enum VectorClockError {
     #[error("Cannot compare vector clocks: node IDs are incompatible")]
+    /// Node IDs are incompatible for comparison
     IncompatibleNodes,
     #[error("Invalid node ID: {0}")]
+    /// The node ID is invalid
     InvalidNodeId(String),
     #[error("Clock overflow detected for node {node:?}")]
-    ClockOverflow { node: NodeId },
+    /// A clock value overflowed
+    ClockOverflow {
+        /// The node whose clock overflowed
+        node: NodeId,
+    },
 }
 
 /// VectorClock tracks the logical time across all known nodes.
@@ -508,9 +514,12 @@ mod tests {
         let merged_b = vc_b.merged(&vc_partition);
 
         // The happened_before relationship must still hold after merge
-        assert!(merged_a.happened_before(&merged_b),
+        assert!(
+            merged_a.happened_before(&merged_b),
             "happened_before not preserved after merge: {:?} vs {:?}",
-            merged_a, merged_b);
+            merged_a,
+            merged_b
+        );
     }
 
     /// Test a multi-round partition reconciliation scenario.
@@ -549,7 +558,7 @@ mod tests {
         vc2.merge(&vc3);
         // But vc2 is missing n1's updates from round 2
         assert_eq!(vc2.get(&n1), 0); // vc2 doesn't know about n1
-        // After final reconciliation between vc1 and vc2
+                                     // After final reconciliation between vc1 and vc2
         vc2.merge(&vc1);
         assert_eq!(vc2.get(&n1), 6);
         assert_eq!(vc2.get(&n2), 3);

--- a/substrate/tests/gossip_simulation.rs
+++ b/substrate/tests/gossip_simulation.rs
@@ -39,7 +39,10 @@ impl TestNetwork {
             nodes.push(Arc::new(RwLock::new(substrate)));
         }
 
-        Self { nodes, shared_graph }
+        Self {
+            nodes,
+            shared_graph,
+        }
     }
 
     /// Submit an event to a specific node AND to the shared graph.
@@ -314,8 +317,18 @@ fn test_crdt_100_percent_convergence() {
         assert_eq!(merged.value(), expected, "Main merge failed for {}", desc);
         assert_eq!(alt1.value(), expected, "Alt1 merge failed for {}", desc);
         assert_eq!(alt2.value(), expected, "Alt2 merge failed for {}", desc);
-        assert_eq!(merged.state_hash(), alt1.state_hash(), "Hash mismatch for {}", desc);
-        assert_eq!(alt1.state_hash(), alt2.state_hash(), "Hash mismatch for {}", desc);
+        assert_eq!(
+            merged.state_hash(),
+            alt1.state_hash(),
+            "Hash mismatch for {}",
+            desc
+        );
+        assert_eq!(
+            alt1.state_hash(),
+            alt2.state_hash(),
+            "Hash mismatch for {}",
+            desc
+        );
     }
 }
 
@@ -361,7 +374,11 @@ async fn test_network_event_processed_through_consensus() {
     // Verify events are finalized (4 witnesses in round 0 => supermajority)
     let node0 = network.nodes[0].read().await;
     for id in &event_ids {
-        assert!(node0.is_finalized(id), "Event {:?} should be finalized", &id[..4]);
+        assert!(
+            node0.is_finalized(id),
+            "Event {:?} should be finalized",
+            &id[..4]
+        );
     }
 }
 

--- a/zk/src/operator.rs
+++ b/zk/src/operator.rs
@@ -118,11 +118,7 @@ impl RollupOperator {
     }
 
     /// Extract events from a causal graph starting at a given index.
-    fn collect_from_graph(
-        graph: &CausalGraph,
-        start_index: usize,
-        limit: usize,
-    ) -> Vec<Event> {
+    fn collect_from_graph(graph: &CausalGraph, start_index: usize, limit: usize) -> Vec<Event> {
         let all_ids = graph.event_ids();
         all_ids
             .iter()

--- a/zk/src/proof_bundle.rs
+++ b/zk/src/proof_bundle.rs
@@ -120,8 +120,7 @@ impl ProofBundle {
 
     /// Deserialize a bundle from bytes using bincode.
     pub fn from_bytes(data: &[u8]) -> Result<Self, ProofBundleError> {
-        bincode::deserialize(data)
-            .map_err(|e| ProofBundleError::SerializationError(e.to_string()))
+        bincode::deserialize(data).map_err(|e| ProofBundleError::SerializationError(e.to_string()))
     }
 
     /// Verify the integrity of this proof bundle.

--- a/zk/src/settlement/ethereum.rs
+++ b/zk/src/settlement/ethereum.rs
@@ -19,7 +19,7 @@ use async_trait::async_trait;
 pub struct EthereumAdapter {
     rpc_url: String,
     contract_address: String,
-    operator_key: [u8; 32],
+    _operator_key: [u8; 32],
 }
 
 impl EthereumAdapter {
@@ -33,7 +33,7 @@ impl EthereumAdapter {
         Self {
             rpc_url: rpc_url.to_string(),
             contract_address: contract_address.to_string(),
-            operator_key: *operator_key,
+            _operator_key: *operator_key,
         }
     }
 
@@ -110,7 +110,9 @@ impl SettlementLayer for EthereumAdapter {
         // In production, this would serialize the bundle and send it to the
         // OmniaRollup contract, which verifies the ZK proof and updates the
         // committed state root on-chain.
-        let bundle_bytes = bundle.to_bytes().map_err(|e| SettlementError::RpcError(e.to_string()))?;
+        let bundle_bytes = bundle
+            .to_bytes()
+            .map_err(|e| SettlementError::RpcError(e.to_string()))?;
         let tx_hash = format!("0x{}", hex::encode(blake3::hash(&bundle_bytes).as_bytes()));
         tracing::info!(
             "[Ethereum] Submitted proof bundle, state_root={}, tx: {}",

--- a/zk/src/settlement/mod.rs
+++ b/zk/src/settlement/mod.rs
@@ -5,8 +5,8 @@
 //! this trait, ensuring that switching settlement layers requires zero changes
 //! to consensus, the causal graph, or shard logic.
 
-use async_trait::async_trait;
 use crate::proof_bundle::ProofBundle;
+use async_trait::async_trait;
 
 pub mod bitcoin;
 pub mod celestia;

--- a/zk/tests/settlement_agnostic.rs
+++ b/zk/tests/settlement_agnostic.rs
@@ -87,7 +87,11 @@ async fn test_bitcoin_adapter_not_implemented() {
     let result = adapter.post_batch(b"test").await;
     assert!(result.is_err());
     let err_msg = result.unwrap_err().to_string();
-    assert!(err_msg.contains("Not implemented") || err_msg.contains("NotImplemented"), "Unexpected error: {}", err_msg);
+    assert!(
+        err_msg.contains("Not implemented") || err_msg.contains("NotImplemented"),
+        "Unexpected error: {}",
+        err_msg
+    );
 }
 
 #[tokio::test]
@@ -104,9 +108,7 @@ async fn test_solana_adapter_not_implemented() {
     let adapter = SolanaAdapter;
     assert_eq!(adapter.chain_id(), "solana");
 
-    let result = adapter
-        .verify_proof(&[0u8; 32], &[1u8; 32], &[])
-        .await;
+    let result = adapter.verify_proof(&[0u8; 32], &[1u8; 32], &[]).await;
     assert!(result.is_err());
 }
 


### PR DESCRIPTION
## CI was failing on `fmt` and `clippy` jobs

### Fixes
- **`cargo fmt`** — applied across entire workspace (~1,963 lines of violations)
- **168 clippy warnings** in `omnia-substrate`:
  - Added doc comments to 141 public items
  - Removed 4 unused imports
  - Fixed 5 useless `format!` → `.to_string()`
  - Fixed 12 needless borrows
  - Replaced manual `impl Default` with `#[derive(Default)]`
  - Fixed `large_enum_variant` by boxing `Event` in `DrainedEvent::Gossip`
  - Fixed `mismatched_lifetime_syntaxes` with explicit `'_'` lifetime
  - Prefixed dead_code field `last_finalized` → `_last_finalized`
  - Removed unnecessary `mut` and qualification
- **3 clippy warnings** in other crates (shards, zk, binding)
- **Dependabot config** — ignore `rand >=0.9` and `bincode >=2.0` (known incompatible)

### Verification
- `cargo fmt --check` → PASS ✅
- `cargo clippy -D warnings` → 0 warnings ✅
- `cargo test --workspace` → 305 passed, 0 failed ✅
- `cargo test --all-features` → 305 passed, 0 failed ✅