### PR TITLE
fix: use stable Rust toolchain in CI to resolve transitive dep MSRV issues

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: "1.85"
+          toolchain: "stable"
       - uses: Swatinem/rust-cache@v2
       - name: Run benchmarks
         run: cargo bench --workspace || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: "1.85"
+          toolchain: "stable"
       - uses: Swatinem/rust-cache@v2
       - run: cargo check --workspace
 
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: "1.85"
+          toolchain: "stable"
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --workspace
       - run: cargo test --workspace --all-features
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: "1.85"
+          toolchain: "stable"
           components: clippy
       - uses: Swatinem/rust-cache@v2
       - run: cargo clippy --workspace -- -D warnings
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: "1.85"
+          toolchain: "stable"
           components: rustfmt
       - run: cargo fmt --all -- --check
 
@@ -64,7 +64,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: "1.85"
+          toolchain: "stable"
       - uses: rustsec/audit-check@v2.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem

CI was still failing after upgrading to Rust 1.85 because transitive dependencies now require Rust 1.86+:
- `icu_normalizer_data@2.2.0`, `icu_properties@2.2.0` → requires 1.86
- `time@0.3.47`, `time-core@0.1.8` → requires 1.88

These come in through `libp2p` via `omnia-substrate`.

## Fix

- Changed CI toolchain from `1.85` to `stable` — ensures CI always has the latest stable Rust, avoiding recurring MSRV issues
- Regenerated `Cargo.lock` to pin latest compatible versions

This builds on PR #9 which fixed fmt + clippy warnings.