### PR TITLE
Step 5.5: Fix binary size to ≤12MB + remaining hygiene

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,13 +29,15 @@ rust-version = "1.88"
 bincode = "1"
 
 # Release profile optimization — Decision 3: panic = "abort"
-# Thin LTO balances compile time vs binary size improvement
+# Fat LTO provides maximum dead-code elimination and cross-crate inlining
+# to meet the ≤12MB binary size target. Compile time is longer but
+# acceptable for release builds.
 # codegen-units = 1 maximizes optimization opportunities
 [profile.release]
 panic = "abort"
-lto = "thin"
+lto = "fat"
 codegen-units = 1
-strip = true
+strip = "symbols"
 debug = false
 
 # Bench profile inherits release but keeps debug info for profiling

--- a/binding/Cargo.toml
+++ b/binding/Cargo.toml
@@ -8,7 +8,7 @@ license = { workspace = true }
 repository = { workspace = true }
 
 [dependencies]
-omnia-substrate = { path = "../substrate" }
+omnia-substrate = { path = "../substrate", default-features = false }
 omnia-shards = { path = "../shards" }
 omnia-primitives = { path = "../omnia-primitives" }
 serde = { version = "1.0", features = ["derive"] }

--- a/economics/Cargo.toml
+++ b/economics/Cargo.toml
@@ -8,7 +8,7 @@ license = { workspace = true }
 repository = { workspace = true }
 
 [dependencies]
-omnia-substrate = { path = "../substrate" }
+omnia-substrate = { path = "../substrate", default-features = false }
 omnia-primitives = { path = "../omnia-primitives" }
 serde = { version = "1.0", features = ["derive"] }
 postcard = { version = "1", features = ["alloc"] }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -9,15 +9,15 @@ repository = { workspace = true }
 
 [dependencies]
 # Workspace crate dependencies — each provides a distinct protocol layer
-omnia-substrate = { path = "../substrate" }   # Layer 1: causal graph consensus, slashing, gossip
+omnia-substrate = { path = "../substrate", default-features = false }   # Layer 1: causal graph consensus, slashing, gossip
 omnia-primitives = { path = "../omnia-primitives" }  # Shared types: Event, VectorClock, wire format
 omnia-shards = { path = "../shards" }         # Layer 2: domain shard routing and fee enforcement
 omnia-economics = { path = "../economics" }   # Layer 5: UBC token, governance, useful-work rewards
 omnia-binding = { path = "../binding" }       # Layer 3: physical-digital binding layer
-omnia-network = { path = "../omnia-network", optional = true }  # P2P networking layer
-omnia-adapters = { path = "../omnia-adapters", optional = true } # ZK-rollup settlement adapters
-omnia-crypto = { path = "../omnia-crypto", optional = true }     # Crypto primitives (for light mode keygen)
-omnia-consensus = { path = "../omnia-consensus", optional = true } # Consensus engine (for pipeline)
+omnia-network = { path = "../omnia-network", default-features = false, optional = true }  # P2P networking layer
+omnia-adapters = { path = "../omnia-adapters", default-features = false, optional = true } # ZK-rollup settlement adapters
+omnia-crypto = { path = "../omnia-crypto", default-features = false, optional = true }     # Crypto primitives (for light mode keygen)
+omnia-consensus = { path = "../omnia-consensus", default-features = false, optional = true } # Consensus engine (for pipeline)
 
 # Async runtime — needed for all async I/O, signal handling, and task spawning
 tokio = { version = "1", features = ["full", "signal"] }
@@ -37,7 +37,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"  # JSON serialization for API request/response bodies
 
 # Prometheus metrics exposition — industry standard for monitoring
-prometheus = "0.13"
+prometheus = { version = "0.13", optional = true }
 
 # Ergonomic error handling — anyhow::Result with context chaining
 anyhow = "1"
@@ -80,17 +80,23 @@ chrono = { version = "0.4", features = ["serde"] }
 # UUID generation for event and proposal identifiers
 uuid = { version = "1", features = ["v4"] }
 
-utoipa = "5"             # OpenAPI spec generation — auto-documents all REST endpoints
-utoipa-swagger-ui = { version = "8", features = ["axum"] }  # Interactive API docs UI
+# OpenAPI spec generation — auto-documents all REST endpoints
+utoipa = "5"
+# Swagger UI embeds ~11MB of JS/CSS assets into the binary.
+# Make it optional so release builds can omit it and meet the ≤12MB target.
+# Enable with --features swagger-ui for development.
+utoipa-swagger-ui = { version = "8", features = ["axum"], optional = true }  # Interactive API docs UI
 
 [features]
 default = ["full"]
-full = ["network", "zk", "bls", "pqc"]
+full = ["network", "zk", "bls", "pqc", "metrics"]
 light = []  # no networking, no ZK, no heavy crypto
-network = ["omnia-network/network", "omnia-substrate/network"]
-zk = ["omnia-adapters/arkworks", "dep:omnia-adapters"]
-bls = ["omnia-crypto/bls", "dep:omnia-crypto"]
-pqc = ["omnia-crypto/pqc", "dep:omnia-crypto"]
+metrics = ["dep:prometheus"]
+swagger-ui = ["dep:utoipa-swagger-ui"]
+network = ["omnia-network/network", "omnia-substrate/network", "dep:omnia-network"]
+zk = ["omnia-adapters/arkworks", "omnia-substrate/zk", "dep:omnia-adapters"]
+bls = ["omnia-crypto/bls", "omnia-substrate/bls", "dep:omnia-crypto"]
+pqc = ["omnia-crypto/pqc", "omnia-substrate/pqc", "dep:omnia-crypto"]
 ethereum-live = ["omnia-adapters/ethereum-live", "zk"]
 
 [dev-dependencies]

--- a/node/src/api/events.rs
+++ b/node/src/api/events.rs
@@ -140,6 +140,7 @@ pub async fn submit_event(
         .insert(event_id_hex.clone(), stored);
 
     // Increment the events counter
+    #[cfg(feature = "metrics")]
     state.metrics.events_submitted.inc();
 
     tracing::info!(event_id = %event_id_hex, status = %status, "Event submitted via API");

--- a/node/src/http.rs
+++ b/node/src/http.rs
@@ -39,9 +39,11 @@ use axum::response::Response;
 use axum::routing::get;
 use axum::Extension;
 use axum::Router;
+#[cfg(feature = "metrics")]
 use prometheus::{Encoder, TextEncoder};
 use serde_json::json;
 use utoipa::OpenApi;
+#[cfg(feature = "swagger-ui")]
 use utoipa_swagger_ui::SwaggerUi;
 
 use crate::api;
@@ -57,8 +59,8 @@ use crate::state::AppState;
 /// - `/health` — backward-compatible health check (aliases `/healthz`)
 /// - `/metrics` — Prometheus metrics endpoint
 /// - `/api/v1/*` — API endpoints (with JWT auth and authorization)
-/// - `/swagger-ui` — Swagger UI for API documentation
-/// - `/api-docs/openapi.json` — OpenAPI JSON specification
+/// - `/swagger-ui` — Swagger UI for API documentation (optional, `swagger-ui` feature)
+/// - `/api-docs/openapi.json` — OpenAPI JSON specification (optional, `swagger-ui` feature)
 ///
 /// # Middleware
 ///
@@ -80,13 +82,21 @@ pub fn build_http_router() -> Router<AppState> {
     let rate_limiter = Arc::new(RateLimiter::from_env());
     let cors = default_cors_layer();
 
-    Router::new()
+    let router = Router::new()
         .route("/healthz", get(liveness_handler)) // Kubernetes livenessProbe
         .route("/readyz", get(readiness_handler)) // Kubernetes readinessProbe
         .route("/health", get(liveness_handler)) // backward compat
         .route("/metrics", get(metrics_handler))
-        .nest("/api/v1", api::build_api_router())
-        .merge(SwaggerUi::new("/swagger-ui").url("/api-docs/openapi.json", ApiDoc::openapi()))
+        .nest("/api/v1", api::build_api_router());
+
+    // Swagger UI is optional — embeds ~11MB of JS/CSS assets into the binary.
+    // Enable with --features swagger-ui for development.
+    #[cfg(feature = "swagger-ui")]
+    let router = router.merge(
+        SwaggerUi::new("/swagger-ui").url("/api-docs/openapi.json", ApiDoc::openapi())
+    );
+
+    router
         // --- Middleware layers ---
         // Order: last added = outermost.
         // Request flow: CORS → Extension(inject) → RateLimit → Handler
@@ -173,6 +183,7 @@ pub async fn readiness_handler(State(state): State<AppState>) -> Response {
 /// Returns all registered Prometheus metrics in the standard
 /// text exposition format. This endpoint is scraped by Prometheus
 /// or compatible monitoring systems.
+#[cfg(feature = "metrics")]
 pub async fn metrics_handler() -> impl IntoResponse {
     let encoder = TextEncoder::new();
     let metric_families = prometheus::gather();
@@ -191,6 +202,15 @@ pub async fn metrics_handler() -> impl IntoResponse {
     (StatusCode::OK, body)
 }
 
+/// Handler for `GET /metrics` when metrics feature is disabled.
+#[cfg(not(feature = "metrics"))]
+pub async fn metrics_handler() -> impl IntoResponse {
+    (
+        StatusCode::NOT_FOUND,
+        "Metrics endpoint disabled (compile without --features metrics to enable)\n",
+    )
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
@@ -198,6 +218,7 @@ mod tests {
     use crate::api::events::StoredEvent;
     use crate::api::node::PeerInfo;
     use crate::config::NodeConfig;
+    #[cfg(feature = "metrics")]
     use crate::state::NodeMetrics;
     use axum::body::Body;
     use axum::http::{Request, StatusCode as HttpStatus};
@@ -255,6 +276,7 @@ mod tests {
             })
             .collect();
 
+        #[cfg(feature = "metrics")]
         let metrics = NodeMetrics::new().expect("Failed to create metrics");
 
         AppState {
@@ -265,6 +287,7 @@ mod tests {
             economics: Arc::new(Mutex::new(EconomicsState::new())),
             event_store: Arc::new(RwLock::new(event_store)),
             peers: Arc::new(RwLock::new(peers)),
+            #[cfg(feature = "metrics")]
             metrics: Arc::new(metrics),
             started_at: Instant::now(),
             is_syncing: Arc::new(AtomicBool::new(is_syncing)),

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -27,7 +27,9 @@ use anyhow::{Context, Result};
 use clap::Parser;
 use omnia_economics::EconomicsState;
 use omnia_node::config::{CliArgs, CliCommand, NodeConfig};
-use omnia_node::state::{AppState, NodeMetrics};
+use omnia_node::state::AppState;
+#[cfg(feature = "metrics")]
+use omnia_node::state::NodeMetrics;
 use omnia_shards::{
     BiologicalShard, ComputationalShard, EconomicsShard, FeeSchedule, FinancialShard,
     IdentityShard, PhysicalShard, ShardRouter,
@@ -184,7 +186,9 @@ async fn main() -> Result<()> {
     tracing::info!("Economics state initialized (10% decay, 1000 UBC/month)");
 
     // Initialize Prometheus metrics
+    #[cfg(feature = "metrics")]
     let metrics = NodeMetrics::new().context("Failed to initialize Prometheus metrics")?;
+    #[cfg(feature = "metrics")]
     tracing::info!("Prometheus metrics initialized");
 
     // 5. Build shared application state
@@ -199,6 +203,7 @@ async fn main() -> Result<()> {
         economics: Arc::new(Mutex::new(economics)),
         event_store: Arc::new(RwLock::new(std::collections::HashMap::new())),
         peers: Arc::new(RwLock::new(Vec::new())),
+        #[cfg(feature = "metrics")]
         metrics: Arc::new(metrics),
         started_at: Instant::now(),
         is_syncing: Arc::new(AtomicBool::new(false)),

--- a/node/src/state.rs
+++ b/node/src/state.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 use std::sync::OnceLock;
 use std::time::Instant;
 
+#[cfg(feature = "metrics")]
 use prometheus::{IntCounter, IntGauge};
 use tokio::sync::{Mutex, RwLock};
 
@@ -27,12 +28,14 @@ use crate::config::NodeConfig;
 /// Using `OnceLock` ensures metrics are only registered once per process,
 /// even when multiple test instances are created. Subsequent calls to
 /// `NodeMetrics::new()` return clones of the same registered metrics.
+#[cfg(feature = "metrics")]
 static NODE_METRICS: OnceLock<NodeMetrics> = OnceLock::new();
 
 /// Prometheus metrics for the node.
 ///
 /// All metrics are registered with the default Prometheus registry
 /// so they can be exposed via the `/metrics` endpoint.
+#[cfg(feature = "metrics")]
 #[derive(Debug, Clone)]
 pub struct NodeMetrics {
     /// Total number of events submitted via the API.
@@ -49,6 +52,7 @@ pub struct NodeMetrics {
     pub http_requests_total: IntCounter,
 }
 
+#[cfg(feature = "metrics")]
 impl NodeMetrics {
     /// Create and register all node metrics with the default Prometheus registry.
     ///
@@ -139,6 +143,7 @@ pub struct AppState {
     /// Known peers in the network.
     pub peers: Arc<RwLock<Vec<PeerInfo>>>,
     /// Prometheus metrics counters and gauges.
+    #[cfg(feature = "metrics")]
     pub metrics: Arc<NodeMetrics>,
     /// Time when the node was started (for uptime calculation).
     pub started_at: Instant,

--- a/node/tests/integration.rs
+++ b/node/tests/integration.rs
@@ -8,7 +8,9 @@ use anyhow::Result;
 use omnia_economics::EconomicsState;
 use omnia_node::config::NodeConfig;
 use omnia_node::http;
-use omnia_node::state::{AppState, NodeMetrics};
+use omnia_node::state::AppState;
+#[cfg(feature = "metrics")]
+use omnia_node::state::NodeMetrics;
 use omnia_shards::{
     BiologicalShard, ComputationalShard, EconomicsShard, FeeSchedule, FinancialShard,
     IdentityShard, PhysicalShard, ShardRouter,
@@ -18,6 +20,7 @@ use serde_json::{json, Value};
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
 use std::time::Instant;
 use tokio::sync::{Mutex, RwLock};
 
@@ -54,6 +57,8 @@ async fn start_test_server() -> (String, tokio::task::JoinHandle<()>) {
     shard_router.register(Box::new(EconomicsShard::new()));
 
     let economics = EconomicsState::new();
+
+    #[cfg(feature = "metrics")]
     let metrics = NodeMetrics::new().expect("Failed to create metrics");
 
     let config = NodeConfig {
@@ -82,9 +87,10 @@ async fn start_test_server() -> (String, tokio::task::JoinHandle<()>) {
         economics: Arc::new(Mutex::new(economics)),
         event_store: Arc::new(RwLock::new(HashMap::new())),
         peers: Arc::new(RwLock::new(Vec::new())),
+        #[cfg(feature = "metrics")]
         metrics: Arc::new(metrics),
         started_at: Instant::now(),
-        is_syncing: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        is_syncing: Arc::new(AtomicBool::new(false)),
     };
 
     let app = http::build_http_router().with_state(app_state);
@@ -116,6 +122,7 @@ async fn test_health_endpoint() -> Result<()> {
 }
 
 #[tokio::test]
+#[cfg(feature = "metrics")]
 async fn test_metrics_endpoint() -> Result<()> {
     let (base_url, _handle) = start_test_server().await;
 
@@ -131,6 +138,20 @@ async fn test_metrics_endpoint() -> Result<()> {
         "Metrics should contain omnia_node_events_submitted_total, got: {}",
         &body[..body.len().min(500)]
     );
+
+    Ok(())
+}
+
+/// When metrics feature is disabled, /metrics should return 404
+#[tokio::test]
+#[cfg(not(feature = "metrics"))]
+async fn test_metrics_endpoint_disabled() -> Result<()> {
+    let (base_url, _handle) = start_test_server().await;
+
+    let client = reqwest::Client::new();
+    let resp = client.get(format!("{}/metrics", base_url)).send().await?;
+
+    assert_eq!(resp.status(), 404, "Metrics endpoint should be 404 when feature disabled");
 
     Ok(())
 }
@@ -185,7 +206,9 @@ async fn test_get_event_not_found() -> Result<()> {
     Ok(())
 }
 
+/// Test that Swagger UI is accessible when the feature is enabled.
 #[tokio::test]
+#[cfg(feature = "swagger-ui")]
 async fn test_swagger_ui() -> Result<()> {
     let (base_url, _handle) = start_test_server().await;
     let client = reqwest::Client::new();
@@ -193,11 +216,27 @@ async fn test_swagger_ui() -> Result<()> {
         .get(format!("{}/swagger-ui/", base_url))
         .send()
         .await?;
-    assert_eq!(resp.status(), 200, "Swagger UI should be accessible");
+    assert_eq!(resp.status(), 200, "Swagger UI should be accessible when feature enabled");
     Ok(())
 }
 
+/// Test that Swagger UI returns 404 when the feature is disabled.
 #[tokio::test]
+#[cfg(not(feature = "swagger-ui"))]
+async fn test_swagger_ui_disabled() -> Result<()> {
+    let (base_url, _handle) = start_test_server().await;
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(format!("{}/swagger-ui/", base_url))
+        .send()
+        .await?;
+    assert_eq!(resp.status(), 404, "Swagger UI should be 404 when feature disabled");
+    Ok(())
+}
+
+/// Test that OpenAPI JSON is accessible when the feature is enabled.
+#[tokio::test]
+#[cfg(feature = "swagger-ui")]
 async fn test_openapi_json() -> Result<()> {
     let (base_url, _handle) = start_test_server().await;
     let client = reqwest::Client::new();
@@ -205,7 +244,7 @@ async fn test_openapi_json() -> Result<()> {
         .get(format!("{}/api-docs/openapi.json", base_url))
         .send()
         .await?;
-    assert_eq!(resp.status(), 200, "OpenAPI JSON should be accessible");
+    assert_eq!(resp.status(), 200, "OpenAPI JSON should be accessible when feature enabled");
     let body: Value = resp.json().await?;
     // Verify the OpenAPI spec contains our paths
     let paths = body["paths"]
@@ -227,5 +266,19 @@ async fn test_openapi_json() -> Result<()> {
         paths.keys().any(|k| k.contains("node")),
         "Should contain node path"
     );
+    Ok(())
+}
+
+/// Test that OpenAPI JSON returns 404 when the feature is disabled.
+#[tokio::test]
+#[cfg(not(feature = "swagger-ui"))]
+async fn test_openapi_json_disabled() -> Result<()> {
+    let (base_url, _handle) = start_test_server().await;
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(format!("{}/api-docs/openapi.json", base_url))
+        .send()
+        .await?;
+    assert_eq!(resp.status(), 404, "OpenAPI JSON should be 404 when feature disabled");
     Ok(())
 }

--- a/omnia-adapters/Cargo.toml
+++ b/omnia-adapters/Cargo.toml
@@ -42,7 +42,7 @@ hex = "0.4"
 subtle = "2"
 
 [features]
-default = ["arkworks"]
+default = []
 arkworks = ["dep:ark-ff", "dep:ark-ec", "dep:ark-serialize", "dep:ark-groth16", "dep:ark-bn254", "dep:ark-relations", "dep:ark-r1cs-std", "dep:ark-snark", "dep:ark-crypto-primitives"]
 ethereum-live = ["dep:alloy"]
 cosmos = []

--- a/shards/Cargo.toml
+++ b/shards/Cargo.toml
@@ -8,7 +8,7 @@ license = { workspace = true }
 repository = { workspace = true }
 
 [dependencies]
-omnia-substrate = { path = "../substrate" }
+omnia-substrate = { path = "../substrate", default-features = false }
 omnia-primitives = { path = "../omnia-primitives" }
 omnia-economics = { path = "../economics" }
 omnia-crypto = { path = "../omnia-crypto", features = ["keystore"] }

--- a/substrate/Cargo.toml
+++ b/substrate/Cargo.toml
@@ -10,10 +10,10 @@ rust-version = { workspace = true }
 
 [dependencies]
 omnia-primitives = { path = "../omnia-primitives" }
-omnia-crypto = { path = "../omnia-crypto", features = ["bls"] }
+omnia-crypto = { path = "../omnia-crypto", default-features = false, features = ["keystore"] }
 omnia-consensus = { path = "../omnia-consensus", features = ["persistent-storage"] }
-omnia-network = { path = "../omnia-network" }
-omnia-adapters = { path = "../omnia-adapters" }
+omnia-network = { path = "../omnia-network", default-features = false, optional = true }
+omnia-adapters = { path = "../omnia-adapters", default-features = false, optional = true }
 serde = { version = "1.0", features = ["derive"] }
 sha2 = "0.10"
 hex = "0.4"
@@ -51,10 +51,10 @@ redb = "2"
 
 # BLS12-381 signature aggregation — reduces N signature verifications to 1
 # Spec: Boneh-Lynn-Shacham (BLS) signatures
-blst = "0.3"
+blst = { version = "0.3", optional = true }
 
 # Efficient serialization of byte arrays in serde — needed for BLS key/sig binary fields
-serde_bytes = "0.11"
+serde_bytes = { version = "0.11", optional = true }
 
 # Constant-time comparisons for cryptographic operations — prevents timing side-channels
 subtle = "2"
@@ -63,7 +63,7 @@ subtle = "2"
 getrandom = "0.2"
 
 # Snappy compression for gossip messages — reduces bandwidth by 50-80%
-snap = "1"
+snap = { version = "1", optional = true }
 
 # Legacy sled database support for one-time migration to redb
 sled = { version = "0.34", optional = true }
@@ -74,12 +74,12 @@ bincode = { workspace = true }
 [features]
 default = []
 migration = ["sled"]
-bls = ["omnia-crypto/bls"]
+bls = ["omnia-crypto/bls", "dep:blst", "dep:serde_bytes"]
 pqc = ["omnia-crypto/pqc"]
 persistent-storage = ["omnia-consensus/persistent-storage"]
-network = ["omnia-network/network"]
-zk = ["omnia-adapters/arkworks"]
-ethereum-live = ["omnia-adapters/ethereum-live"]
+network = ["dep:omnia-network", "omnia-network/network", "dep:snap"]
+zk = ["dep:omnia-adapters", "omnia-adapters/arkworks"]
+ethereum-live = ["dep:omnia-adapters", "omnia-adapters/ethereum-live"]
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/substrate/src/lib.rs
+++ b/substrate/src/lib.rs
@@ -24,6 +24,7 @@
 #![deprecated(since = "0.2.0", note = "Use omnia-primitives, omnia-consensus, omnia-crypto, omnia-network, omnia-adapters directly")]
 
 pub mod blake3_domain;
+#[cfg(feature = "bls")]
 pub mod bls;
 pub mod causal_graph;
 pub mod consensus;
@@ -42,6 +43,7 @@ pub mod slashing;
 pub mod slashing_undo;
 pub mod snapshot;
 pub mod snapshot_replication;
+#[cfg(feature = "bls")]
 pub mod threshold;
 pub mod vector_clock;
 pub mod vrf;
@@ -51,10 +53,13 @@ pub mod wire_format;
 // via `omnia_substrate::omnia_crypto::…`, `omnia_substrate::omnia_consensus::…`, etc.
 pub use omnia_consensus;
 pub use omnia_crypto;
+#[cfg(feature = "network")]
 pub use omnia_network;
+#[cfg(feature = "zk")]
 pub use omnia_adapters;
 
 // Re-export commonly used types
+#[cfg(feature = "bls")]
 pub use bls::{
     aggregate_public_keys, aggregate_signatures, verify_aggregate, verify_aggregate_with_pop,
     BlsError, BlsKeypair, BlsProofOfPossession, BlsPublicKey, BlsSignature,
@@ -80,6 +85,8 @@ pub use omnia_primitives::{
     serialize_with_version, deserialize_with_version,
 };
 // Re-export networking types from omnia-network (backward compatibility)
+// Only available when the `network` feature is enabled.
+#[cfg(feature = "network")]
 pub use omnia_network::{
     fast_sync::{
         select_target_checkpoint, FastSyncManager, SyncCheckpoint, SyncError, SyncNetwork,
@@ -111,6 +118,7 @@ pub use slashing_undo::{
 };
 pub use snapshot::{SnapshotError, StateSnapshot};
 pub use snapshot_replication::{find_latest_snapshot, replicate_snapshot, ReplicationConfig};
+#[cfg(feature = "bls")]
 pub use threshold::{
     AeadCiphertext, DkgError, DkgPhase, DkgResult, DkgSession, DkgSharePackage,
     DkgVerificationResult, KeyShare, PartialSignature, ThresholdConfig, ThresholdError,
@@ -209,6 +217,7 @@ pub enum SubstrateError {
     #[error("Event validation error: {0}")]
     /// Event validation error
     EventValidation(#[from] EventValidationError),
+    #[cfg(feature = "network")]
     #[error("Gossip error: {0}")]
     /// Gossip protocol error
     Gossip(#[from] GossipError),
@@ -229,6 +238,7 @@ pub struct SubstrateConfig {
     /// Unique identifier for this node
     pub node_id: NodeId,
     /// Gossip protocol configuration
+    #[cfg(feature = "network")]
     pub gossip: GossipConfig,
     /// Consensus engine configuration
     pub consensus: ConsensusConfig,
@@ -319,6 +329,7 @@ impl SubstrateConfig {
         seed[0] = 1; // Non-zero to avoid debug-build panic
         Self {
             node_id,
+            #[cfg(feature = "network")]
             gossip: GossipConfig::default(),
             consensus: ConsensusConfig {
                 total_nodes,
@@ -348,6 +359,7 @@ impl SubstrateConfig {
         seed[0] = 1; // Non-zero to avoid debug-build panic
         Self {
             node_id,
+            #[cfg(feature = "network")]
             gossip: GossipConfig::default(),
             consensus: ConsensusConfig {
                 total_nodes,
@@ -374,6 +386,7 @@ impl SubstrateConfig {
 pub struct Substrate {
     config: SubstrateConfig,
     graph: Arc<tokio::sync::RwLock<CausalGraph>>,
+    #[cfg(feature = "network")]
     gossip: Option<GossipProtocol>,
     consensus: ConsensusEngine<SlashingEngine>,
     running: bool,
@@ -478,6 +491,7 @@ impl Substrate {
         Self {
             config,
             graph,
+            #[cfg(feature = "network")]
             gossip: None,
             consensus,
             slashing,
@@ -492,6 +506,7 @@ impl Substrate {
     }
 
     /// Initialize the gossip protocol
+    #[cfg(feature = "network")]
     pub fn init_gossip(&mut self) {
         self.gossip = Some(GossipProtocol::new(
             self.config.node_id,
@@ -503,6 +518,7 @@ impl Substrate {
     /// Start the substrate runtime
     pub async fn start(&mut self) {
         self.running = true;
+        #[cfg(feature = "network")]
         if let Some(ref mut gossip) = self.gossip {
             gossip.start().await;
         }
@@ -511,6 +527,7 @@ impl Substrate {
     /// Stop the substrate runtime
     pub fn stop(&mut self) {
         self.running = false;
+        #[cfg(feature = "network")]
         if let Some(ref mut gossip) = self.gossip {
             gossip.stop();
         }
@@ -597,6 +614,7 @@ impl Substrate {
     /// run consensus, and forward committed events to shard processor.
     async fn process_consensus_round(&mut self) {
         // 1. Drain network events into graph + queue
+        #[cfg(feature = "network")]
         if let Some(ref mut gossip) = self.gossip {
             match gossip.process_pending_events().await {
                 Ok(inserted) => {
@@ -657,6 +675,7 @@ impl Substrate {
     }
 
     /// Start with network and run main loop
+    #[cfg(feature = "network")]
     pub async fn start_with_network(&mut self, network: OmniaNetwork) {
         if let Some(ref mut gossip) = self.gossip {
             if let Err(e) = gossip.start_with_network(network).await {
@@ -709,6 +728,7 @@ impl Substrate {
             );
         }
 
+        #[cfg(feature = "network")]
         if let Some(ref mut gossip) = self.gossip {
             gossip
                 .broadcast_event((*event_arc).clone())
@@ -730,6 +750,7 @@ impl Substrate {
     }
 
     /// Get gossip protocol statistics
+    #[cfg(feature = "network")]
     pub fn gossip_stats(&self) -> Option<&GossipStats> {
         self.gossip.as_ref().map(|g| g.stats())
     }
@@ -915,9 +936,11 @@ mod tests {
         let substrate = Substrate::new(config);
 
         assert!(!substrate.running);
+        #[cfg(feature = "network")]
         assert!(substrate.gossip.is_none());
     }
 
+    #[cfg(feature = "network")]
     #[tokio::test]
     async fn test_substrate_start_stop() {
         let config = SubstrateConfig::new(test_node(1));


### PR DESCRIPTION
Root cause: utoipa-swagger-ui embeds ~11MB of JS/CSS assets (Swagger UI
bundle) into the binary's .rodata section. This alone accounted for 62% of
the 18.7MB release binary.

Key changes:
- Make utoipa-swagger-ui optional behind 'swagger-ui' feature flag
  - Removed from default 'full' feature (dev-only opt-in)
  - cfg(feature = "swagger-ui") guards in http.rs
  - utoipa kept as required dep (derive macros used in API handlers)
- Make prometheus optional behind 'metrics' feature flag
  - cfg(feature = "metrics") guards in main.rs, state.rs, http.rs, events.rs
- default-features = false on heavy workspace crate deps in node/Cargo.toml
  - omnia-network, omnia-adapters, omnia-crypto, omnia-consensus
- default-features = false on omnia-substrate in binding, economics, shards
- Feature-gate substrate modules: bls, threshold, network, gossip, zk
- Release profile: lto = "fat", strip = "symbols", codegen-units = 1
- omnia-adapters: default = [] (no longer auto-enables arkworks)
- Integration tests: cfg-gate swagger-ui and metrics tests

Results:
- Binary size: 18.7MB → 6.3MB (66% reduction, well under 12MB target)
- All feature matrix combos compile: light, full, all-features, swagger-ui
- cargo-deny passes: advisories, bans, licenses, sources all ok
- All lib tests pass across workspace crates