### PR TITLE
Step 5: Unify tests/benches/fuzz + optimize release profiles

### DIFF
--- a/.cargo-mutants.toml
+++ b/.cargo-mutants.toml
@@ -1,14 +1,19 @@
 # cargo-mutants configuration for Omnia Protocol
 # Mutation testing verifies test suites catch real bugs
 
-# Exclude generated code and test utilities from mutation
-exclude_re = ["target/", "fuzz/", "chaos-tests/"]
+mutant_schema = "all"
 
-# Minimum mutation score to pass CI
+# Exclude generated code, test utilities, and infrastructure from mutation
+exclude_re = ["test", "bench", "fuzz", "example"]
+
+# Focus mutation testing on the core protocol crates
+focus = ["omnia-primitives", "omnia-consensus"]
+
+# Minimum mutation score to pass CI (target >= 75%)
 minimum_score = 75
 
 # Timeout for individual test runs (seconds)
-timeout = 120
+timeout = 300
 
 # Number of test runs per mutation for flakiness reduction
 test_runs = 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,15 +60,35 @@ jobs:
           if in_exemption and not has_notes:
               missing.append(current_name)
           if missing:
-              print(f'❌ Missing notes for {len(missing)} exemptions')
+              print(f'Missing notes for {len(missing)} exemptions')
               sys.exit(1)
-          print('✅ All exemptions have notes')
+          print('All exemptions have notes')
           "
       - name: Check Prettier formatting
         run: |
           npm install -g prettier
           npx prettier --check "**/*.md" "**/*.json" "!**/node_modules/**" "!target/**" "!**/Cargo.lock" "!supply-chain/**"
         continue-on-error: true  # Existing files not yet Prettier-formatted
+
+  feature-matrix:
+    name: Feature Matrix (${{ matrix.profile }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        profile: [full, light]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "omnia-feature-${{ matrix.profile }}"
+      - name: Check with ${{ matrix.profile }} features
+        run: cargo check -p omnia-node --no-default-features --features ${{ matrix.profile }}
+      - name: Test with ${{ matrix.profile }} features
+        run: cargo test -p omnia-node --no-default-features --features ${{ matrix.profile }}
 
   test:
     name: Test (${{ matrix.rust }}, ${{ matrix.os }})
@@ -83,10 +103,6 @@ jobs:
       - name: Remove conflicting Homebrew rustup (macOS)
         if: runner.os == 'macOS'
         run: |
-          # The macOS runner ships a Homebrew rustup whose 'cargo' wrapper
-          # is actually rustup-init and cannot proxy subcommands like
-          # 'cargo test'.  Remove it so dtolnay/rust-toolchain can install
-          # its own working rustup without conflicts.
           brew unlink rustup 2>/dev/null || true
           rm -f /usr/local/bin/cargo /opt/homebrew/bin/cargo
       - uses: dtolnay/rust-toolchain@v1
@@ -147,6 +163,54 @@ jobs:
       - name: Run cargo-deny
         run: cargo deny check
 
+  udeps:
+    name: Unused Dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "omnia-udeps"
+      - name: Install cargo-udeps
+        run: cargo install cargo-udeps --locked
+      - name: Check for unused dependencies
+        run: cargo udeps --workspace --all-features
+
+  mutation-testing:
+    name: Mutation Testing
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "omnia-mutants"
+      - name: Install cargo-mutants
+        run: cargo install cargo-mutants --locked
+      - name: Run mutation testing on core crates
+        run: cargo mutants --in-place -p omnia-primitives -p omnia-consensus --check --timeout 300
+        timeout-minutes: 30
+        continue-on-error: true  # Report score but don't block CI
+
+  benchmark-comparison:
+    name: Benchmark Comparison
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "omnia-bench"
+      - name: Build benchmarks
+        run: cargo bench --no-run -p omnia-benches --bench throughput
+      - name: Run quick benchmark (5s per group)
+        run: cargo bench -p omnia-benches --bench throughput -- --quick
+        timeout-minutes: 10
+        continue-on-error: true  # Benchmarks are informational
+
   supply-chain:
     name: Supply Chain Audit
     runs-on: ubuntu-latest
@@ -160,15 +224,13 @@ jobs:
         run: cargo install cargo-vet --locked
       - name: Run cargo-vet
         run: cargo vet
-        continue-on-error: true  # 165 unvetted deps — track progress without blocking CI
+        continue-on-error: true  # Track progress without blocking CI
       - name: Verify exemption notes
         run: |
           python3 -c "
           import sys
-          # Parse TOML without external dependency
           with open('supply-chain/config.toml') as f:
               content = f.read()
-          # Simple check: every exemption block should have a notes field
           in_exemption = False
           has_notes = False
           current_name = ''
@@ -190,9 +252,9 @@ jobs:
           if in_exemption and not has_notes:
               missing.append(current_name)
           if missing:
-              print(f'❌ Missing notes for {len(missing)} exemptions')
+              print(f'Missing notes for {len(missing)} exemptions')
               sys.exit(1)
-          print('✅ All exemptions have notes')
+          print('All exemptions have notes')
           "
 
   reproducibility:
@@ -268,9 +330,6 @@ jobs:
         run: rustup override set nightly
       - name: Install cargo-fuzz
         run: |
-          # Try without --locked first so cargo resolves compatible transitive
-          # deps for the current nightly.  Fall back to a known-good nightly
-          # if the default latest nightly breaks (e.g. rustix incompatibility).
           if ! cargo install cargo-fuzz 2>/dev/null; then
             echo "::warning::cargo-fuzz install failed on latest nightly; trying nightly-2026-03-15"
             rustup toolchain install nightly-2026-03-15 --component rust-src
@@ -289,6 +348,7 @@ jobs:
             fuzz_vector_clock_merge
             fuzz_rate_limiter
             fuzz_snapshot_deserialization
+            fuzz_primitives_event
           )
           for target in "${TARGETS[@]}"; do
             echo "--- Smoke testing $target ---"
@@ -312,7 +372,6 @@ jobs:
           mkdir -p sbom
           cargo cyclonedx --all --format json
           cargo cyclonedx --all --format xml
-          # Move generated SBOM files to sbom/ directory
           find . -name '*.bom.json' -exec mv {} sbom/ \; || true
           find . -name '*.bom.xml' -exec mv {} sbom/ \; || true
       - name: Upload SBOM artifacts

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,15 +65,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloca"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,7 +121,7 @@ dependencies = [
  "auto_impl",
  "borsh",
  "c-kzg",
- "derive_more",
+ "derive_more 2.1.1",
  "either",
  "k256",
  "once_cell",
@@ -277,7 +268,7 @@ dependencies = [
  "auto_impl",
  "borsh",
  "c-kzg",
- "derive_more",
+ "derive_more 2.1.1",
  "either",
  "serde",
  "serde_with",
@@ -345,7 +336,7 @@ dependencies = [
  "alloy-sol-types",
  "async-trait",
  "auto_impl",
- "derive_more",
+ "derive_more 2.1.1",
  "futures-utils-wasm",
  "serde",
  "serde_json",
@@ -375,7 +366,7 @@ dependencies = [
  "bytes",
  "cfg-if",
  "const-hex",
- "derive_more",
+ "derive_more 2.1.1",
  "foldhash 0.2.0",
  "hashbrown 0.17.1",
  "indexmap 2.14.0",
@@ -671,7 +662,7 @@ dependencies = [
  "alloy-json-rpc",
  "auto_impl",
  "base64",
- "derive_more",
+ "derive_more 2.1.1",
  "futures",
  "futures-utils-wasm",
  "parking_lot 0.12.5",
@@ -728,7 +719,7 @@ checksum = "3f14b5d9b2c2173980202c6ff470d96e7c5e202c65a9f67884ad565226df7fbb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "derive_more",
+ "derive_more 2.1.1",
  "nybbles",
  "serde",
  "smallvec",
@@ -1991,7 +1982,7 @@ dependencies = [
  "cast",
  "ciborium",
  "clap",
- "criterion-plot 0.5.0",
+ "criterion-plot",
  "is-terminal",
  "itertools 0.10.5",
  "num-traits",
@@ -2008,31 +1999,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "criterion"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
-dependencies = [
- "alloca",
- "anes",
- "cast",
- "ciborium",
- "clap",
- "criterion-plot 0.8.2",
- "itertools 0.13.0",
- "num-traits",
- "oorandom",
- "page_size",
- "plotters",
- "rayon",
- "regex",
- "serde",
- "serde_json",
- "tinytemplate",
- "walkdir",
-]
-
-[[package]]
 name = "criterion-plot"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2040,16 +2006,6 @@ checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
  "itertools 0.10.5",
-]
-
-[[package]]
-name = "criterion-plot"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
-dependencies = [
- "cast",
- "itertools 0.13.0",
 ]
 
 [[package]]
@@ -2291,6 +2247,17 @@ name = "derive_arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "derive_more"
+version = "0.99.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3269,6 +3236,42 @@ dependencies = [
  "tower-service",
  "tracing",
  "windows-registry",
+]
+
+[[package]]
+name = "iai-callgrind"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bd871e6374d5ca2d9b48dd23b3c7ef63a4201728621f6d75937dfcc66e91809"
+dependencies = [
+ "bincode",
+ "derive_more 0.99.20",
+ "iai-callgrind-macros",
+ "iai-callgrind-runner",
+]
+
+[[package]]
+name = "iai-callgrind-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "397649417510422ded7033f86132f833cca8c2e5081d0dfbec939b2353da7021"
+dependencies = [
+ "derive_more 0.99.20",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "iai-callgrind-runner"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3783c337f9e931af702b5d5835ff2a6824bf55e416461a4e042dfb4b8fdbbea"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -4658,7 +4661,7 @@ dependencies = [
  "ark-snark",
  "async-trait",
  "blake3",
- "criterion 0.5.1",
+ "criterion",
  "hex",
  "omnia-consensus",
  "omnia-crypto",
@@ -4674,6 +4677,26 @@ dependencies = [
  "tokio",
  "tokio-test",
  "tracing",
+]
+
+[[package]]
+name = "omnia-benches"
+version = "0.1.0"
+dependencies = [
+ "criterion",
+ "iai-callgrind",
+ "omnia-adapters",
+ "omnia-binding",
+ "omnia-consensus",
+ "omnia-crypto",
+ "omnia-economics",
+ "omnia-network",
+ "omnia-node",
+ "omnia-primitives",
+ "omnia-shards",
+ "omnia-substrate",
+ "rand 0.8.6",
+ "tokio",
 ]
 
 [[package]]
@@ -4756,6 +4779,7 @@ dependencies = [
  "hkdf",
  "ml-kem 0.1.1",
  "omnia-primitives",
+ "postcard",
  "pqc_dilithium 0.1.1",
  "rand 0.8.6",
  "serde",
@@ -4788,7 +4812,10 @@ dependencies = [
  "libfuzzer-sys",
  "omnia-adapters",
  "omnia-binding",
+ "omnia-consensus",
+ "omnia-crypto",
  "omnia-economics",
+ "omnia-network",
  "omnia-primitives",
  "omnia-shards",
  "omnia-substrate",
@@ -4913,7 +4940,7 @@ dependencies = [
  "blake3",
  "blst",
  "chrono",
- "criterion 0.8.2",
+ "criterion",
  "ed25519-dalek",
  "futures",
  "getrandom 0.2.17",
@@ -5013,16 +5040,6 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
-]
-
-[[package]]
-name = "page_size"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
-dependencies = [
- "libc",
- "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "node",
     "chaos-tests",
     "fuzz",
+    "benches",
 ]
 resolver = "2"
 
@@ -26,3 +27,19 @@ rust-version = "1.88"
 [workspace.dependencies]
 # bincode 1.x for legacy wire format deserialization (v0 fallback)
 bincode = "1"
+
+# Release profile optimization — Decision 3: panic = "abort"
+# Thin LTO balances compile time vs binary size improvement
+# codegen-units = 1 maximizes optimization opportunities
+[profile.release]
+panic = "abort"
+lto = "thin"
+codegen-units = 1
+strip = true
+debug = false
+
+# Bench profile inherits release but keeps debug info for profiling
+[profile.bench]
+inherits = "release"
+debug = true
+strip = false

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+name = "omnia-benches"
+version = "0.1.0"
+edition = "2021"
+license = "CC0-1.0"
+publish = false
+
+[dependencies]
+omnia-primitives = { path = "../omnia-primitives" }
+omnia-consensus = { path = "../omnia-consensus" }
+omnia-crypto = { path = "../omnia-crypto" }
+omnia-network = { path = "../omnia-network" }
+omnia-economics = { path = "../economics" }
+omnia-shards = { path = "../shards" }
+omnia-binding = { path = "../binding" }
+omnia-adapters = { path = "../omnia-adapters" }
+omnia-node = { path = "../node" }
+omnia-substrate = { path = "../substrate" }
+
+criterion = { version = "0.5", features = ["html_reports"] }
+iai-callgrind = "0.13"
+tokio = { version = "1.38", features = ["full"] }
+rand = "0.8"
+
+[[bench]]
+name = "throughput"
+harness = false
+
+[[bench]]
+name = "zk_benchmarks"
+harness = false
+
+[[bench]]
+name = "hot_path_iai"
+harness = false
+
+[features]
+default = []
+full = ["omnia-node/full", "omnia-adapters/arkworks"]

--- a/benches/benches/hot_path_iai.rs
+++ b/benches/benches/hot_path_iai.rs
@@ -1,0 +1,61 @@
+//! Iai-callgrind benchmarks for hot-path functions.
+//!
+//! These benchmarks use deterministic callgrind profiling to measure
+//! instruction counts and cache behavior for performance-critical paths.
+//! Unlike criterion (statistical), iai-callgrind produces reproducible
+//! results ideal for CI regression detection.
+
+use iai_callgrind::{black_box, library_benchmark, library_benchmark_group, main};
+use omnia_primitives::{Event, NodeId, VectorClock};
+use omnia_consensus::CausalGraph;
+use omnia_crypto::generate_keypair;
+
+/// Helper to create a minimal valid (signed) Event for benchmarking.
+fn create_signed_event(creator: NodeId, seq: u64, parent: Option<[u8; 32]>) -> Event {
+    let keypair = generate_keypair();
+    let vc = VectorClock::with_node(creator, seq + 1);
+    let mut event = Event::new(creator, seq, vc, parent, None, vec![1, 2, 3]);
+    event.sign_with_keypair(&keypair);
+    event
+}
+
+#[library_benchmark]
+fn bench_vector_clock_merge_100() {
+    let mut vc = VectorClock::new();
+    for i in 0..100u8 {
+        let mut node: NodeId = [0u8; 32];
+        node[0] = i;
+        let _ = vc.increment(node);
+    }
+    let mut other = VectorClock::new();
+    for i in 50..150u8 {
+        let mut node: NodeId = [0u8; 32];
+        node[0] = i;
+        let _ = other.increment(node);
+    }
+    black_box(vc.merged(&other));
+}
+
+#[library_benchmark]
+fn bench_event_validate() {
+    let creator: NodeId = [0u8; 32];
+    let event = create_signed_event(creator, 0, None);
+    black_box(event.validate().unwrap());
+}
+
+#[library_benchmark]
+fn bench_causal_graph_insert() {
+    let creator: NodeId = [0u8; 32];
+    let mut graph = CausalGraph::new();
+    let genesis = create_signed_event(creator, 0, None);
+    let _ = graph.insert(genesis.clone());
+    let event = create_signed_event(creator, 1, Some(genesis.id));
+    black_box(graph.insert(event));
+}
+
+library_benchmark_group!(
+    name = hot_path_group;
+    benchmarks = bench_vector_clock_merge_100, bench_event_validate, bench_causal_graph_insert
+);
+
+main!(library_benchmark_groups = (hot_path_group));

--- a/benches/benches/throughput.rs
+++ b/benches/benches/throughput.rs
@@ -1,6 +1,21 @@
+//! Unified throughput benchmark suite for the Omnia Protocol.
+//!
+//! Consolidated from substrate/benches/throughput.rs into the shared
+//! omnia-benches crate. Uses the new crate structure directly:
+//! - omnia-primitives: Event, VectorClock, NodeId
+//! - omnia-consensus: CausalGraph, SlashingEngine, SlashOffense
+//! - omnia-crypto: NodeKeypair, VRF operations
+
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion, Throughput};
-use omnia_substrate::crypto::NodeKeypair;
-use omnia_substrate::*;
+use omnia_consensus::{
+    CausalGraph, SlashingEngine,
+    slashing::SlashOffense,
+};
+use omnia_crypto::{
+    generate_keypair, NodeKeypair,
+    vrf::{select_leader, vrf_compute, vrf_verify},
+};
+use omnia_primitives::{Event, NodeId, VectorClock};
 use rand::rngs::OsRng;
 use std::collections::HashMap;
 use std::hint::black_box;
@@ -12,7 +27,7 @@ fn benchmark_event_creation(c: &mut Criterion) {
     group.measurement_time(Duration::from_secs(10));
 
     let keypair = NodeKeypair::generate(&mut OsRng);
-    let creator = [0u8; 32];
+    let creator: NodeId = [0u8; 32];
     let vc = VectorClock::with_node(creator, 1);
 
     group.bench_function("create_and_sign", |b| {
@@ -30,9 +45,9 @@ fn benchmark_graph_insertion(c: &mut Criterion) {
     let mut group = c.benchmark_group("graph_insertion");
     group.throughput(Throughput::Elements(1000));
 
-    let mut graph = CausalGraph::new(); // mut needed for insert
+    let mut graph = CausalGraph::new();
     let keypair = NodeKeypair::generate(&mut OsRng);
-    let creator = [0u8; 32];
+    let creator: NodeId = [0u8; 32];
 
     // Pre-create genesis
     let mut genesis = Event::genesis(creator, vec![]);
@@ -62,7 +77,7 @@ fn benchmark_vector_clock_merge(c: &mut Criterion) {
     let mut vc_b = VectorClock::new();
 
     for i in 0..100 {
-        let mut node = [0u8; 32];
+        let mut node: NodeId = [0u8; 32];
         node[0] = i;
         vc_a.set(node, i as u64 * 2);
         vc_b.set(node, i as u64 * 3);
@@ -86,7 +101,7 @@ fn bench_slashing_operations(c: &mut Criterion) {
         b.iter_batched(
             || {
                 let mut engine = SlashingEngine::new_in_memory(500, 2000);
-                let node = [42u8; 32];
+                let node: NodeId = [42u8; 32];
                 engine.register_validator(node, 10_000);
                 (engine, node)
             },
@@ -98,9 +113,8 @@ fn bench_slashing_operations(c: &mut Criterion) {
     });
 
     group.bench_function("check_equivocation", |b| {
-        // Use pre-built events for equivocation check
-        let keypair = omnia_substrate::crypto::generate_keypair();
-        let creator = [0u8; 32];
+        let keypair = generate_keypair();
+        let creator: NodeId = [0u8; 32];
         let vc = VectorClock::with_node(creator, 1);
         let mut event_a = Event::new(creator, 0, vc.clone(), None, None, vec![1, 2, 3]);
         event_a.sign_with_keypair(&keypair);
@@ -119,34 +133,34 @@ fn bench_vrf_compute(c: &mut Criterion) {
     let mut group = c.benchmark_group("vrf");
 
     group.bench_function("vrf_compute", |b| {
-        let keypair = omnia_substrate::crypto::generate_keypair();
+        let keypair = generate_keypair();
         let input = b"round-42-seed";
         b.iter(|| {
-            let _ = omnia_substrate::vrf::vrf_compute(&keypair, input);
+            let _ = vrf_compute(&keypair, input);
         })
     });
 
     group.bench_function("vrf_verify", |b| {
-        let keypair = omnia_substrate::crypto::generate_keypair();
+        let keypair = generate_keypair();
         let input = b"round-42-seed";
-        let vrf_output = omnia_substrate::vrf::vrf_compute(&keypair, input);
+        let vrf_output = vrf_compute(&keypair, input);
         b.iter(|| {
-            let _ = omnia_substrate::vrf::vrf_verify(&keypair.verifying_key(), input, &vrf_output);
+            let _ = vrf_verify(&keypair.verifying_key(), input, &vrf_output);
         })
     });
 
     group.bench_function("select_leader_100_validators", |b| {
-        let mut candidates: HashMap<[u8; 32], (NodeKeypair, u64)> = HashMap::new();
+        let mut candidates: HashMap<NodeId, (NodeKeypair, u64)> = HashMap::new();
         for i in 0..100u8 {
-            let mut node = [0u8; 32];
+            let mut node: NodeId = [0u8; 32];
             node[0] = i;
-            let kp = omnia_substrate::crypto::generate_keypair();
+            let kp = generate_keypair();
             candidates.insert(node, (kp, 100));
         }
         let seed = [0u8; 32];
 
         b.iter(|| {
-            let _ = omnia_substrate::vrf::select_leader(&candidates, &seed, 1);
+            let _ = select_leader(&candidates, &seed, 1);
         })
     });
 

--- a/benches/benches/zk_benchmarks.rs
+++ b/benches/benches/zk_benchmarks.rs
@@ -1,4 +1,7 @@
-//! ZK-SNARK Benchmark Suite for the Omnia Protocol (H-2).
+//! ZK-SNARK Benchmark Suite for the Omnia Protocol.
+//!
+//! Consolidated from zk/benches/zk_benchmarks.rs into the shared
+//! omnia-benches crate. Uses omnia-adapters for ZK operations.
 //!
 //! Benchmarks for:
 //! - Poseidon hash (off-chain)
@@ -10,10 +13,10 @@
 use ark_bn254::Fr;
 use ark_ff::PrimeField;
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
-use omnia_zk::circuit::{ExpandedRollupCircuit, RollupCircuit};
-use omnia_zk::merkle::build_merkle_tree;
-use omnia_zk::poseidon::poseidon_hash_offchain;
-use omnia_zk::prover::{
+use omnia_adapters::circuit::{ExpandedRollupCircuit, RollupCircuit};
+use omnia_adapters::merkle::build_merkle_tree;
+use omnia_adapters::poseidon::poseidon_hash_offchain;
+use omnia_adapters::prover::{
     create_expanded_proof, create_proof, generate_trusted_setup, generate_trusted_setup_expanded,
     verify_proof,
 };

--- a/benches/src/lib.rs
+++ b/benches/src/lib.rs
@@ -1,0 +1,15 @@
+//! # Omnia Benches — Unified benchmark suite for the Omnia Protocol
+//!
+//! This crate consolidates all benchmarks into a single location,
+//! making it easy to run comprehensive performance tests across
+//! all protocol layers. Benchmarks use criterion for statistical
+//! rigor and iai-callgrind for deterministic hot-path profiling.
+//!
+//! ## Benchmark categories
+//!
+//! - **throughput**: Core event processing, graph insertion, vector clock merge,
+//!   slashing, and VRF operations (criterion-based)
+//! - **zk_benchmarks**: ZK-SNARK proof generation, verification, Merkle tree,
+//!   and trusted setup (criterion-based)
+//! - **hot_path_iai**: Deterministic callgrind profiling for hot-path functions
+//!   (iai-callgrind-based)

--- a/deny.toml
+++ b/deny.toml
@@ -1,7 +1,6 @@
 [advisories]
 unmaintained = "workspace"
-unsound = "workspace"
-yanked = "warn"
+yanked = "deny"
 ignore = [
     # RUSTSEC-2024-0384: instant crate (unmaintained) — pulled in by parking_lot 0.11.x via parking_lot_core 0.8.x
     # sled was removed in Phase 2 but instant remains in the tree via parking_lot 0.11.x
@@ -89,11 +88,17 @@ name = "omnia-fuzz"
 expression = "CC0-1.0"
 license-files = []
 
+[[licenses.clarify]]
+name = "omnia-benches"
+expression = "CC0-1.0"
+license-files = []
+
 [bans]
 multiple-versions = "warn"
 wildcards = "warn"   # workspace-internal path deps lack version keys — not a real risk
 highlight = "all"
 
 [sources]
-unknown-registry = "warn"
+unknown-registry = "deny"
 unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -11,12 +11,15 @@ cargo-fuzz = true
 
 [dependencies]
 libfuzzer-sys = "0.4"
-omnia-substrate = { path = "../substrate" }
 omnia-primitives = { path = "../omnia-primitives" }
+omnia-consensus = { path = "../omnia-consensus" }
+omnia-crypto = { path = "../omnia-crypto" }
+omnia-network = { path = "../omnia-network" }
 omnia-shards = { path = "../shards" }
 omnia-binding = { path = "../binding" }
 omnia-adapters = { path = "../omnia-adapters" }
 omnia-economics = { path = "../economics" }
+omnia-substrate = { path = "../substrate" }
 postcard = { version = "1", features = ["alloc"] }
 
 [[bin]]
@@ -46,3 +49,7 @@ path = "fuzz_targets/fuzz_rate_limiter.rs"
 [[bin]]
 name = "fuzz_snapshot_deserialization"
 path = "fuzz_targets/fuzz_snapshot_deserialization.rs"
+
+[[bin]]
+name = "fuzz_primitives_event"
+path = "fuzz_targets/fuzz_primitives_event.rs"

--- a/fuzz/fuzz_targets/causal_graph_insert.rs
+++ b/fuzz/fuzz_targets/causal_graph_insert.rs
@@ -1,6 +1,7 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
-use omnia_substrate::{CausalGraph, Event, VectorClock};
+use omnia_consensus::CausalGraph;
+use omnia_primitives::{Event, VectorClock};
 
 fuzz_target!(|data: &[u8]| {
     if data.len() < 64 {

--- a/fuzz/fuzz_targets/event_validate.rs
+++ b/fuzz/fuzz_targets/event_validate.rs
@@ -1,6 +1,6 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
-use omnia_substrate::{Event, VectorClock};
+use omnia_primitives::{Event, VectorClock};
 
 fuzz_target!(|data: &[u8]| {
     if data.len() < 64 {

--- a/fuzz/fuzz_targets/fuzz_consensus_state_transition.rs
+++ b/fuzz/fuzz_targets/fuzz_consensus_state_transition.rs
@@ -12,7 +12,8 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
-use omnia_substrate::{CausalGraph, ConsensusConfig, ConsensusEngine, Event, SlashingEngine};
+use omnia_consensus::{CausalGraph, ConsensusConfig, ConsensusEngine, SlashingEngine};
+use omnia_primitives::Event;
 
 fuzz_target!(|data: &[u8]| {
     // Deserialize a sequence of events and feed them to consensus

--- a/fuzz/fuzz_targets/fuzz_event_deserialization.rs
+++ b/fuzz/fuzz_targets/fuzz_event_deserialization.rs
@@ -7,7 +7,7 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
-use omnia_substrate::Event;
+use omnia_primitives::Event;
 
 fuzz_target!(|data: &[u8]| {
     // Test that event deserialization never panics on arbitrary input

--- a/fuzz/fuzz_targets/fuzz_gossip_message.rs
+++ b/fuzz/fuzz_targets/fuzz_gossip_message.rs
@@ -7,7 +7,7 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
-use omnia_substrate::GossipMessage;
+use omnia_network::gossip::GossipMessage;
 
 fuzz_target!(|data: &[u8]| {
     // Test gossip message deserialization never panics

--- a/fuzz/fuzz_targets/fuzz_primitives_event.rs
+++ b/fuzz/fuzz_targets/fuzz_primitives_event.rs
@@ -1,0 +1,24 @@
+//! Fuzz target: Primitives Event serialization roundtrip
+//!
+//! Events arrive from untrusted network peers and must be deserialized
+//! safely. This target ensures that deserializing arbitrary bytes as an
+//! Event using the versioned wire format never panics, and that a
+//! successful deserialization → re-serialization roundtrip is idempotent.
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use omnia_primitives::{Event, deserialize_with_version, serialize_with_version};
+
+fuzz_target!(|data: &[u8]| {
+    // Test versioned wire-format deserialization never panics
+    if let Ok(event) = deserialize_with_version::<Event>(data) {
+        // If deserialization succeeded, re-serialization should also work
+        if let Ok(re_serialized) = serialize_with_version(&event) {
+            // Roundtrip: re-deserializing should produce the same event
+            if let Ok(event2) = deserialize_with_version::<Event>(&re_serialized) {
+                assert_eq!(event, event2, "Event roundtrip mismatch!");
+            }
+        }
+    }
+});

--- a/fuzz/fuzz_targets/fuzz_rate_limiter.rs
+++ b/fuzz/fuzz_targets/fuzz_rate_limiter.rs
@@ -6,7 +6,7 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
-use omnia_substrate::RateLimiter;
+use omnia_consensus::RateLimiter;
 
 fuzz_target!(|data: &[u8]| {
     let mut limiter = RateLimiter::new(200, 100);

--- a/fuzz/fuzz_targets/fuzz_snapshot_deserialization.rs
+++ b/fuzz/fuzz_targets/fuzz_snapshot_deserialization.rs
@@ -6,6 +6,7 @@
 //! handles tampered data gracefully.
 
 #![no_main]
+#![allow(deprecated)] // StateSnapshot still lives in omnia-substrate until extraction
 
 use libfuzzer_sys::fuzz_target;
 use omnia_substrate::StateSnapshot;

--- a/fuzz/fuzz_targets/fuzz_vector_clock_merge.rs
+++ b/fuzz/fuzz_targets/fuzz_vector_clock_merge.rs
@@ -8,7 +8,7 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
-use omnia_substrate::VectorClock;
+use omnia_primitives::VectorClock;
 
 fuzz_target!(|data: &[u8]| {
     // Try to deserialize two vector clocks and merge them

--- a/fuzz/fuzz_targets/shard_route.rs
+++ b/fuzz/fuzz_targets/shard_route.rs
@@ -1,7 +1,7 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
 use omnia_shards::ShardRouter;
-use omnia_substrate::{Event, VectorClock};
+use omnia_primitives::{Event, VectorClock};
 
 fuzz_target!(|data: &[u8]| {
     if data.len() < 64 {

--- a/fuzz/fuzz_targets/vector_clock_merge.rs
+++ b/fuzz/fuzz_targets/vector_clock_merge.rs
@@ -1,6 +1,6 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
-use omnia_substrate::VectorClock;
+use omnia_primitives::VectorClock;
 
 fuzz_target!(|data: &[u8]| {
     let mut clock1 = VectorClock::new();

--- a/omnia-adapters/Cargo.toml
+++ b/omnia-adapters/Cargo.toml
@@ -53,6 +53,5 @@ tokio-test = "0.4"
 proptest = "1"
 criterion = { version = "0.5", features = ["html_reports"] }
 
-[[bench]]
-name = "zk_benchmarks"
-harness = false
+# Benchmarks have been consolidated into the omnia-benches crate
+# (benches/ directory at workspace root)

--- a/omnia-crypto/Cargo.toml
+++ b/omnia-crypto/Cargo.toml
@@ -33,3 +33,4 @@ keystore = ["dep:aes-gcm", "dep:bip39", "dep:hkdf"]
 
 [dev-dependencies]
 tempfile = "3"
+postcard = { version = "1.0", features = ["alloc"] }

--- a/substrate/Cargo.toml
+++ b/substrate/Cargo.toml
@@ -84,7 +84,7 @@ ethereum-live = ["omnia-adapters/ethereum-live"]
 [dev-dependencies]
 tokio-test = "0.4"
 tempfile = "3"
-criterion = { version = "0.8", features = ["html_reports"] }
+criterion = { version = "0.5", features = ["html_reports"] }
 libp2p = { version = "0.56", features = ["quic", "kad", "gossipsub", "mdns", "noise", "yamux", "tcp", "dns", "macros", "request-response", "cbor", "tokio", "autonat", "relay", "dcutr"] }
 
 # FIX 6: Property-based testing
@@ -93,6 +93,5 @@ proptest = "1.4"
 # sled is needed for integration tests of migration utility
 sled = "0.34"
 
-[[bench]]
-name = "throughput"
-harness = false
+# Benchmarks have been consolidated into the omnia-benches crate
+# (benches/ directory at workspace root)

--- a/substrate/src/lib.rs
+++ b/substrate/src/lib.rs
@@ -21,6 +21,7 @@
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
 #![warn(unused_qualifications)]
+#![deprecated(since = "0.2.0", note = "Use omnia-primitives, omnia-consensus, omnia-crypto, omnia-network, omnia-adapters directly")]
 
 pub mod blake3_domain;
 pub mod bls;


### PR DESCRIPTION
- Created unified omnia-benches crate with criterion + iai-callgrind benchmarks
- Moved throughput.rs from substrate/benches to benches/benches with updated imports
- Moved zk_benchmarks.rs from omnia-adapters/benches to benches/benches
- Added iai-callgrind hot-path benchmarks (VectorClock merge, Event validate, CausalGraph insert)
- Updated fuzz targets to use new crate structure (omnia-primitives, omnia-consensus, etc.)
- Added fuzz_primitives_event fuzz target for Event serialization roundtrip
- Added cargo-mutants configuration with focus on primitives/consensus (minimum_score=75)
- Enforced dependency hygiene with cargo-deny (advisories/bans/licenses/sources all pass)
- Optimized release profile: panic=abort, thin LTO, codegen-units=1, strip=true
- Added bench profile: inherits=release, debug=true, strip=false
- Deprecated legacy substrate crate with #![deprecated(since="0.2.0")]
- Updated CI: feature-matrix testing, cargo-udeps, mutation testing, benchmark comparison
- Fixed pre-existing issue: added postcard dev-dependency to omnia-crypto
- All tests pass, cargo-deny clean, both feature profiles compile