### PR TITLE
fix: configure cargo audit to ignore known transitive dep vulnerabilities

Security audit found 2 real vulnerabilities in hickory-proto 0.25.2
(transitive dep via libp2p 0.56) and 2 unmaintained crate warnings.
These cannot be fixed without a libp2p upgrade.

Ignored advisories (with rationale in .cargo/audit.toml):
- RUSTSEC-2026-0119: hickory-proto CPU exhaustion (DoS) — libp2p pins 0.25.x
- RUSTSEC-2026-0118: hickory-proto NSEC3 unbounded loop — libp2p pins 0.25.x
- RUSTSEC-2025-0141: bincode unmaintained — pinned to 1.x, postcard migration planned
- RUSTSEC-2024-0436: paste unmaintained — transitive from ed25519-dalek

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,11 @@
+[advisories]
+# hickory-proto 0.25.x DoS vulnerabilities — transitive dep via libp2p 0.56.
+# Patched in hickory-proto >=0.26.1, but libp2p 0.56 pins 0.25.x.
+# These are DNS-specific DoS issues; omnia-protocol does not expose DNS
+# resolution to untrusted input. Ignore until libp2p upgrades hickory.
+ignore = [
+    "RUSTSEC-2026-0119",  # hickory-proto: CPU exhaustion via O(n²) name compression
+    "RUSTSEC-2026-0118",  # hickory-proto: unbounded loop in NSEC3 validation
+    "RUSTSEC-2025-0141",  # bincode: unmaintained (pinned to 1.x; migration to postcard planned)
+    "RUSTSEC-2024-0436",  # paste: unmaintained (transitive dep from ed25519-dalek)
+]


### PR DESCRIPTION
---
name: Pull Request
about: Propose changes to the Omnia Protocol.
title: "[PR]: "
labels: [enhancement, needs-review]
assignees: []
---

## 🚀 Description

A clear and concise description of the changes proposed in this pull request.

## 💡 Motivation and Context

Explain why these changes are needed and what problem they solve. Link to any relevant issues (e.g., `Fixes #123`).

## ✅ How Has This Been Tested?

Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also, list any relevant details for your test configuration.

- [ ] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing

## 📸 Screenshots (if appropriate)

If applicable, add screenshots to help explain your changes.

## 📝 Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## ➕ Additional Context

Add any other context or information about the pull request here.
