### PR TITLE
docs: restructure documentation into organized hierarchy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+> 🎯 Audience: Developers, Operators
+> 🔗 Context: Version history and migration notes for all releases
+> 📅 Last Updated: 2026-05-20
 
 All notable changes to this project will be documented in this file.
 
@@ -547,3 +550,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implementation roadmap (Phase 0 to Phase 3).
 - Basic README.md, CONTRIBUTING.md, LICENSE, SECURITY.md.
 - Initial diagrams for architecture, governance, supply chain, consensus comparison, and identity system.
+
+---
+🔙 **Back**: [README.md](./README.md) | 🔄 **Related**: [docs/reference/roadmap.md](./docs/reference/roadmap.md)  
+🚀 **Next**: [docs/reference/roadmap.md](./docs/reference/roadmap.md) | 📜 **Source of Truth**: [Restructuring Blueprint](./docs/reference/blueprint-reference.md)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,7 @@
 # Contributor Covenant Code of Conduct
+> 🎯 Audience: All
+> 🔗 Context: Community standards and enforcement guidelines for all participants
+> 📅 Last Updated: 2026-05-20
 
 ## Our Pledge
 
@@ -74,3 +77,7 @@ This Code of Conduct is adapted from the [Contributor Covenant][homepage], versi
 
 [homepage]: https://www.contributor-covenant.org
 [v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+
+---
+🔙 **Back**: [README.md](./README.md) | 🔄 **Related**: [CONTRIBUTING.md](./CONTRIBUTING.md)  
+🚀 **Next**: [CONTRIBUTING.md](./CONTRIBUTING.md) | 📜 **Source of Truth**: [Restructuring Blueprint](./docs/reference/blueprint-reference.md)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,7 @@
 # 🤝 Contributing to Omnia Protocol
+> 🎯 Audience: Developers
+> 🔗 Context: Contribution guidelines, CI gates, and code review process for the Rust-only codebase
+> 📅 Last Updated: 2026-05-20
 
 Thank you for your interest in contributing to Omnia! Whether you're a cryptographer, Rust developer, or visionary, there's a place for you.
 
@@ -314,3 +317,7 @@ By contributing to Omnia Protocol, you agree that your contributions will be lic
 ---
 
 **Last Updated:** May 2026
+
+---
+🔙 **Back**: [README.md](./README.md) | 🔄 **Related**: [docs/architecture/](./docs/architecture/)  
+🚀 **Next**: [docs/building/](./docs/building/) | 📜 **Source of Truth**: [Restructuring Blueprint](./docs/reference/blueprint-reference.md)

--- a/README.md
+++ b/README.md
@@ -24,6 +24,18 @@
 
 ---
 
+## 🚪 Choose Your Path
+
+| If you are... | Start Here | Next Step |
+|---------------|------------|-----------|
+| 🌱 New to Omnia | [docs/use-cases/](docs/use-cases/) | [Quick Start](#-quick-start) |
+| 💻 Contributor | [CONTRIBUTING.md](CONTRIBUTING.md) | [docs/architecture/](docs/architecture/) |
+| 🏗️ Systems Architect | [docs/reference/blueprint-reference.md](docs/reference/blueprint-reference.md) | [docs/architecture/trait-boundaries.md](docs/architecture/trait-boundaries.md) |
+| 📦 Validator Operator | [docs/building/feature-matrix.md](docs/building/feature-matrix.md) | [docs/operations/validator-setup.md](docs/operations/validator-setup.md) |
+| 📊 Performance Engineer | [docs/reference/benchmark-gates.md](docs/reference/benchmark-gates.md) | [docs/architecture/pipeline-design.md](docs/architecture/pipeline-design.md) |
+
+---
+
 ## 🏗️ The Omnia Architecture
 
 ```
@@ -222,12 +234,18 @@ To uphold our commitment to radical transparency, we maintain a live dashboard o
 
 ## 📚 Documentation
 
-- [**Architecture**](./ARCHITECTURE.md) - Technical deep-dives and layer specifications.
-- [**Implementation**](./docs/specifications/IMPLEMENTATION.md) - Protocol specifications.
-- [**Governance**](./docs/GOVERNANCE.md) - Community and decision-making.
-- [**Use Cases**](./docs/USE_CASES.md) - Real-world applications.
-- [**FAQ**](./docs/FAQ.md) - Common questions.
-- [**Research**](./substrate/RESEARCH.md) - Consensus research and implementation results.
+Full documentation is organized in [docs/](docs/):
+
+- [**docs/architecture/**](docs/architecture/) — Layer specifications, trait boundaries, pipeline design, CRDT proofs
+- [**docs/building/**](docs/building/) — Feature flags, cross-compilation, binary optimization
+- [**docs/operations/**](docs/operations/) — Validator setup, monitoring, deployment, runbook
+- [**docs/reference/**](docs/reference/) — Roadmap, benchmarks, ADR index, security audit, dependency policy
+- [**docs/use-cases/**](docs/use-cases/) — Real-world scenarios, FAQ, governance
+
+Quick links:
+- [**Architecture (legacy)**](./ARCHITECTURE.md) — Being superseded by docs/architecture/
+- [**Implementation Spec**](./docs/specifications/IMPLEMENTATION.md) — Protocol specifications
+- [**Research**](./substrate/RESEARCH.md) — Consensus research and implementation results
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,4 +1,7 @@
 # Security Policy
+> 🎯 Audience: Operators, Architects
+> 🔗 Context: Vulnerability disclosure policy, security review process, and threat model references
+> 📅 Last Updated: 2026-05-20
 
 **Document version**: 4.0
 **Last Updated**: 2026-05-16
@@ -170,3 +173,7 @@ We follow a coordinated disclosure process:
 3. **Coordinated disclosure**: When a fix is ready, we coordinate with the reporter on the disclosure timeline. We prefer to publish a security advisory (CVE) alongside the patch release.
 4. **Credit**: Reporters who follow responsible disclosure receive credit in our security advisories, unless they request anonymity.
 5. **No legal action**: We will not pursue legal action against security researchers who act in good faith, follow our reporting process, and avoid unnecessary harm to users or systems.
+
+---
+🔙 **Back**: [README.md](./README.md) | 🔄 **Related**: [docs/reference/security-audit.md](./docs/reference/security-audit.md)  
+🚀 **Next**: [SECURITY_BOUNTY.md](./SECURITY_BOUNTY.md) | 📜 **Source of Truth**: [Restructuring Blueprint](./docs/reference/blueprint-reference.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,119 @@
+# Omnia Protocol Documentation
+> 🎯 Audience: All
+> 🔗 Context: Central navigation hub for all Omnia Protocol documentation
+> 📅 Last Updated: 2026-05-20
+
+Welcome to the Omnia Protocol documentation hub. This index provides structured navigation to every document in the repository, organized by audience and topic.
+
+---
+
+## 🚪 Choose Your Path
+
+| If you are... | Start Here | Next Step |
+|---------------|------------|-----------|
+| 🌱 New to Omnia | [docs/use-cases/](use-cases/) | [Quickstart](#quick-start) |
+| 💻 Contributor | [CONTRIBUTING.md](../CONTRIBUTING.md) | [docs/architecture/](architecture/) |
+| 🏗️ Systems Architect | [docs/reference/blueprint-reference.md](reference/blueprint-reference.md) | [docs/architecture/trait-boundaries.md](architecture/trait-boundaries.md) |
+| 📦 Validator Operator | [docs/building/feature-matrix.md](building/feature-matrix.md) | [docs/operations/validator-setup.md](operations/validator-setup.md) |
+| 📊 Performance Engineer | [docs/reference/benchmark-gates.md](reference/benchmark-gates.md) | [docs/architecture/pipeline-design.md](architecture/pipeline-design.md) |
+
+---
+
+## Quick Start
+
+```bash
+git clone https://github.com/Willow7737/omnia-protocol.git
+cd omnia-protocol
+cargo test --workspace
+cargo bench --no-run
+```
+
+---
+
+## 📂 Documentation Structure
+
+### [architecture/](architecture/) — Crate Layout, DAG, Traits, Pipeline, Cache Alignment
+
+Deep technical documentation on the protocol's layered architecture, trait contracts, and consensus pipeline.
+
+| Document | Description |
+|----------|-------------|
+| [README.md](architecture/README.md) | Architecture index and layer overview |
+| [layer-1-substrate.md](architecture/layer-1-substrate.md) | Substrate layer — VectorClock, Event, CausalGraph, CRDTs, Gossip, Consensus |
+| [layer-2-shards.md](architecture/layer-2-shards.md) | Domain Shards — 6 shards, ShardRouter, cross-shard messaging |
+| [layer-3-binding.md](architecture/layer-3-binding.md) | Binding Layer — ProvenanceLog, PhysicalAnchor, PQC signatures |
+| [layer-4-identity.md](architecture/layer-4-identity.md) | Identity Hardening — DIDs, Shamir, Biometrics, AI Agents |
+| [layer-5-economics.md](architecture/layer-5-economics.md) | Economics — UBC, Governance, Decay |
+| [zk-rollup-settlement.md](architecture/zk-rollup-settlement.md) | ZK-Rollup Phase 0 — Settlement-agnostic architecture |
+| [trait-boundaries.md](architecture/trait-boundaries.md) | Trait contracts — EventProcessor, SettlementLayer, Shard |
+| [pipeline-design.md](architecture/pipeline-design.md) | Consensus pipeline, mempool, leader selection |
+| [crdt-convergence.md](architecture/crdt-convergence.md) | CRDT convergence proofs |
+| [vector-clock-reconciliation.md](architecture/vector-clock-reconciliation.md) | Vector clock reconciliation strategy |
+
+### [building/](building/) — Feature Profiles, Cross-Compilation, Binary Optimization
+
+Guides for building the Omnia node binary with various feature configurations.
+
+| Document | Description |
+|----------|-------------|
+| [README.md](building/README.md) | Building index |
+| [feature-matrix.md](building/feature-matrix.md) | Feature flags and build profiles |
+| [cross-compilation.md](building/cross-compilation.md) | Cross-compilation guide |
+| [binary-optimization.md](building/binary-optimization.md) | Binary size and release optimization |
+
+### [operations/](operations/) — Validator Setup, Monitoring, Deployment, Feature Flags
+
+Operational runbooks and deployment guides for running Omnia nodes.
+
+| Document | Description |
+|----------|-------------|
+| [README.md](operations/README.md) | Operations index |
+| [validator-setup.md](operations/validator-setup.md) | Validator setup guide |
+| [monitoring.md](operations/monitoring.md) | Monitoring setup — Grafana, Prometheus, alerts |
+| [deployment.md](operations/deployment.md) | Deployment procedures — Docker, Kubernetes |
+| [runbook.md](operations/runbook.md) | Operations runbook — startup, key rotation, slashing, partition recovery |
+| [feature-flags.md](operations/feature-flags.md) | Feature flag reference |
+
+### [reference/](reference/) — Roadmap, Benchmarks, Blueprint, Metrics Glossary
+
+Reference documentation including roadmaps, benchmark data, and policy documents.
+
+| Document | Description |
+|----------|-------------|
+| [README.md](reference/README.md) | Reference index |
+| [roadmap.md](reference/roadmap.md) | Implementation roadmap — Phase 0 through Phase 5+ |
+| [benchmark-gates.md](reference/benchmark-gates.md) | Performance baselines and benchmark data |
+| [blueprint-reference.md](reference/blueprint-reference.md) | Blueprint/spec reference — implementation status |
+| [metrics-glossary.md](reference/metrics-glossary.md) | Metrics and terminology glossary |
+| [adr-index.md](reference/adr-index.md) | Architecture Decision Record index |
+| [security-audit.md](reference/security-audit.md) | Security audit package — findings, validated audits |
+| [dependency-policy.md](reference/dependency-policy.md) | Dependency policy — pinning, audits, exemptions |
+| [crypto-migration.md](reference/crypto-migration.md) | Cryptographic migration playbook |
+
+### [use-cases/](use-cases/) — Real-World Scenarios, Phase Alignment, User Impact
+
+Use case documentation and user-facing guides.
+
+| Document | Description |
+|----------|-------------|
+| [README.md](use-cases/README.md) | Use cases index |
+| [real-world-scenarios.md](use-cases/real-world-scenarios.md) | Real-world application scenarios |
+| [phase-alignment.md](use-cases/phase-alignment.md) | Phase alignment and user impact per development phase |
+| [faq.md](use-cases/faq.md) | Frequently asked questions |
+| [governance.md](use-cases/governance.md) | Governance system — voting, treasury, reputation |
+
+---
+
+## 🔗 Key Root Documents
+
+| Document | Description |
+|----------|-------------|
+| [README.md](../README.md) | Project landing page with workspace overview |
+| [ARCHITECTURE.md](../ARCHITECTURE.md) | Architecture documentation (legacy, being superseded by docs/architecture/) |
+| [CONTRIBUTING.md](../CONTRIBUTING.md) | Contribution guidelines |
+| [SECURITY.md](../SECURITY.md) | Security policy and reporting |
+| [CHANGELOG.md](../CHANGELOG.md) | Version changelog |
+
+---
+🔙 **Back**: [README.md](../) | 🔄 **Related**: [ARCHITECTURE.md](../ARCHITECTURE.md)
+🚀 **Next**: [architecture/](architecture/) | 📜 **Source of Truth**: [Restructuring Blueprint](reference/blueprint-reference.md)

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,59 @@
+# Architecture Documentation
+> 🎯 Audience: Developers
+> 🔗 Context: Index for all architecture documents describing the Omnia Protocol's layered design
+> 📅 Last Updated: 2026-05-20
+
+## Layer Overview
+
+Omnia Protocol is a five-layer distributed system designed to enable trustless coordination at global and interplanetary scales.
+
+```
+┌─────────────────────────────────────────┐
+│  LAYER 5: Economics (UBC, Governance)   │ ✅ IMPLEMENTED
+├─────────────────────────────────────────┤
+│  LAYER 4: Identity (DIDs, Shamir, Bio) │ ✅ IMPLEMENTED (in shards)
+├─────────────────────────────────────────┤
+│  LAYER 3: Binding (Provenance, RF, QC) │ ✅ IMPLEMENTED (QC real, RF stub)
+├─────────────────────────────────────────┤
+│  LAYER 2: Domain Shards (6 shards)     │ ✅ IMPLEMENTED
+├─────────────────────────────────────────┤
+│  LAYER 1: Substrate (Causal Graph)     │ ✅ IMPLEMENTED
+├─────────────────────────────────────────┤
+│  PHASE 0: ZK-Rollup (Settlement Layer) │ ✅ IMPLEMENTED
+├─────────────────────────────────────────┤
+│  NODE BINARY (CLI + REST API)          │ ✅ IMPLEMENTED
+└─────────────────────────────────────────┘
+```
+
+## Architecture Documents
+
+| Document | Layer | Key Topics |
+|----------|-------|------------|
+| [layer-1-substrate.md](layer-1-substrate.md) | Layer 1 | VectorClock, Event, CausalGraph, CRDTs, Gossip, ConsensusEngine |
+| [layer-2-shards.md](layer-2-shards.md) | Layer 2 | 6 domain shards, ShardRouter, cross-shard messaging, fee enforcement |
+| [layer-3-binding.md](layer-3-binding.md) | Layer 3 | ProvenanceLog, PhysicalAnchor, PQC signatures, key rotation |
+| [layer-4-identity.md](layer-4-identity.md) | Layer 4 | DIDs, Shamir's Secret Sharing, biometric anchors, AI agents |
+| [layer-5-economics.md](layer-5-economics.md) | Layer 5 | UBC, quota, quadratic voting, reputation decay, slashing |
+| [zk-rollup-settlement.md](zk-rollup-settlement.md) | Phase 0 | Settlement-agnostic ZK-rollup, Groth16, Poseidon, Ethereum adapter |
+| [trait-boundaries.md](trait-boundaries.md) | Cross-cutting | EventProcessor, SettlementLayer, Shard trait contracts, ADRs 001–007 |
+| [pipeline-design.md](pipeline-design.md) | Cross-cutting | Consensus pipeline, mempool, leader selection, queue invariants |
+| [crdt-convergence.md](crdt-convergence.md) | Cross-cutting | CRDT convergence proofs for GCounter, OrSet, LWWRegister |
+| [vector-clock-reconciliation.md](vector-clock-reconciliation.md) | Cross-cutting | Vector clock reconciliation strategy, partition recovery |
+
+## Workspace Crates
+
+| Crate | Purpose | Tests |
+|-------|---------|-------|
+| `substrate/` | Causal graph, consensus, gossip, crypto, CRDTs, slashing (redb) | 454+ |
+| `shards/` | 6 domain shards + cross-shard messaging | 62+ |
+| `binding/` | Provenance log, RF stub, hybrid PQC signatures | 61+ |
+| `economics/` | UBC token, quota, governance, useful work | 58+ |
+| `omnia-adapters/` | ZK-rollup (arkworks R1CS + Groth16 + Merkle), Ethereum adapter | 129+ |
+| `node/` | Binary entrypoint, REST API, health/metrics | 30+ |
+| `chaos-tests/` | Network partitions, crash recovery, byzantine, message loss | ~15 scenarios |
+
+**Total: 800+ lib tests + chaos/integration tests, all passing.**
+
+---
+🔙 **Back**: [docs/](../) | 🔄 **Related**: [trait-boundaries.md](trait-boundaries.md)
+🚀 **Next**: [layer-1-substrate.md](layer-1-substrate.md) | 📜 **Source of Truth**: [Restructuring Blueprint](../reference/blueprint-reference.md)

--- a/docs/architecture/crdt-convergence.md
+++ b/docs/architecture/crdt-convergence.md
@@ -1,0 +1,197 @@
+# CRDT Convergence Proofs
+> 🎯 Audience: Developers
+> 🔗 Context: Mathematical foundation for why CRDTs guarantee convergence under arbitrary message delivery order
+> 📅 Last Updated: 2026-05-20
+
+## Formal Convergence Theorem
+
+> **Theorem.** *For any state-based CRDT C, if replicas start at the same state and apply the same set of merge operations in any order, they converge to the same state.*
+
+**Proof sketch.** A state-based CRDT's merge function must satisfy three algebraic properties for its join semilattice:
+
+1. **Commutativity**: `merge(a, b) = merge(b, a)`
+2. **Associativity**: `merge(merge(a, b), c) = merge(a, merge(b, c))`
+3. **Idempotency**: `merge(a, a) = a`
+
+These three properties define a **join semilattice** over the state space. In a join semilattice, the least upper bound (lub) of any finite set of elements exists and is unique. Since merge computes the lub of its operands, and lub is unique, the order in which merges are applied cannot affect the final result. Replicas that receive the same set of state updates — regardless of delivery order, duplication, or delay — will converge to the same state.
+
+---
+
+## GCounter — Grow-Only Counter
+
+### State Representation
+
+A GCounter maintains a map `counts: NodeId → u64`, where each node tracks its own monotonically increasing contribution.
+
+### Merge Semantics
+
+```
+merge(a, b).counts[node] = max(a.counts[node], b.counts[node])
+```
+
+The merge is **pointwise maximum** over all node entries.
+
+### Proof of Properties
+
+**Commutativity.** `max(x, y) = max(y, x)` for all `x, y ∈ u64`. Therefore `merge(a, b) = merge(b, a)` pointwise, hence structurally.
+
+**Associativity.** `max(max(x, y), z) = max(x, max(y, z)) = max(x, y, z)` for all `x, y, z ∈ u64`. Therefore `merge(merge(a, b), c) = merge(a, merge(b, c))`.
+
+**Idempotency.** `max(x, x) = x` for all `x ∈ u64`. Therefore `merge(a, a) = a`.
+
+**Monotonicity.** The total value is `value(a) = Σ_node a.counts[node]`. Since `max(x, y) ≥ x` and `max(x, y) ≥ y`, each entry after merge is at least as large as before. After increment by `δ > 0`, the affected entry increases by `δ`. Therefore `value` is non-decreasing under both increment and merge.
+
+### Property-Based Tests
+
+| Test | Property |
+|------|----------|
+| `proptest_merge_commutative` | `merge(a, b) == merge(b, a)` |
+| `proptest_merge_idempotent` | `merge(a, a) == a` |
+| `proptest_merge_associative` | `merge(merge(a, b), c) == merge(a, merge(b, c))` |
+| `proptest_monotonic` | `value` never decreases after increment or merge |
+
+---
+
+## OrSet — Observed-Remove Set
+
+### State Representation
+
+An OrSet maintains two maps per element:
+
+- `adds: T → Set<Token>` — all tokens ever added for element `T`
+- `removes: T → Set(Token)` — all tokens observed at removal time
+
+A `Token = (NodeId, sequence_number)` uniquely identifies an add operation.
+
+An element is **present** iff `adds[T] \ removes[T] ≠ ∅`.
+
+### Merge Semantics
+
+```
+merge(a, b).adds[T]    = a.adds[T] ∪ b.adds[T]
+merge(a, b).removes[T] = a.removes[T] ∪ b.removes[T]
+```
+
+The merge is **set union** over add-tokens and remove-tokens.
+
+### Proof of Properties
+
+**Commutativity.** Set union is commutative: `X ∪ Y = Y ∪ X`. Therefore `merge(a, b).adds = merge(b, a).adds` and similarly for removes. The observable state (which elements are present) is identical.
+
+**Associativity.** Set union is associative: `(X ∪ Y) ∪ Z = X ∪ (Y ∪ Z)`. Therefore `merge(merge(a, b), c) = merge(a, merge(b, c))`.
+
+**Idempotency.** Set union is idempotent: `X ∪ X = X`. Therefore `merge(a, a) = a`.
+
+### Add-Wins Semantics
+
+The key invariant of an observed-remove set is:
+
+> If an element is concurrently added and removed, the **add wins**.
+
+**Proof.** A remove operation can only observe tokens that existed at the time of the remove. A concurrent add creates a *new* token that the remove cannot have observed. Therefore the new token is in `adds[T]` but not in `removes[T]`, so `adds[T] \ removes[T] ≠ ∅`, and the element remains present after merge.
+
+This property ensures that no addition is silently lost due to a concurrent remove — a critical guarantee for use cases like shopping carts and access control lists.
+
+### Property-Based Tests
+
+| Test | Property |
+|------|----------|
+| `proptest_merge_commutative` | Observable elements of `merge(a, b)` == `merge(b, a)` |
+| `proptest_merge_idempotent` | `merge(a, a) == a` |
+| `proptest_add_wins` | Concurrently added element survives remove after merge |
+
+---
+
+## LWWRegister — Last-Writer-Wins Register
+
+### State Representation
+
+An LWWRegister stores:
+
+- `value: Option<T>` — the current value
+- `version: u64` — monotonic version counter
+- `timestamp: u64` — wall-clock time of the write
+- `node_id: NodeId` — the node that performed the write
+
+### Merge Semantics
+
+```
+merge(a, b):
+  if b.should_win(a):
+    take b's (value, timestamp, node_id, version)
+  else:
+    keep a's (value, timestamp, node_id, version)
+  merge vector clocks
+```
+
+Where `should_win` uses a deterministic three-level tiebreaker:
+
+1. **Higher version wins** (primary ordering)
+2. **Higher timestamp wins** (secondary ordering, if versions equal)
+3. **Higher node_id wins** (tertiary tiebreaker, if both above equal)
+
+### Proof of Properties
+
+**Determinism.** For any two registers `a` and `b`, exactly one of `a.should_win(b)` or `b.should_win(a)` is true (or both false for equal states). The tiebreaker over `node_id` is a total order since `NodeId` is a fixed-width byte array with lexicographic comparison, which is a total order. Therefore `merge(a, b)` always produces the same result.
+
+**Commutativity of outcome.** `merge(a, b)` and `merge(b, a)` both select the register with the winning metadata. Since `should_win` is deterministic and antisymmetric (for `a ≠ b`, exactly one wins), both merge directions produce the same winning value.
+
+**Idempotency.** `a.should_win(a)` is false (version, timestamp, and node_id are all equal, and `a.node_id > a.node_id` is false). Therefore `merge(a, a)` keeps `a`'s value. The vector clock merge is also idempotent (pointwise max of identical clocks). Thus `merge(a, a) = a`.
+
+### Why the Tiebreaker Order Matters
+
+The tiebreaker order `version > timestamp > node_id` is carefully chosen:
+
+- **Version first**: A monotonic version counter is more reliable than a wall-clock timestamp because it cannot be affected by clock skew. This ensures that causally newer writes always win.
+- **Timestamp second**: When versions are equal (e.g., concurrent first writes), the timestamp provides a reasonable best-effort ordering.
+- **Node ID last**: When all else is equal, a deterministic comparison of node identifiers ensures that every replica makes the same choice, guaranteeing convergence even in the degenerate case of identical timestamps.
+
+### Property-Based Tests
+
+| Test | Property |
+|------|----------|
+| `proptest_merge_deterministic` | `merge(a, b)` always returns the same result |
+| `proptest_merge_idempotent` | `merge(a, a) == a` |
+| `proptest_newer_wins` | Register with higher version/timestamp/node_id wins |
+
+---
+
+## Why These Properties Guarantee Convergence
+
+In a distributed system, messages between replicas can be:
+
+- **Delayed**: arbitrarily long delivery time
+- **Reordered**: messages arrive in a different order than sent
+- **Duplicated**: the same message delivered multiple times
+
+State-based CRDTs handle all three cases through their algebraic properties:
+
+| Scenario | Property that handles it |
+|----------|--------------------------|
+| Reordered messages | Commutativity: merge order doesn't matter |
+| Duplicated messages | Idempotency: merging the same state twice is harmless |
+| Arbitrary fan-in | Associativity: grouping of merges doesn't matter |
+
+Together, these properties mean that a replica can apply incoming state updates in any order, at any time, and the result will be the same as if they were applied in any other order. This is precisely the guarantee needed for eventual consistency in the Omnia Protocol's gossip-based synchronization.
+
+### Formal Statement
+
+For any CRDT type `C` implementing `CvRDT` with a merge function satisfying commutativity, associativity, and idempotency:
+
+```
+∀ replicas r₁, r₂: if r₁ and r₂ receive the same multiset of state updates S,
+then after processing all updates: state(r₁) = state(r₂)
+```
+
+This holds regardless of the order in which each replica processes the updates in `S`, or whether some updates are processed multiple times.
+
+---
+
+## References
+
+- Shapiro, M., Preguiça, N., Baquero, C., & Zawirski, M. (2011). *Conflict-free Replicated Data Types*. SSS 2011.
+- Almeida, P. S., Baquero, C., & Preguiça, N. (2018). *Delta State Replicated Data Types*. Journal of Parallel and Distributed Computing.
+
+---
+🔙 **Back**: [architecture/](./) | 🔄 **Related**: [vector-clock-reconciliation.md](./vector-clock-reconciliation.md)
+🚀 **Next**: [vector-clock-reconciliation.md](./vector-clock-reconciliation.md) | 📜 **Source of Truth**: [Restructuring Blueprint](../reference/blueprint-reference.md)

--- a/docs/architecture/layer-1-substrate.md
+++ b/docs/architecture/layer-1-substrate.md
@@ -1,0 +1,145 @@
+# Layer 1: The Substrate
+> 🎯 Audience: Developers
+> 🔗 Context: Foundation layer enabling the network to agree on what happened without global clock time or a single authority
+> 📅 Last Updated: 2026-05-20
+
+## Core Components
+
+### 1. VectorClock
+- Tracks logical time across all known nodes
+- Implements partial ordering: `happened_before`, `concurrent`, `merge`
+- Enables parallel execution of causally independent events
+- Located in: `substrate/src/vector_clock.rs`
+
+### 2. Event
+- Fundamental unit of the protocol
+- Two-parent structure (self-parent + other-parent) forming a DAG
+- Contains: vector clock, payload, cryptographic signature
+- Ed25519 signatures with replay protection via nonce tracking
+- Located in: `substrate/src/event.rs`
+
+### 3. CausalGraph
+- DAG storage for all events
+- O(1) amortized insertion (hash map lookup) and O(1) amortized lookup
+- Topological ordering for deterministic sequencing
+- Concurrent event detection for parallel execution
+- `state_root()` — Merkle root of the entire graph state
+- `merkle_proof()` — Inclusion proof for any event
+- `prune_old_events()` — Event pruning for long-term sustainability
+- `unprocessed_events` queue — O(new_events) consensus processing, not O(n) full graph walk
+- Located in: `substrate/src/causal_graph.rs`
+
+### 4. CRDTs (Conflict-free Replicated Data Types)
+- **GCounter**: Grow-only counter for monotonic values
+- **OrSet**: Observed-remove set with add-wins semantics
+- **LwwRegister**: Last-write-wins register for single values
+- Located in: `substrate/src/crdt/`
+
+For mathematical convergence proofs, see [crdt-convergence.md](./crdt-convergence.md).
+
+### 5. GossipProtocol
+- Epidemic event propagation across the network
+- Built on libp2p (QUIC transport + GossipSub + mDNS discovery)
+- Kademlia DHT for wide-area peer discovery
+- AutoNAT for NAT type detection, relay for NAT traversal, DCutr for direct upgrades
+- Snappy compression for messages >256 bytes
+- Gossip-about-gossip pattern (inspired by Hashgraph)
+- Bandwidth-efficient: only missing events transmitted
+- Located in: `substrate/src/gossip.rs`, `substrate/src/network.rs`
+
+### 6. ConsensusEngine
+- BFT finality mechanism running on top of the causal graph
+- Witness/fame/commit model (inspired by Hashgraph + AlephBFT)
+- Optimistic confirmation for low-latency finality
+- Processes only new (unprocessed) events, not the entire graph each round
+- VRF-based leader selection with stake weighting
+- Consensus state persisted across restarts via `RedbConsensusStore`
+- Located in: `substrate/src/consensus.rs`
+
+For pipeline and queue design, see [pipeline-design.md](./pipeline-design.md).
+
+### 7. SlashingEngine
+- Three offense types: Equivocation (500pts), LivenessViolation (100pts), InvalidAttestation (300pts)
+- Gradual slashing with 3-tier model: Warning → Jail → Ejection (ADR-011)
+- Persistent state via `RedbSlashingStore` with snapshot-and-rollback pattern
+- `SlashingUndoManager` for governance-based reversal
+- Located in: `substrate/src/slashing.rs`, `substrate/src/slashing_undo.rs`
+
+### 8. State Management
+- `state_root()` — Merkle root of the entire graph state
+- `merkle_proof()` — Inclusion proof for any event
+- `prune_old_events()` — Event pruning for long-term sustainability
+- `StateSnapshot` — Serialized snapshot with integrity verification
+- Fast-sync protocol for new nodes (BLAKE3 checkpoints, supermajority agreement)
+- Located in: `substrate/src/snapshot.rs`, `substrate/src/fast_sync.rs`
+
+### 9. KeyStore and Crypto
+- `EncryptedKeyStore` with AES-256-GCM + HKDF-SHA256 encryption
+- BIP-39 mnemonic support with SLIP-0010 HD key derivation
+- Key rotation with cryptographic proof (`KeyRotationProof`)
+- BLAKE3 domain separation for all hash contexts
+- `CryptoProfile` abstraction for hash, signature, VRF, and ZK schemes
+- Located in: `substrate/src/keystore.rs`, `substrate/src/crypto.rs`, `substrate/src/blake3_domain.rs`
+
+### 10. BLS Threshold Signatures and DKG
+- BLS12-381 signature aggregation for N-to-1 verification
+- `ThresholdKeyManager` for t-of-n key sharing
+- `DkgSession` state machine with Feldman VSS-based DKG
+- AES-256-GCM encrypted share packages with associated data
+- Located in: `substrate/src/bls.rs`, `substrate/src/threshold.rs`
+
+### 11. VRF and Leader Selection
+- V1: Ed25519 signature + BLAKE3 derivation (legacy)
+- V2: ECVRF with Fiat-Shamir + Ed25519 signatures (standard, target)
+- Stake-weighted leader selection via `compute_leader()`
+- Located in: `substrate/src/vrf.rs`
+
+See [ADR-012](../reference/adr-index.md#adr-012-vrf-construction-choice) for the VRF construction decision.
+
+## Design Decisions
+
+### Why Causal Consistency over Blockchain?
+
+| Property | Blockchain | Causal Graph (Omnia) |
+|----------|-----------|---------------------|
+| Ordering | Total (sequential) | Partial (parallel) |
+| Throughput | ~100-1000 TPS | ~527 events/sec (single-node measured) |
+| Latency | ~12s block time | Not yet benchmarked at scale |
+| Concurrency | None (single chain) | Automatic (DAG) |
+| Finality | Probabilistic | Deterministic (BFT) |
+
+### Consensus Model: Hybrid Approach
+
+After researching Hashgraph, IOTA Tangle, and AlephBFT, we chose a hybrid:
+
+| Approach | Pros for Omnia | Cons |
+|----------|---------------|------|
+| Pure Hashgraph | Virtual voting is elegant; proven throughput | Patented; requires complete history |
+| Pure IOTA | Simple tip selection; feeless | FPC finality not as strong as BFT |
+| Pure AlephBFT | Strong BFT guarantees; leaderless | Committee-based, not fully permissionless |
+| **Omnia Hybrid** | Causal ordering + CRDT convergence + simple BFT | Novel combination — needs thorough testing |
+
+- **Structure**: Hashgraph-like DAG with two-parent events
+- **Ordering**: Vector clock-based partial ordering
+- **Finality**: AlephBFT-inspired supermajority witness
+- **State**: CRDT semantics for deterministic convergence
+
+See `substrate/RESEARCH.md` for detailed comparative analysis.
+
+## Performance
+
+⚠️ The `CausalGraph` uses an `unprocessed_events` queue so that consensus only processes new events each round — O(new_events) processing. **Actual measured single-node throughput is ~527 events/sec** (see [benchmark-gates.md](../reference/benchmark-gates.md) for full benchmark results). Multi-node distributed throughput will be lower due to network latency and BFT consensus requirements. CausalGraph insertion is O(1) amortized via hash map operations, not O(1) guaranteed.
+
+## Testing Strategy
+
+Every module has comprehensive unit tests. The critical integration test simulates:
+- 3+ nodes in a network
+- Each node creates events
+- Events propagate via gossip
+- CRDT state converges to identical values on all nodes
+- Multi-node BFT finality validated (4 nodes, all tests passing)
+- All tests in: `substrate/tests/`
+
+---
+🔙 **Back**: [architecture/](./) | 🔄 **Related**: [pipeline-design.md](./pipeline-design.md)
+🚀 **Next**: [layer-2-shards.md](./layer-2-shards.md) | 📜 **Source of Truth**: [Restructuring Blueprint](../reference/blueprint-reference.md)

--- a/docs/architecture/layer-2-shards.md
+++ b/docs/architecture/layer-2-shards.md
@@ -1,0 +1,124 @@
+# Layer 2: Domain Shards
+> 🎯 Audience: Developers
+> 🔗 Context: Layer 2 organizes different types of activity into specialized lanes with optimized state management
+> 📅 Last Updated: 2026-05-20
+
+## Overview
+
+Layer 2 organizes different types of activity into specialized lanes, each with optimized consensus and state management. Each domain shard is a projection of the unified state that maintains its own state tree, processes transactions relevant to its domain (via `EventProcessor` trait), can reference state from other shards atomically, and contributes to the global state root.
+
+## Implemented Shards (6 total)
+
+| Shard | Purpose | Location |
+|-------|---------|----------|
+| 💰 Financial | Balances, transfers, replay protection | `shards/src/financial/` |
+| 🆔 Identity | DID management, credentials, social recovery | `shards/src/identity/` |
+| 📦 Physical | Object registration, provenance tracking | `shards/src/physical/` |
+| 🧮 Computational | AI training, proofs | `shards/src/computational/` |
+| 🧬 Biological | Health records, bio-signals, consent registry | `shards/src/biological/` |
+| 📊 Economics | UBC, governance, useful work | `shards/src/economics_shard.rs` |
+
+## ShardRouter
+
+The `ShardRouter` dispatches events to the correct shard by domain. Processing order:
+
+1. Deserialize payload into `ShardPayload`
+2. Check nonce for replay protection (`RedbNonceStore` for persistence)
+3. Look up fee via `FeeSchedule::fee_for_op()`
+4. Deduct fee from caller's UBC quota via `QuotaSystem::spend()`
+5. Route operation to target shard
+
+If the caller has insufficient UBC, the operation is rejected with `ShardError::InsufficientFee`.
+
+A `ShardRouter::new_without_fees()` constructor is available for testing.
+
+Located in: `shards/src/router.rs`
+
+## Cross-Shard Transactions
+
+Cross-shard messaging with causality proofs is implemented in `shards/src/cross_shard.rs`. A single transaction can atomically touch multiple shards via the `ShardRouter`. `CrossShardMessage` carries causality verification.
+
+## Fee Enforcement
+
+The `FeeSchedule` maps each `ShardOp` variant to a fixed `u64` fee:
+
+| Domain | Fee (UBC) |
+|--------|-----------|
+| Financial | 10 |
+| Computational | 5 |
+| Physical | 3 |
+| Identity | 2 |
+| Biological | 3 |
+| Cross-Shard | 15 |
+| Economics/Default | 3 |
+
+Fees are deducted atomically before shard dispatch. No fee refund on operation failure.
+
+## Replay Protection
+
+Per-creator nonce tracking with `RedbNonceStore` persistence across restarts. Production nodes **MUST** use persistent nonce storage; in-memory nonce tracking (the fallback when no data dir is configured) loses replay protection state on restart.
+
+## Key Shard Details
+
+### FinancialShard
+
+⚠️ The `FinancialShard` uses **strict causal ordering** (not CRDTs) for balance consistency. This is critical — using CRDTs for financial balances could lead to double-spend scenarios under concurrent operations.
+
+### IdentityShard
+
+- `did:omnia:` method with full validation (`shards/src/identity/did.rs`)
+- Shamir's Secret Sharing over GF(256) for social recovery (`shards/src/identity/recovery.rs`)
+- Privacy-preserving biometric anchors: `BLAKE3(salt || template)` — template never stored in cleartext (`shards/src/identity/biometric.rs`)
+- `AgentIdentity` with 5 capability types (`shards/src/identity/agent.rs`)
+- Encrypted share storage with AES-256-GCM
+- Recovery adds new key to DID authentication (rotation, not replacement)
+
+### PhysicalShard
+
+- `PhysicalOp::AnchorItem` creates immutable provenance entries
+- `PhysicalOp::TransferOwnership` records transfers in append-only log
+- `PhysicalOp::VerifyChain` validates complete provenance chain
+- `ProvenanceTracker` with full create/transfer/verify/destroy lifecycle
+
+### BiologicalShard
+
+- Consent registry with `ConsentRecord`
+- `BiologicalOp::GrantAccess` / `RevokeAccess` for patient-controlled data sharing
+- `BiologicalOp::QueryWithZkProof` — ZK proof for privacy-preserving queries (stub verifier for now)
+
+## Shard Architecture Diagram
+
+```
+┌─────────────┐    ┌─────────────┐    ┌─────────────┐
+│  Financial  │    │  Identity   │    │  Physical   │
+│   Shard ✅  │    │   Shard ✅  │    │   Shard ✅  │
+└──────┬──────┘    └──────┬──────┘    └──────┬──────┘
+       │                  │                  │
+       └────────┬─────────┴────────┬────────┘
+                │                  │
+         ┌──────┴──────┐    ┌──────┴──────┐
+         │ Computational│    │  Biological │
+         │   Shard ✅   │    │   Shard ✅  │
+         └──────┬──────┘    └──────┬──────┘
+                │                  │
+                └────────┬─────────┘
+                         │
+                  ┌──────┴──────┐
+                  │  Economics  │
+                  │   Shard ✅  │
+                  └──────┬──────┘
+                         │
+                  ┌──────┴──────┐
+                  │  ShardRouter│
+                  │ (EventProc) │
+                  └──────┬──────┘
+                         │
+                  ┌──────┴──────┐
+                  │  Substrate  │
+                  │ (CausalGraph│
+                  └─────────────┘
+```
+
+---
+🔙 **Back**: [architecture/](./) | 🔄 **Related**: [trait-boundaries.md](./trait-boundaries.md)
+🚀 **Next**: [layer-3-binding.md](./layer-3-binding.md) | 📜 **Source of Truth**: [Restructuring Blueprint](../reference/blueprint-reference.md)

--- a/docs/architecture/layer-3-binding.md
+++ b/docs/architecture/layer-3-binding.md
@@ -1,0 +1,80 @@
+# Layer 3: The Binding Layer
+> 🎯 Audience: Developers
+> 🔗 Context: Layer 3 anchors the digital system to physical reality without requiring trusted intermediaries
+> 📅 Last Updated: 2026-05-20
+
+## Overview
+
+The Binding Layer anchors the digital system to physical reality without requiring trusted intermediaries (oracles). It provides provenance tracking, physical anchoring, and post-quantum cryptographic commitments.
+
+## Components
+
+### ProvenanceLog — ✅ Implemented
+
+The provenance log is fully implemented as an append-only CRDT. It provides:
+
+- Create, transfer, verify, destroy lifecycle for tracked items
+- Complete ownership history (cryptographic birth certificate)
+- No intermediaries needed for verification
+- `ProvenanceTracker` with full lifecycle management
+
+Located in: `binding/src/provenance.rs`
+
+### PhysicalAnchor — ✅ Implemented (with stubs)
+
+Combines RF fingerprinting stub, quantum commitments, and provenance into a unified verification interface.
+
+- RF fingerprinting is a stub (Hamming distance comparison); real implementation requires SDR hardware (HackRF/USRP)
+- Located in: `binding/src/anchor.rs`, `binding/src/rf_fingerprint.rs`, `binding/src/physical_shard.rs`
+
+### Quantum Commitments — ✅ Implemented
+
+The quantum commitment system uses a hybrid Ed25519 + CRYSTALS-Dilithium approach with phase transitions:
+
+```rust
+pub enum CommitmentPhase {
+    ClassicalOnly = 0,  // Only Ed25519 verified
+    Hybrid = 1,         // Both Ed25519 and Dilithium verified
+    PostQuantum = 2,    // Only Dilithium verified
+}
+```
+
+- Both `verify_ed25519()` and `verify_dilithium()` perform real cryptographic verification
+- ML-KEM-768 (FIPS-203 standardized Kyber768) key encapsulation for post-quantum key exchange
+- Constant-time comparisons via `subtle::ConstantTimeEq`
+- X25519 ECDH + ML-KEM-768 hybrid mode for defense-in-depth
+
+Located in: `binding/src/quantum_commit.rs`
+
+### PQC Key Rotation — ✅ Implemented
+
+`PqcKeyRotationManager` handles phase transitions automatically:
+
+- Enforces that phases only advance forward (ClassicalOnly → Hybrid → PostQuantum)
+- Key rotation requires authorization signature from old key
+- Rotation state persisted as JSON, recoverable after process restart
+- `KeyStoreBridge` integrates with `EncryptedKeyStore` for persistent rotation state
+
+Located in: `binding/src/key_rotation.rs`, `binding/src/keystore_bridge.rs`
+
+### Biometric Binding — ✅ Implemented
+
+Privacy-preserving biometric anchors using `BLAKE3(salt || template)`. The template is never stored in cleartext.
+
+Located in: `shards/src/identity/biometric.rs`
+
+## What's a Stub ⚠️
+
+| Feature | Status | What's Needed |
+|---------|--------|---------------|
+| RF fingerprinting | ⚠️ Stub | SDR hardware (HackRF/USRP) for real RF-DNA feature extraction |
+| Physical time anchors | 🌑 Not Implemented | Previously described as "Gravitational Timestamps" — protocol relies on logical time via vector clocks |
+| Satellite mesh | 🌑 Not Implemented | GPS + Galileo + Starlink cross-validation for location verification |
+
+## Cryptographic Migration
+
+For the migration playbook if any cryptographic primitive is compromised, see [crypto-migration.md](../reference/crypto-migration.md).
+
+---
+🔙 **Back**: [architecture/](./) | 🔄 **Related**: [layer-4-identity.md](./layer-4-identity.md)
+🚀 **Next**: [layer-4-identity.md](./layer-4-identity.md) | 📜 **Source of Truth**: [Restructuring Blueprint](../reference/blueprint-reference.md)

--- a/docs/architecture/layer-4-identity.md
+++ b/docs/architecture/layer-4-identity.md
@@ -1,0 +1,86 @@
+# Layer 4: Identity Hardening
+> 🎯 Audience: Developers
+> 🔗 Context: Layer 4 enables self-sovereign identity where individuals, AI agents, and collectives own their identity forever
+> 📅 Last Updated: 2026-05-20
+
+## Overview
+
+Identity is implemented within the `omnia-shards` crate (`IdentityShard`), not as a separate crate/layer. It provides self-sovereign identity where individuals, AI agents, and collectives own their identity forever.
+
+## Components
+
+### Decentralized Identifiers (DIDs) — ✅ Implemented
+
+The `did:omnia:` method is fully implemented with validation.
+
+**Format:** `did:omnia:<hex_public_key>` where `<hex_public_key>` is a 64-character hex string representing a 32-byte Ed25519 public key.
+
+**Validation rules** (implemented in `shards/src/identity/did.rs`):
+- Must start with `did:omnia:` (the `DID_PREFIX` constant)
+- The method-specific identifier must be exactly 64 hex characters (32 bytes)
+- The hex must be valid (no non-hex characters)
+
+**Properties:**
+- You create it yourself (no authority issues it)
+- It's cryptographically verifiable
+- It cannot be revoked or censored
+- It's portable across platforms
+
+### Shamir's Secret Sharing — ✅ Implemented
+
+Social recovery uses **Shamir's Secret Sharing over GF(256)** (implemented in `shards/src/identity/recovery.rs`):
+
+1. Your key is split into N shares using `ShamirRecovery::split(secret, threshold, total)`
+2. Any threshold number of shares (e.g., 3 of 5) can reconstruct the key via `ShamirRecovery::reconstruct(shares)`
+3. If you lose your key, guardians provide their shares
+4. The key is reconstructed from the threshold number of shares using Lagrange interpolation
+5. No single guardian has your full key (K-1 shares reveal nothing)
+
+The GF(256) arithmetic uses the AES irreducible polynomial (0x11B) for reduction. The threshold must be at least 2.
+
+**Recovery flow:**
+- `IdentityOp::ConfigureRecovery` — splits secret, persists encrypted shares
+- `IdentityOp::RecoverDid` — reconstructs secret, derives new Ed25519 keypair, adds to `doc.authentication` (rotation, not replacement)
+- `recovery_count` incremented to prevent replay attacks
+- Encrypted share storage with AES-256-GCM (BLAKE3 + HKDF-SHA256 key derivation)
+
+### Biometric Anchors — ✅ Implemented
+
+Privacy-preserving biometric anchors using `BLAKE3(salt || template)`. The raw template is never stored in cleartext.
+
+Located in: `shards/src/identity/biometric.rs`
+
+### AI Agent Identity — ✅ Implemented
+
+AI agent identities with 5 capability types (in `shards/src/identity/agent.rs`):
+
+```rust
+pub enum AgentCapability {
+    FinancialTransfer { max_amount: u64, currency: String },
+    DataProcessing { domains: Vec<String>, max_records: u64 },
+    ContractExecution { contract_types: Vec<String> },
+    ComputeProof { max_compute_units: u64 },
+    GovernanceVote { max_weight: u64 },
+}
+```
+
+The `GovernanceVote` capability includes a `max_weight` parameter that limits the agent's maximum quadratic voting weight.
+
+### Social Recovery — ✅ Implemented
+
+Social recovery with configurable guardian threshold. The `IdentityOp::ConfigureRecovery` operation splits the secret and stores the threshold/total configuration. The `IdentityOp::RecoverDid` operation reconstructs the secret from K+ shares.
+
+The reconstructed secret is used to rotate the DID's public key and authentication methods via `complete_recovery()`, which adds the recovered key to DID authentication (rotation, not replacement). A `recovery_count` is incremented to prevent replay attacks.
+
+## Reputation System — Partially Implemented
+
+| Component | Status |
+|-----------|--------|
+| ✅ Exponential reputation decay | Implemented (fixed-point PPM arithmetic) |
+| ✅ Quadratic voting weight calculation | Implemented |
+| 🌑 Full reputation scoring | Not yet implemented |
+| 📋 Reputation thresholds | Planned |
+
+---
+🔙 **Back**: [architecture/](./) | 🔄 **Related**: [layer-3-binding.md](./layer-3-binding.md)
+🚀 **Next**: [layer-5-economics.md](./layer-5-economics.md) | 📜 **Source of Truth**: [Restructuring Blueprint](../reference/blueprint-reference.md)

--- a/docs/architecture/layer-5-economics.md
+++ b/docs/architecture/layer-5-economics.md
@@ -1,0 +1,115 @@
+# Layer 5: Economics
+> 🎯 Audience: Developers
+> 🔗 Context: Layer 5 creates a monetary system that serves people, not extracts from them
+> 📅 Last Updated: 2026-05-20
+
+## Overview
+
+The Economics layer implements a monetary system designed to serve participants through Universal Basic Compute, quadratic voting, and a fee-based sustainability model.
+
+## Universal Basic Compute (UBC) — ✅ Implemented
+
+Every identity receives a soulbound (non-transferable) monthly quota via the UBC token (implemented in `economics/src/ubc.rs`).
+
+Key parameters (from `economics/src/quota.rs`):
+- **Default quota**: 1,000 UBC/month (`DEFAULT_UBC_QUOTA`)
+- **Epoch duration**: 30 days (2,592,000,000 ms, `DEFAULT_EPOCH_DURATION_MS`)
+- **Monthly reset**: Balances are reset to the monthly quota at each epoch boundary; unspent balance is forfeited (anti-hoarding)
+- **Useful-work rewards**: Extra UBC can be earned via `UbcToken::reward()` (additive, not reset)
+
+### UBC Token Model
+
+- `UbcToken::mint_monthly()` — resets balance to monthly quota at epoch boundaries
+- `UbcToken::spend()` — consumes UBC for transactions (destroyed, not transferred)
+- `UbcToken::reward()` — adds UBC for useful-work contributions (additive, not reset at epoch boundaries)
+
+UBC tokens are **soulbound** — they cannot be transferred between identities.
+
+### Proof-of-Useful-Work — ⚠️ Stub
+
+3 work types defined in `economics/src/useful_work.rs`:
+- `AiTraining { model_hash, training_data_hash }` — AI model training
+- `ScientificSimulation { simulation_id, params_hash }` — Distributed computation
+- `DistributedStorage { data_hash, storage_duration }` — Data hosting
+
+Verification is currently a stub (`UsefulWorkProof::verify_stub()`) that checks for non-zero result hash and positive compute units. Reward amount equals compute units consumed (1:1 ratio).
+
+## Governance — ✅ Implemented (partially)
+
+### Quadratic Voting
+
+Voting power = `isqrt(stake)`, where `isqrt` is the integer square root via Newton's method defined in `economics/src/fixed_point.rs`.
+
+**Effect:** One large stakeholder has proportionally less power than many small stakeholders. This prevents whale dominance while still rewarding commitment.
+
+Implemented in `economics/src/governance.rs` with multiplicative reputation decay using fixed-point PPM arithmetic (no floating-point). The `VoteChoice` enum supports For, Against, Abstain.
+
+### Reputation Decay
+
+Decay formula (fixed-point PPM arithmetic, no f64):
+
+```
+effective_weight = base_weight * remaining_ppm / BASIS_PPM
+where remaining_ppm = (BASIS_PPM - decay_rate.ppm())^epochs / BASIS_PPM^epochs
+```
+
+Default decay rate: `DecayRate::ten_percent()` = 100,000 PPM per epoch.
+
+**Effect:** Power cannot concentrate. Even early adopters must stay active to maintain influence.
+
+### Time-Locked Voting — ✅ Implemented
+
+Stake must be locked for a minimum duration before it grants voting power, preventing flash loan attacks:
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `min_lock_duration` | 100 blocks | Minimum lock (~8 min at 5s finality) |
+| `max_lock_duration` | 100,000 blocks | Maximum lock (~6 days at 5s finality) |
+| `strict_enforcement` | true | No early withdrawals |
+
+Freshly-locked stake has zero voting power until the lock matures.
+
+### Governance Quorum — ✅ Implemented
+
+`GovernanceState::quorum_percentage` (default 67%) — total votes cast must represent ≥ 67% of total possible voting weight.
+
+Time-lock: `GovernanceState::time_lock_ms` (default 86,400,000 ms = 24 hours) — after finalization, `execution_time` is set to `current_time_ms + time_lock_ms`.
+
+### What's Not Yet Implemented
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Conviction voting | 📋 Planned | Graduated multipliers based on lock duration |
+| Delegation | 📋 Planned | Delegating voting power to trusted representatives |
+| Treasury | 🌑 Aspirational | No transaction fee distribution mechanism |
+| RPGF | 🌑 Aspirational | Retroactive Public Goods Funding — no implementation |
+
+## Slashing — ✅ Implemented
+
+The `SlashingEngine` tracks three offense types with configurable thresholds. ADR-011 defines a gradual slashing model with 3-tier escalation:
+
+| Offense | 1st | 2nd | 3rd+ |
+|---------|-----|-----|-------|
+| Equivocation | Jailed (5%, 1000r) | Jailed (25%, 5000r) | Ejected (100%) |
+| LivenessViolation | Warning (1%) | Warning (1%) | Jailed (5%, 500r) |
+| InvalidAttestation | Warning (2%) | Jailed (10%, 2000r) | Ejected (100%) |
+
+Persistent storage via `RedbSlashingStore`. The `omnia-node` binary configures redb persistence automatically.
+
+## Fee Structure — ✅ Implemented
+
+The `FeeSchedule` maps operations to fixed UBC fees:
+
+| Category | Fee (UBC) |
+|----------|-----------|
+| Identity operations | 2 |
+| Physical operations | 3 |
+| Biological operations | 3 |
+| Economics/Default | 3 |
+| Computational operations | 5 |
+| Financial operations | 10 |
+| Cross-shard operations | 15 |
+
+---
+🔙 **Back**: [architecture/](./) | 🔄 **Related**: [layer-4-identity.md](./layer-4-identity.md)
+🚀 **Next**: [zk-rollup-settlement.md](./zk-rollup-settlement.md) | 📜 **Source of Truth**: [Restructuring Blueprint](../reference/blueprint-reference.md)

--- a/docs/architecture/pipeline-design.md
+++ b/docs/architecture/pipeline-design.md
@@ -1,0 +1,102 @@
+# Consensus Pipeline Design
+> 🎯 Audience: Developers
+> 🔗 Context: Consensus pipeline, mempool, leader selection, and queue invariants
+> 📅 Last Updated: 2026-05-20
+
+## Overview
+
+This document describes the consensus pipeline — the mechanism that makes consensus processing O(new_events) instead of O(total_events), the mempool for pending events, and the leader selection process.
+
+## The Consensus Queue
+
+The consensus queue (`Substrate::unprocessed_events`) is the mechanism that makes consensus processing O(new_events) instead of O(n). Without the queue, the consensus engine would need to scan the entire causal graph on each iteration to find unprocessed events.
+
+### Why the Queue Makes Consensus O(new_events) Instead of O(n)
+
+When a new event arrives (either locally via `submit_event()` or from the network via gossip), its `EventId` is appended to the queue. When `process_consensus()` runs, it drains the queue entirely:
+
+```rust
+pub async fn process_consensus(&mut self) -> Vec<EventId> {
+    let graph = self.graph.read().await;
+    let mut all_committed = Vec::new();
+    let to_process: Vec<EventId> = self.unprocessed_events.drain(..).collect();
+    for id in &to_process {
+        if let Some(event) = graph.get(id) {
+            if let Ok(committed) = self.consensus.process_event(event, &graph) {
+                all_committed.extend(committed);
+            }
+        }
+    }
+    all_committed
+}
+```
+
+This makes each consensus iteration O(k), where k is the number of new events since the last iteration.
+
+## Queue Invariants
+
+### Invariant 1: Every Event in `unprocessed_events` Is Already in the Graph
+
+For every `EventId` in `unprocessed_events`, there exists a corresponding `Event` in `CausalGraph`. Events are inserted into the graph *before* their IDs are added to the queue.
+
+### Invariant 2: `process_consensus()` Drains the Queue Completely Each Call
+
+After `process_consensus()` returns, `unprocessed_events` is empty. The method uses `self.unprocessed_events.drain(..).collect()`.
+
+### Invariant 3: No Event Is Processed by Consensus Before It Is in the Graph
+
+The `ConsensusEngine::process_event()` method is never called with an event that is not in the `CausalGraph`.
+
+### Invariant 4: The Queue May Contain Duplicate Event IDs
+
+There is no deduplication at the queue level. This is safe because `ConsensusEngine::process_event()` is idempotent — it returns `Ok(Vec::new())` for already-processed events.
+
+## Duplicate Event Handling (3 Levels)
+
+1. **Gossip deduplication**: `seen_events: HashSet<[u8; 32]>` — duplicates dropped before reaching the pending queue
+2. **CausalGraph idempotency**: `CausalGraph::insert()` returns `CausalGraphError::DuplicateEvent`
+3. **Consensus idempotency**: `ConsensusEngine::process_event()` checks `event_states.contains_key()` and returns early
+
+## Mempool
+
+A mempool for pending events with bounded size (default 10,000). Located in: `substrate/src/mempool.rs`.
+
+## Leader Selection
+
+VRF-based leader selection with stake weighting. `compute_leader()` called every round in the main consensus loop. Leader nodes produce proposal events via `propose_block()`.
+
+- V1: Ed25519 signature + BLAKE3 derivation (legacy)
+- V2: ECVRF with Fiat-Shamir + Ed25519 signatures (standard, target)
+- `select_leader_v2()` — Version-aware leader selection
+
+The 100ms sleep poll loop was replaced with `tokio::select!` + round timer. `process_consensus_round()` was extracted for clarity.
+
+Located in: `substrate/src/vrf.rs`, `substrate/src/lib.rs`
+
+See [ADR-012](../reference/adr-index.md#adr-012-vrf-construction-choice) and [ADR-015](../reference/adr-index.md#adr-015-leader-selection-consensus-loop) for the decision records.
+
+## Consensus State Persistence
+
+- `ConsensusStore` trait with `save_state()`, `load_state()`, `save_round()`, `load_round()`
+- `RedbConsensusStore` using redb embedded database with ACID guarantees
+- `ConsensusEngine::load_or_new()` restores from persisted state if available
+- `persist_state()` called after every round advancement
+
+Located in: `substrate/src/consensus_store.rs`
+
+See [ADR-018](../reference/adr-index.md#adr-018-consensus-state-persistence) for the decision record.
+
+## Performance Characteristics
+
+| Operation | Complexity | Notes |
+|-----------|-----------|-------|
+| Append to queue | O(1) | `Vec::push()` amortized |
+| Drain queue | O(k) | k = number of unprocessed events |
+| Consensus per event | O(k × ancestry) | Ancestry checks are O(k) in worst case |
+| Total per iteration | O(k) | Dominated by consensus, not queue management |
+
+The queue ensures that consensus processing scales with the rate of new events, not with the total history size.
+
+---
+🔙 **Back**: [architecture/](./) | 🔄 **Related**: [trait-boundaries.md](./trait-boundaries.md)
+🚀 **Next**: [crdt-convergence.md](./crdt-convergence.md) | 📜 **Source of Truth**: [Restructuring Blueprint](../reference/blueprint-reference.md)

--- a/docs/architecture/trait-boundaries.md
+++ b/docs/architecture/trait-boundaries.md
@@ -1,0 +1,105 @@
+# Trait Boundaries
+> 🎯 Audience: Developers
+> 🔗 Context: Cross-cutting trait contracts that define the boundaries between architectural layers
+> 📅 Last Updated: 2026-05-20
+
+## Overview
+
+The Omnia Protocol uses Rust traits to define strict boundaries between architectural layers. These traits serve as the contract interface that each component must implement, enabling testability, modularity, and clear separation of concerns.
+
+## Core Traits
+
+### EventProcessor — ADR-001
+
+The `EventProcessor` trait defines how each shard processes events. Every domain shard implements this trait.
+
+```rust
+pub trait EventProcessor {
+    fn validate(&self, event: &Event) -> Result<(), EventProcessorError>;
+    fn process_event(&mut self, event: &Event) -> Result<(), EventProcessorError>;
+    fn state_snapshot(&self) -> Result<ShardState, EventProcessorError>;
+}
+```
+
+**Key decisions (ADR-001):**
+- `validate()` takes `&self` (no mutation) — validation is side-effect-free
+- `process_event()` takes `&mut self` — explicit mutation
+- `state_snapshot()` takes `&self` — no hidden mutation through validate or snapshot
+- No interior mutability (`RefCell`, `Mutex`, etc.) — ensures deterministic state machines
+
+See [ADR-001](../reference/adr-index.md#adr-001-event-processor-trait) for the full decision record.
+
+### SettlementLayer — ADR-002
+
+The `SettlementLayer` trait defines the interface for L1 settlement adapters.
+
+```rust
+pub trait SettlementLayer {
+    fn post_batch(&self, batch: &RollupBatch) -> Result<SettlementReceipt, SettlementError>;
+    fn verify_proof(&self, receipt: &SettlementReceipt) -> Result<bool, SettlementError>;
+    fn latest_state_root(&self) -> Result<[u8; 32], SettlementError>;
+    fn deposit(&self, deposit: &Deposit) -> Result<DepositReceipt, SettlementError>;
+    fn request_withdrawal(&self, withdrawal: &Withdrawal) -> Result<WithdrawalReceipt, SettlementError>;
+}
+```
+
+**Key decisions (ADR-002):**
+- Settlement-agnostic — any L1 with data availability and proof verification can implement this trait
+- Returns typed errors (`SettlementError` enum), not strings
+- Ethereum adapter has dual mode: Simulated (default) and Live (feature-gated)
+
+See [ADR-002](../reference/adr-index.md#adr-002-settlement-layer-trait) for the full decision record.
+
+### Gossip Substrate Interface — ADR-003
+
+Defines the boundary between the gossip protocol and the substrate layer.
+
+**Key decisions (ADR-003):**
+- Gossip handles event propagation; substrate handles event ordering and consensus
+- Events are immutable once created — gossip cannot modify them
+- Deduplication at three levels: gossip `seen_events`, CausalGraph duplicate check, consensus idempotency
+
+See [ADR-003](../reference/adr-index.md#adr-003-gossip-substrate-interface) for the full decision record.
+
+### Proof Bundle Format — ADR-005
+
+Defines the serialized format for ZK proof bundles exchanged between the prover and settlement layer.
+
+See [ADR-005](../reference/adr-index.md#adr-005-proof-bundle-format) for the full decision record.
+
+### Shard Trait Contract — ADR-006
+
+Defines the `Shard` trait that each domain shard must implement, including fee enforcement and nonce tracking.
+
+See [ADR-006](../reference/adr-index.md#adr-006-shard-trait-contract) for the full decision record.
+
+### Binding Shard Interface — ADR-007
+
+Defines how the binding layer interfaces with the shard system for provenance and quantum commitments.
+
+See [ADR-007](../reference/adr-index.md#adr-007-binding-shard-interface) for the full decision record.
+
+## Supporting ADRs
+
+| ADR | Title | Key Decision |
+|-----|-------|-------------|
+| ADR-008 | Crypto Dependency Audit | Audit of cryptographic dependency versions |
+| ADR-009 | Poseidon Parameter Justification | Cauchy MDS + BLAKE3 round constants |
+| ADR-010 | Encrypted Keystore Design | AES-256-GCM + HKDF-SHA256 |
+| ADR-011 | Gradual Slashing Model | 3-tier Warning → Jail → Ejection |
+| ADR-012 | VRF Construction Choice | V1 legacy + V2 ECVRF target |
+| ADR-013 | DKG Protocol Selection | Feldman VSS-based DKG |
+| ADR-014 | Poseidon Parameter Migration | Dual-hash transition strategy |
+| ADR-015 | Leader Selection in Consensus Loop | VRF-based, stake-weighted |
+| ADR-016 | Kademlia DHT Configuration | `/omnia/kad/1.0.0`, AutoNAT/Relay/DCutr |
+| ADR-017 | GossipSub Peer Scoring Thresholds | Graylist at -100 |
+| ADR-018 | Consensus State Persistence | RedbConsensusStore, load_or_new |
+| ADR-019 | Fast-Sync Protocol | BLAKE3 checkpoints, supermajority |
+| ADR-020 | Kyber KEM / ML-KEM Integration | FIPS-203, wire-compatible |
+| ADR-021 | Gossip Message Compression | Snappy for >256 bytes |
+
+See [adr-index.md](../reference/adr-index.md) for the complete ADR index with summaries.
+
+---
+🔙 **Back**: [architecture/](./) | 🔄 **Related**: [pipeline-design.md](./pipeline-design.md)
+🚀 **Next**: [pipeline-design.md](./pipeline-design.md) | 📜 **Source of Truth**: [Restructuring Blueprint](../reference/blueprint-reference.md)

--- a/docs/architecture/vector-clock-reconciliation.md
+++ b/docs/architecture/vector-clock-reconciliation.md
@@ -1,0 +1,171 @@
+# Vector Clock Reconciliation Strategy
+> 🎯 Audience: Developers
+> 🔗 Context: Strategy for restoring deterministic ordering after network partition healing
+> 📅 Last Updated: 2026-05-20
+
+## Overview
+
+Vector clocks are the foundation of Omnia's causal ordering system. After a network partition heals, vector clocks across nodes may have diverged. This document describes the reconciliation strategy that ensures deterministic ordering is restored post-merge.
+
+## Vector Clock Basics
+
+A `VectorClock` (implemented in `substrate/src/vector_clock.rs`) is a map of `NodeId → LogicalClock`. Each node maintains its own vector clock, incrementing its own entry each time it creates an event. When a node receives an event from another node, it merges the event's vector clock into its own using pointwise maximum:
+
+```rust
+pub fn merge(&mut self, other: &Self) {
+    for (node, &clock) in other.clocks.iter() {
+        let entry = self.clocks.entry(*node).or_insert(0);
+        *entry = (*entry).max(clock);
+    }
+}
+```
+
+Vector clocks enable three fundamental operations:
+
+1. **`happened_before()`**: Returns `true` if all entries in `self` are ≤ corresponding entries in `other`, with at least one strict inequality. This means `self` causally precedes `other`.
+2. **`concurrent()`**: Returns `true` if neither clock is ≤ the other — i.e., some entries in `self` are greater and some are less. Concurrent events are causally independent and can be processed in parallel.
+3. **`merge()`**: Takes the pointwise maximum of both clocks, representing combined causal knowledge.
+
+## Network Partition Scenario
+
+Consider a network of 4 nodes (A, B, C, D) that splits into two partitions: {A, B} and {C, D}.
+
+**Before partition:**
+```
+Node A: {A:5, B:4, C:3, D:3}
+Node B: {A:5, B:4, C:3, D:3}
+Node C: {A:5, B:4, C:3, D:3}
+Node D: {A:5, B:4, C:3, D:3}
+```
+
+**During partition (events continue locally):**
+```
+Node A: {A:8, B:7, C:3, D:3}   (3 new events from A, 3 from B)
+Node B: {A:8, B:7, C:3, D:3}
+Node C: {A:5, B:4, C:6, D:5}   (3 new events from C, 2 from D)
+Node D: {A:5, B:4, C:6, D:5}
+```
+
+**After partition heals (each node merges with the other partition):**
+```
+Node A: {A:8, B:7, C:6, D:5}   (merged with C/D's clocks)
+Node B: {A:8, B:7, C:6, D:5}
+Node C: {A:8, B:7, C:6, D:5}   (merged with A/B's clocks)
+Node D: {A:8, B:7, C:6, D:5}
+```
+
+After merging, all nodes converge to the same vector clock. This is the CRDT property of vector clocks: `merge()` is commutative, associative, and idempotent.
+
+## VectorClock::merge() Uses Pointwise Max (CRDT Semantics)
+
+The `merge()` operation is a CvRDT (state-based CRDT) merge. It takes the pointwise maximum of each entry:
+
+```rust
+*entry = (*entry).max(clock);
+```
+
+This has several important properties:
+
+1. **Commutativity**: `a.merge(b)` produces the same result as `b.merge(a)`. The order in which partitions merge does not matter.
+
+2. **Associativity**: `a.merge(b).merge(c)` produces the same result as `a.merge(b.merge(c))`. Multi-way merges produce the same result regardless of grouping.
+
+3. **Idempotency**: `a.merge(a)` is a no-op. Merging with yourself changes nothing.
+
+4. **Monotonicity**: `merge()` only increases entries (takes the max). Vector clocks never decrease.
+
+These properties guarantee that after all partitions have exchanged their vector clocks, all nodes converge to the same state — the "least upper bound" of all observed clocks.
+
+## CausalOrder Remains Deterministic Post-Merge
+
+After a partition heals and vector clocks are merged, the `CausalOrder` between any two events remains deterministic. This is because:
+
+**`happened_before` is transitive.** If event X happened before event Y, and event Y happened before event Z, then X happened before Z. This transitivity is preserved after merge because:
+
+- If `X.vc ≤ Y.vc` before merge, then `X.vc ≤ Y.vc` after merge (since merge only adds information, never removes it).
+- The `all_less_equal()` check in `VectorClock::compare()` considers all known nodes, so after merge, previously unknown entries (from the other partition) are included in the comparison.
+
+**Concurrent events remain concurrent after merge.** If two events were concurrent before the partition (neither's vector clock is ≤ the other's), they remain concurrent after merge. Merge only adds entries; it never makes a previously-concurrent pair non-concurrent.
+
+**Example:**
+```
+Before partition:
+  Event E1: {A:2, B:0}  (created by A)
+  Event E2: {A:0, B:2}  (created by B)
+  E1.concurrent(E2) → true  (neither ≤ the other)
+
+After partition heals and clocks merge:
+  Event E1: {A:2, B:0}  (unchanged — events are immutable)
+  Event E2: {A:0, B:2}  (unchanged)
+  E1.concurrent(E2) → true  (still concurrent)
+
+Node's frontier clock: {A:2, B:2}  (merged knowledge)
+```
+
+The events' vector clocks are immutable — they were set when the event was created and never change. The merge only affects the node's *view* of the network's causal knowledge, not the events themselves.
+
+## How Concurrent Events After Merge Are Handled
+
+After a partition heals, some events from the two partitions will be concurrent — they were created independently during the partition. These concurrent events are handled by topological sort:
+
+The `CausalGraph::topological_order()` method produces a deterministic ordering of events that respects causal dependencies:
+
+1. Events are ordered so that every event appears after all its causal predecessors (parents).
+2. Concurrent events are ordered deterministically by timestamp, then by event hash.
+
+```rust
+queue_vec.sort_by(|a, b| {
+    let event_a = self.events.get(a).unwrap();
+    let event_b = self.events.get(b).unwrap();
+    event_a
+        .timestamp
+        .cmp(&event_b.timestamp)
+        .then_with(|| a.cmp(b))
+});
+```
+
+This ensures that all nodes produce the same topological order for the same set of events, even when some events are concurrent. The tiebreaker is the event ID (a SHA-256 hash), which is globally unique and deterministic.
+
+**Important caveat**: The timestamp tiebreaker uses wall-clock time, which may differ across nodes. In Phase 0, this is acceptable because the BFT consensus engine provides finality regardless of topological order. In future phases, the timestamp ordering should be replaced with a purely deterministic tiebreaker (e.g., lexicographic comparison of event IDs) to ensure all nodes produce identical orderings.
+
+## Partition Detection
+
+Partition detection is **not** part of the vector clock reconciliation strategy. The current design assumes that:
+
+1. Partitions are detected eventually (via gossip failure or timeout).
+2. Healing occurs when network connectivity is restored.
+3. Vector clock reconciliation happens automatically through the gossip protocol's `process_pending_events()` mechanism.
+
+When a partition heals and events from the other partition start arriving, the `GossipProtocol` processes them normally:
+
+1. Events are deserialized from gossip bytes.
+2. Events are inserted into the `CausalGraph` (which validates parent links and detects duplicates).
+3. Event IDs are added to `unprocessed_events`.
+4. `process_consensus()` processes the newly arrived events.
+
+The vector clocks embedded in these events carry the causal context from the other partition, and the `CausalGraph` merges them into its frontier:
+
+```rust
+self.frontier.merge(&event.vector_clock);
+```
+
+This automatic reconciliation means that no special "partition healing" protocol is needed at the vector clock level. The CRDT properties of `merge()` guarantee convergence.
+
+## Guarantees and Limitations
+
+### Guarantees
+
+1. **Convergence**: After all partitions have exchanged events, all nodes' `CausalGraph::frontier` clocks converge to the same value.
+2. **Causality preservation**: The `happened_before` relationship is never violated by merge — if X causally preceded Y before the partition, X still causally precedes Y after merge.
+3. **Deterministic ordering**: `topological_order()` produces a consistent ordering of concurrent events across all nodes (with the caveat about timestamps).
+
+### Limitations
+
+1. **No automatic partition detection**: The system does not proactively detect partitions. It relies on the gossip protocol's timeout and retry mechanisms.
+2. **Timestamp-based tiebreaker**: The `topological_order()` method uses wall-clock timestamps as a primary tiebreaker for concurrent events. In a partitioned network, clocks may drift, leading to inconsistent orderings. This is mitigated by the BFT consensus engine.
+3. **Unbounded vector clock growth**: Each node adds an entry to the vector clock. Over time, the `BTreeMap` in `VectorClock` grows linearly with the number of nodes. The `prune_below()` method can reclaim entries for nodes that are no longer active.
+4. **Missing parent handling**: If a partition heals and events arrive before their parents, the `CausalGraph::insert()` method will reject them with `CausalGraphError::MissingParent`. The gossip protocol must retry or request missing events.
+
+---
+🔙 **Back**: [architecture/](./) | 🔄 **Related**: [crdt-convergence.md](./crdt-convergence.md)
+🚀 **Next**: [layer-1-substrate.md](./layer-1-substrate.md) | 📜 **Source of Truth**: [Restructuring Blueprint](../reference/blueprint-reference.md)

--- a/docs/architecture/zk-rollup-settlement.md
+++ b/docs/architecture/zk-rollup-settlement.md
@@ -1,0 +1,134 @@
+# ZK-Rollup Settlement Layer (Phase 0)
+> 🎯 Audience: Developers
+> 🔗 Context: Phase 0 implements settlement-agnostic ZK-rollup architecture for bridging to L1 chains
+> 📅 Last Updated: 2026-05-20
+
+## Overview
+
+Phase 0 implements the ZK-rollup settlement layer, providing a settlement-agnostic architecture that can bridge to any L1 chain with data availability and proof verification capabilities.
+
+## Settlement-Agnostic Architecture
+
+The `SettlementLayer` trait (`omnia-adapters/src/settlement/mod.rs`) defines the interface for all settlement adapters:
+
+```rust
+pub trait SettlementLayer {
+    fn post_batch(&self, batch: &RollupBatch) -> Result<SettlementReceipt, SettlementError>;
+    fn verify_proof(&self, receipt: &SettlementReceipt) -> Result<bool, SettlementError>;
+    fn latest_state_root(&self) -> Result<[u8; 32], SettlementError>;
+    fn deposit(&self, deposit: &Deposit) -> Result<DepositReceipt, SettlementError>;
+    fn request_withdrawal(&self, withdrawal: &Withdrawal) -> Result<WithdrawalReceipt, SettlementError>;
+}
+```
+
+## Ethereum Adapter — ✅ Implemented
+
+- **Simulated mode** (default): Full architecture, in-memory state transitions
+- **Live mode** (feature flag `ethereum-live`): Real RPC via `alloy` v1 with Anvil/Hardhat integration tests
+- Solidity contract: `OmniaRollup.sol` with Groth16 verification using EIP-196/197 BN254 precompiles
+- ABI: `omnia-adapters/contracts/ethereum/OmniaRollup.json`
+- Config validation: URL scheme, contract address format, operator key format
+- BLAKE3 domain-separated batch data hashing (`OMNIA-ETH-BATCH-DATA`)
+- Gas estimation and confirmation waiting with configurable `confirmation_blocks`
+
+Located in: `omnia-adapters/src/settlement/ethereum/`
+
+## Other Adapters — Stubs
+
+Bitcoin, Solana, and Celestia adapters are stubs that return `SettlementError::NotImplemented`.
+
+Located in: `omnia-adapters/src/settlement/`
+
+## ZK Circuit — ✅ Implemented
+
+### Groth16 Proof System
+
+- arkworks R1CS + Groth16 on BN254 curve
+- `RollupCircuit` — basic rollup circuit
+- `ExpandedRollupCircuit` — Merkle path verification + per-event state transition constraints
+- `ExpandedRollupCircuit::for_setup()` — uses non-zero witness fields for trusted setup key generation
+
+Located in: `omnia-adapters/src/circuit.rs`, `omnia-adapters/src/proof.rs`
+
+### Poseidon Hash
+
+- SNARK-friendly hash (BN254, t=3, R_F=8, R_P=57)
+- Dual-hash infrastructure: `PoseidonVersion::Custom` (default, deprecated) and `PoseidonVersion::Reference` (target)
+- Custom: Cauchy MDS + BLAKE3-derived round constants
+- Reference: Deterministic parameters with distinct Cauchy MDS construction and BLAKE3 domain `"Poseidon-Ref-BN254-t3-RF8-RP57"`
+- ⚠️ Parameters use Cauchy MDS matrix and BLAKE3-derived round constants (not Grain LFSR from Filecoin/Neptune paper)
+
+Located in: `omnia-adapters/src/poseidon.rs`
+
+See [ADR-014](../reference/adr-index.md#adr-014-poseidon-parameter-migration) for migration strategy.
+
+### Merkle Tree
+
+- Sparse Merkle tree with BLAKE3 off-circuit leaf hashing
+- `build_merkle_tree()`, `compute_root_from_proof()`, `merkle_proof()`
+- On-circuit compatible: `poseidon_hash_to_fr()` for ZK-friendly alternative
+
+Located in: `omnia-adapters/src/merkle.rs`
+
+### Operation Type Constraints
+
+- `OperationType` enum: Transfer, Mint, Burn, AnchorItem, QueryWithZkProof, SubmitTask, Govern, IdentityUpdate (8 values)
+- Bit decomposition constraints enforcing `operation_type ∈ [0, 7]`
+- `payload_hash` constraint: `payload_hash == Poseidon(event_hash, operation_type)`
+
+### Batch Verification
+
+- `verify_proofs_batch()` for efficient multi-proof verification
+- BLAKE3 domain separation (`OMNIA-BATCH-VRFY-V1`) for random scalar derivation
+- Handles empty batches, single proofs, and multi-proof batches
+
+## Trusted Setup Ceremony — ✅ Implemented
+
+### Powers of Tau
+
+- `PowersOfTau` SRS initialized with generator points (not identity)
+- Transcript hash initialized with BLAKE3 domain separation (`OMNIA-SETUP-TRANSCRIPT-V1`)
+- Real EC operations with BN254 G1 scalar multiplication
+- Fiat-Shamir Proof of Knowledge on BN254 G1
+
+### Ceremony Server/Client
+
+- `CeremonyServer` coordinator with lifecycle: `NotStarted` → `AcceptingContributions` → `Finalized`
+- `CeremonyClient` for generating and verifying contributions
+- CLI subcommands: `setup-contribute`, `setup-verify`
+- HTTP API stubs: `/ceremony/state`, `/ceremony/contribute`, `/ceremony/transcript`, `/ceremony/finalize`
+- `export_transcript()` for independent third-party verification
+
+Located in: `omnia-adapters/src/setup/`
+
+## L2 Operator
+
+The L2 operator with batch builder processes events into settlement batches.
+
+Located in: `omnia-adapters/src/operator.rs`
+
+## Settlement Architecture Diagram
+
+```
+┌───────────────────────────────────────────────┐
+│            Settlement-Agnostic ZK-Rollup      │
+├───────────────┬───────────────┬───────────────┤
+│  Ethereum ✅  │ Bitcoin 🔄    │  Solana 🔄    │
+│  (OmniaRollup │  (stub)       │  (stub)       │
+│   .sol)       │               │               │
+├───────────────┴───────────────┴───────────────┤
+│           SettlementLayer Trait                │
+├───────────────────────────────────────────────┤
+│         L2 Operator + Batch Builder           │
+├───────────────────────────────────────────────┤
+│      ZK Circuit (arkworks R1CS + Groth16) ✅  │
+├───────────────────────────────────────────────┤
+│    Merkle State Root + Inclusion Proofs        │
+├───────────────────────────────────────────────┤
+│         Event Pruning (sustainability)         │
+└───────────────────────────────────────────────┘
+```
+
+---
+🔙 **Back**: [architecture/](./) | 🔄 **Related**: [pipeline-design.md](./pipeline-design.md)
+🚀 **Next**: [trait-boundaries.md](./trait-boundaries.md) | 📜 **Source of Truth**: [Restructuring Blueprint](../reference/blueprint-reference.md)

--- a/docs/building/README.md
+++ b/docs/building/README.md
@@ -1,0 +1,35 @@
+# Building Omnia Protocol
+> 🎯 Audience: Developers
+> 🔗 Context: Index for build guides, feature profiles, and binary optimization
+> 📅 Last Updated: 2026-05-20
+
+## Prerequisites
+
+- Rust 1.85+ (see `rust-toolchain.toml` for exact version)
+- System dependencies: `build-essential`, `pkg-config`, `libssl-dev`
+- Docker and Docker Compose (for containerized deployment)
+
+## Build Documents
+
+| Document | Description |
+|----------|-------------|
+| [feature-matrix.md](feature-matrix.md) | Feature flags and build profiles — `ethereum-live`, default features |
+| [cross-compilation.md](cross-compilation.md) | Cross-compilation guide — Docker builds, target triples |
+| [binary-optimization.md](binary-optimization.md) | Binary size and release optimization — LTO, codegen-units, strip |
+
+## Quick Build
+
+```bash
+# Full workspace build
+cargo build --workspace
+
+# With Ethereum live mode (adds alloy dependency)
+cargo build --features ethereum-live
+
+# Release build (optimized)
+cargo build --release --workspace
+```
+
+---
+🔙 **Back**: [docs/](../) | 🔄 **Related**: [operations/](../operations/)
+🚀 **Next**: [feature-matrix.md](./feature-matrix.md) | 📜 **Source of Truth**: [Restructuring Blueprint](../reference/blueprint-reference.md)

--- a/docs/building/binary-optimization.md
+++ b/docs/building/binary-optimization.md
@@ -1,0 +1,61 @@
+# Binary Optimization
+> 🎯 Audience: Developers
+> 🔗 Context: Binary size and release optimization for the omnia-node binary
+> 📅 Last Updated: 2026-05-20
+
+## Release Profile Configuration
+
+The workspace `Cargo.toml` includes aggressive release optimization settings:
+
+```toml
+[profile.release]
+panic = "abort"        # No unwinding — smaller binary
+lto = "fat"            # Full cross-crate LTO for maximum dead-code elimination
+codegen-units = 1      # Single codegen unit for maximum optimization
+strip = "symbols"      # Strip debug symbols
+debug = false          # No debug info
+```
+
+**Target:** ≤12MB binary size for `omnia-node`.
+
+## Build Commands
+
+```bash
+# Optimized release build
+cargo build --release -p omnia-node
+
+# Check binary size
+ls -lh target/release/omnia-node
+
+# With Ethereum live mode (adds alloy, increases binary size)
+cargo build --release -p omnia-node --features ethereum-live
+```
+
+## Size Reduction Techniques
+
+### What We Already Do
+
+1. **`panic = "abort"`** — Removes unwinding infrastructure (~100-200KB savings)
+2. **`lto = "fat"`** — Cross-crate inlining and dead-code elimination (significant savings)
+3. **`codegen-units = 1`** — Allows the optimizer to see the full picture
+4. **`strip = "symbols"`** — Removes debug symbols
+
+### Further Optimization (Future)
+
+- **`upx` compression** — Additional binary compression for distribution
+- **Feature-gated dependencies** — Keep heavy deps like `alloy` behind feature flags
+- **Minimal runtime** — Exclude unnecessary default features from dependencies
+
+## Reproducible Builds
+
+A reproducible build script is available:
+
+```bash
+./scripts/reproducible-build.sh
+```
+
+This ensures deterministic binary output across build environments. The script pins the Rust toolchain, sets deterministic environment variables, and verifies the build hash.
+
+---
+🔙 **Back**: [building/](./) | 🔄 **Related**: [feature-matrix.md](./feature-matrix.md)
+🚀 **Next**: [../operations/](../operations/) | 📜 **Source of Truth**: [Restructuring Blueprint](../reference/blueprint-reference.md)

--- a/docs/building/cross-compilation.md
+++ b/docs/building/cross-compilation.md
@@ -1,0 +1,93 @@
+# Cross-Compilation Guide
+> 🎯 Audience: Developers
+> 🔗 Context: Building Omnia Protocol for different target platforms
+> 📅 Last Updated: 2026-05-20
+
+## Docker Build (Recommended)
+
+The easiest way to build for any platform is using the provided Dockerfile:
+
+```bash
+# Build the Docker image
+docker build -f docker/Dockerfile -t omnia-protocol/omnia-node:latest .
+
+# Build for a specific platform
+docker build --platform linux/amd64 -f docker/Dockerfile -t omnia-protocol/omnia-node:amd64 .
+docker build --platform linux/arm64 -f docker/Dockerfile -t omnia-protocol/omnia-node:arm64 .
+```
+
+The Docker image uses `rust:1.85-slim-bookworm` as the build environment and produces a minimal runtime image.
+
+## Native Cross-Compilation
+
+### Linux x86_64 (Default)
+
+```bash
+cargo build --release --target x86_64-unknown-linux-gnu
+```
+
+### Linux ARM64 (aarch64)
+
+```bash
+rustup target add aarch64-unknown-linux-gnu
+cargo build --release --target aarch64-unknown-linux-gnu
+```
+
+### macOS
+
+```bash
+rustup target add x86_64-apple-darwin
+cargo build --release --target x86_64-apple-darwin
+
+# Apple Silicon
+rustup target add aarch64-apple-darwin
+cargo build --release --target aarch64-apple-darwin
+```
+
+### Windows
+
+```bash
+rustup target add x86_64-pc-windows-msvc
+cargo build --release --target x86_64-pc-windows-msvc
+```
+
+## Docker Compose 5-Node Testnet
+
+The Docker Compose configuration provides a complete 5-node testnet:
+
+```bash
+# Clone and build
+git clone https://github.com/Willow7737/omnia-protocol.git
+cd omnia-protocol
+
+# Create .env file
+cp docker/.env.example docker/.env
+# Edit docker/.env to set your Grafana admin password
+
+# Start the 5-node testnet
+docker compose -f docker/docker-compose.yml up -d
+
+# Start with monitoring (Grafana + Prometheus)
+docker compose -f docker/docker-compose.yml --profile monitoring up -d
+```
+
+## Kubernetes (Helm)
+
+For production deployment, use the Helm chart:
+
+```bash
+# Build and push the Docker image
+docker build -f docker/Dockerfile -t omnia-protocol/omnia-node:latest .
+docker push omnia-protocol/omnia-node:latest
+
+# Configure values
+cp helm/omnia-node/values.yaml my-values.yaml
+# Edit my-values.yaml
+
+# Install
+helm install omnia-node ./helm/omnia-node -f my-values.yaml
+```
+
+---
+🔙 **Back**: [building/](./) | 🔄 **Related**: [binary-optimization.md](./binary-optimization.md)
+🚀 **Next**: [binary-optimization.md](./binary-optimization.md) | 📜 **Source of Truth**: [Restructuring Blueprint](../reference/blueprint-reference.md)

--- a/docs/building/feature-matrix.md
+++ b/docs/building/feature-matrix.md
@@ -1,0 +1,82 @@
+# Feature Matrix
+> 🎯 Audience: Developers
+> 🔗 Context: Feature flags and build profiles for the Omnia Protocol workspace
+> 📅 Last Updated: 2026-05-20
+
+## Workspace Feature Flags
+
+### `ethereum-live` (omnia-adapters / zk crate)
+
+Enables real Ethereum settlement via `alloy` v1 dependency. Without this flag, the Ethereum adapter runs in **Simulated** mode (in-memory state transitions only).
+
+```toml
+# In omnia-adapters/Cargo.toml
+[features]
+default = []
+ethereum-live = ["alloy"]
+```
+
+**Effect on build:**
+- **Without flag**: Lightweight build, no alloy dependency (300+ sub-crates excluded)
+- **With flag**: Adds `alloy` v1 with contract bindings, real RPC calls, gas estimation
+- **CI**: Feature-gated tests run separately in `.github/workflows/ethereum-settlement.yml`
+
+### Default Features
+
+The workspace builds with minimal features by default. All core consensus, shards, binding, economics, and node functionality is available without feature flags.
+
+## Build Profiles
+
+### Release Profile
+
+Configured in workspace `Cargo.toml` for maximum optimization:
+
+```toml
+[profile.release]
+panic = "abort"        # No unwinding — smaller binary, no catch_unwind needed
+lto = "fat"            # Cross-crate inlining and dead-code elimination
+codegen-units = 1      # Maximum optimization opportunities
+strip = "symbols"      # Strip debug symbols from binary
+debug = false          # No debug info in release
+```
+
+Target: ≤12MB binary size for `omnia-node`.
+
+### Bench Profile
+
+Inherits release but keeps debug info for profiling:
+
+```toml
+[profile.bench]
+inherits = "release"
+debug = true
+strip = false
+```
+
+## Crate-Level Features
+
+| Crate | Feature | Effect |
+|-------|---------|--------|
+| `omnia-adapters` | `ethereum-live` | Real Ethereum RPC via Alloy (default: simulated) |
+| `substrate` | (none) | All substrate features included by default |
+| `shards` | (none) | All shard types included by default |
+| `binding` | (none) | PQC signatures, provenance included by default |
+| `economics` | (none) | UBC, governance, quota included by default |
+| `node` | (none) | All node features included by default |
+
+## Verification
+
+```bash
+# Check feature resolution
+cargo tree --features ethereum-live
+
+# Build with all features
+cargo build --all-features
+
+# Build without default features
+cargo build --no-default-features
+```
+
+---
+🔙 **Back**: [building/](./) | 🔄 **Related**: [cross-compilation.md](./cross-compilation.md)
+🚀 **Next**: [cross-compilation.md](./cross-compilation.md) | 📜 **Source of Truth**: [Restructuring Blueprint](../reference/blueprint-reference.md)

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -1,0 +1,37 @@
+# Operations Documentation
+> 🎯 Audience: Operators
+> 🔗 Context: Index for all operational guides, runbooks, and deployment procedures
+> 📅 Last Updated: 2026-05-20
+
+## Operations Documents
+
+| Document | Description |
+|----------|-------------|
+| [validator-setup.md](validator-setup.md) | Validator setup guide — key generation, node configuration, startup |
+| [monitoring.md](monitoring.md) | Monitoring setup — Grafana, Prometheus, alert rules |
+| [deployment.md](deployment.md) | Deployment procedures — Docker Compose, Kubernetes/Helm |
+| [runbook.md](runbook.md) | Operations runbook — key rotation, slashing, partition recovery |
+| [feature-flags.md](feature-flags.md) | Feature flag reference for operator configuration |
+
+## Quick Reference
+
+```bash
+# Start a node
+omnia-node --node-id 1 --http-port 8080
+
+# Check health
+curl http://localhost:8080/healthz
+
+# Check readiness
+curl http://localhost:8080/readyz
+
+# View metrics
+curl http://localhost:8080/metrics
+
+# Docker 5-node testnet
+docker compose -f docker/docker-compose.yml up -d
+```
+
+---
+🔙 **Back**: [docs/](../) | 🔄 **Related**: [building/](../building/)
+🚀 **Next**: [validator-setup.md](./validator-setup.md) | 📜 **Source of Truth**: [Restructuring Blueprint](../reference/blueprint-reference.md)

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -1,0 +1,105 @@
+# Deployment Procedures
+> 🎯 Audience: Operators
+> 🔗 Context: Deployment procedures for Docker Compose and Kubernetes/Helm
+> 📅 Last Updated: 2026-05-20
+
+## Quick Start: Docker Compose (Development)
+
+1. Clone the repository:
+   ```bash
+   git clone https://github.com/Willow7737/omnia-protocol.git
+   cd omnia-protocol
+   ```
+
+2. Create a `.env` file from the example:
+   ```bash
+   cp docker/.env.example docker/.env
+   # Edit docker/.env to set your Grafana admin password
+   ```
+
+3. Start the 5-node testnet:
+   ```bash
+   docker compose -f docker/docker-compose.yml up -d
+   ```
+
+4. Start monitoring (optional):
+   ```bash
+   docker compose -f docker/docker-compose.yml --profile monitoring up -d
+   ```
+
+5. Verify the nodes are running:
+   ```bash
+   curl http://localhost:9090/healthz
+   ```
+
+## Production Deployment: Kubernetes
+
+1. Build and push the Docker image:
+   ```bash
+   docker build -f docker/Dockerfile -t omnia-protocol/omnia-node:latest .
+   docker push omnia-protocol/omnia-node:latest
+   ```
+
+2. Configure the Helm chart values:
+   ```bash
+   cp helm/omnia-node/values.yaml my-values.yaml
+   # Edit my-values.yaml with your configuration
+   ```
+
+3. Install the Helm chart:
+   ```bash
+   helm install omnia-node ./helm/omnia-node -f my-values.yaml
+   ```
+
+4. Verify the deployment:
+   ```bash
+   kubectl get pods -l app=omnia-node
+   kubectl port-forward svc/omnia-node 9090:9090
+   curl http://localhost:9090/healthz
+   ```
+
+## Configuration
+
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `RUST_LOG` | `info` | Log level (trace, debug, info, warn, error) |
+| `OMNIA_NODE_ID` | (required) | Unique node identifier (u64) |
+| `OMNIA_BOOTSTRAP_NODES` | (empty) | Comma-separated list of bootstrap node addresses |
+| `OMNIA_LISTEN_ADDR` | `/ip4/0.0.0.0/tcp/9090` | Libp2p listen address |
+| `OMNIA_TOTAL_NODES` | `5` | Expected number of nodes in the network |
+| `OMNIA_DATA_DIR` | `/app/data` | Data directory for persistent storage |
+| `OMNIA_JWT_SECRET` | (none) | HMAC secret for JWT auth |
+| `OMNIA_AUTHORIZED_CALLERS` | (none) | Comma-separated authorized caller IDs |
+| `OMNIA_RATE_LIMIT_RPS` | (none) | Max requests per second per IP |
+
+### Configuration File
+
+See `node/omnia-node.toml.example` for the full configuration file format.
+
+## Upgrade Procedure
+
+1. Build the new Docker image with the updated version
+2. For Docker Compose: `docker compose pull && docker compose up -d`
+3. For Kubernetes: `helm upgrade omnia-node ./helm/omnia-node -f my-values.yaml`
+4. Monitor the health endpoint: `curl http://localhost:9090/healthz`
+5. Check logs for errors: `docker logs omnia-bootstrap` or `kubectl logs -l app=omnia-node`
+
+## Rollback Procedure
+
+1. For Docker Compose: `docker compose down && docker compose up -d <previous-version>`
+2. For Kubernetes: `helm rollback omnia-node <previous-revision>`
+3. Verify the rollback by checking the health endpoint and monitoring dashboards
+
+## Security Considerations
+
+- Never expose the Grafana dashboard to the public internet without authentication
+- Always change the default Grafana password (see `docker/.env.example`)
+- Run the node as a non-root user (the Docker image uses UID 1000 by default)
+- Keep the operating system and Docker/Kubernetes runtime updated
+- Regularly audit the supply chain using `cargo vet` and `cargo deny`
+
+---
+🔙 **Back**: [operations/](./) | 🔄 **Related**: [monitoring.md](./monitoring.md)
+🚀 **Next**: [runbook.md](./runbook.md) | 📜 **Source of Truth**: [Restructuring Blueprint](../reference/blueprint-reference.md)

--- a/docs/operations/feature-flags.md
+++ b/docs/operations/feature-flags.md
@@ -1,0 +1,80 @@
+# Feature Flag Reference
+> 🎯 Audience: Operators
+> 🔗 Context: Feature flags and their operational impact for running Omnia Protocol nodes
+> 📅 Last Updated: 2026-05-20
+
+## Feature Flags
+
+### `ethereum-live`
+
+**Crate:** `omnia-adapters` / `zk`
+
+**Purpose:** Enables real Ethereum settlement via Alloy RPC integration.
+
+**Without flag (default):** Ethereum adapter runs in **Simulated** mode — full architecture, in-memory state transitions, no real on-chain interaction.
+
+**With flag:** Adds `alloy` v1 dependency for real RPC calls to Ethereum nodes. Supports:
+- Real batch submission to OmniaRollup.sol
+- Groth16 proof verification on-chain
+- State root queries
+- Deposit and withdrawal operations
+- Gas estimation and confirmation waiting
+
+**Build:**
+```bash
+cargo build --features ethereum-live
+```
+
+**Docker:**
+```bash
+docker build --build-arg FEATURES=ethereum-live -f docker/Dockerfile .
+```
+
+**CI:** Feature-gated tests run in `.github/workflows/ethereum-settlement.yml` with Anvil.
+
+**Impact on binary size:** Adding `alloy` increases binary size significantly (~300+ sub-crates). Use only when real Ethereum settlement is needed.
+
+---
+
+## Runtime Configuration
+
+These are not compile-time feature flags but runtime configuration options that affect node behavior:
+
+### Snapshot Configuration
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `snapshot_interval` | 10000 | Take a state snapshot every N events |
+
+### Pruning Configuration
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `pruning_depth` | 0 | Events older than (finalized_round - depth) are pruned; 0 = archive mode |
+
+### Readiness Configuration
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `readiness_min_peers` | 1 | Minimum peers for readiness probe |
+| `readiness_max_finalization_age` | 600 | Max rounds since last finalization for readiness |
+
+### Security Configuration
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `OMNIA_JWT_SECRET` | (none) | HMAC secret for JWT auth |
+| `OMNIA_AUTHORIZED_CALLERS` | (none) | Comma-separated authorized caller IDs |
+| `OMNIA_AUTHORIZED_ADMINS` | (none) | Comma-separated admin caller IDs |
+| `OMNIA_RATE_LIMIT_RPS` | (none) | Max requests per second per IP |
+
+### Logging Configuration
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `RUST_LOG` | `info` | Log level (trace, debug, info, warn, error) |
+| `RUST_LOG_FORMAT` | (default) | Set to `json` for structured JSON logging |
+
+---
+🔙 **Back**: [operations/](./) | 🔄 **Related**: [../building/feature-matrix.md](../building/feature-matrix.md)
+🚀 **Next**: [../reference/](../reference/) | 📜 **Source of Truth**: [Restructuring Blueprint](../reference/blueprint-reference.md)

--- a/docs/operations/monitoring.md
+++ b/docs/operations/monitoring.md
@@ -1,0 +1,91 @@
+# Monitoring Setup
+> 🎯 Audience: Operators
+> 🔗 Context: Grafana dashboards, Prometheus configuration, and alert rules for Omnia nodes
+> 📅 Last Updated: 2026-05-20
+
+## Quick Start
+
+```sh
+cd docker
+docker compose --profile monitoring up -d
+
+# Access Grafana: http://localhost:3000 (admin / password from docker/.env)
+# Access Prometheus: http://localhost:9095
+```
+
+The `GRAFANA_ADMIN_PASSWORD` environment variable is required in `docker/.env`. Copy `docker/.env.example` to `docker/.env` and set a secure password.
+
+## Dashboard Panels
+
+The `omnia-node.json` dashboard includes the following panels:
+
+| Panel | Metric Expression | Type | Description |
+|-------|-------------------|------|-------------|
+| Finalized Events/sec | `rate(omnia_node_events_finalized_total[1m])` | timeseries | Consensus throughput |
+| Peer Count | `omnia_node_peers_connected` | stat | Current P2P connections (thresholds: red=0, yellow=2, green=4) |
+| Consensus Round Latency | `histogram_quantile(0.95, rate(omnia_consensus_round_duration_seconds_bucket[5m]))` | timeseries | P95 consensus latency |
+| Gossip Message Rate | `rate(omnia_gossip_events_sent_total[1m])` and `rate(omnia_gossip_events_received_total[1m])` | timeseries | Sent and received gossip |
+| Slashing Events | `rate(omnia_slashing_events_total[1h])` | timeseries | Slashing frequency |
+| Fee Revenue | `rate(omnia_fees_collected_total[1h])` | timeseries | UBC fees collected |
+| Causal Graph Size | `omnia_causal_graph_total_events` | stat | Total events in DAG (thresholds: green, yellow=100K, red=1M) |
+| Memory Usage | `process_resident_memory_bytes` and `process_heap_bytes` | timeseries | RSS and heap memory |
+| Events Submitted vs Finalized | `rate(omnia_node_events_submitted_total[1m])` vs `rate(omnia_node_events_finalized_total[1m])` | timeseries | Consensus lag indicator |
+
+## Node-Level Prometheus Metrics
+
+The `NodeMetrics` struct in `node/src/state.rs` registers these metrics with the default Prometheus registry:
+
+| Metric Name | Type | Description |
+|---|---|---|
+| `omnia_node_events_submitted_total` | IntCounter | Total events submitted via the API |
+| `omnia_node_events_finalized_total` | IntCounter | Total events finalized by consensus |
+| `omnia_node_peers_connected` | IntGauge | Current number of connected peers |
+| `omnia_node_consensus_round` | IntGauge | Current consensus round |
+| `omnia_node_shard_operations_total` | IntCounter | Total shard operations processed |
+| `omnia_node_http_requests_total` | IntCounter | Total HTTP requests served |
+
+Additional substrate-level metrics (gossip, slashing, consensus latency, fee revenue, graph size) are registered by the substrate crate's own instrumentation.
+
+## Alert Rules
+
+The alert rules in `monitoring/grafana/alerts/omnia-alerts.yml` are evaluated by Prometheus:
+
+| Alert | Condition | Duration | Severity | Component |
+|-------|-----------|----------|----------|-----------|
+| FinalityStalled | `rate(omnia_node_events_finalized_total[5m]) == 0` | 5m | Critical | consensus |
+| PeerCountDrop | `omnia_node_peers_connected < 2` | 3m | Warning | network |
+| HighSlashingRate | `rate(omnia_slashing_events_total[10m]) > 0.1` | 10m | Warning | slashing |
+| MemoryGrowth | `deriv(process_resident_memory_bytes[30m]) > 10485760` | 30m | Warning | system |
+
+**Threshold explanations:**
+- **HighSlashingRate:** `> 0.1` means more than 0.1 slashing events per second (approximately 1 every 10 seconds), indicating potential Byzantine behavior or misconfiguration.
+- **MemoryGrowth:** `> 10,485,760` (10 MB) means memory is growing faster than ~10 MB per 30 minutes, which could indicate a memory leak.
+
+## Prometheus Configuration
+
+The Prometheus instance is configured in `docker/monitoring/prometheus.yml`:
+
+```yaml
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: 'omnia-bootstrap'
+    static_configs:
+      - targets: ['omnia-bootstrap:9090']
+    metrics_path: /metrics
+
+  - job_name: 'omnia-nodes'
+    static_configs:
+      - targets:
+        - 'omnia-node-1:9091'
+        - 'omnia-node-2:9092'
+        - 'omnia-node-3:9093'
+        - 'omnia-node-4:9094'
+    metrics_path: /metrics
+```
+
+---
+🔙 **Back**: [operations/](./) | 🔄 **Related**: [deployment.md](./deployment.md)
+🚀 **Next**: [deployment.md](./deployment.md) | 📜 **Source of Truth**: [Restructuring Blueprint](../reference/blueprint-reference.md)

--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -1,0 +1,299 @@
+# Operations Runbook
+> 🎯 Audience: Operators
+> 🔗 Context: Step-by-step procedures for common operational tasks when running Omnia Protocol nodes
+> 📅 Last Updated: 2026-05-20
+
+## Table of Contents
+
+1. [Node Startup](#node-startup)
+2. [Key Rotation](#key-rotation)
+3. [Emergency Slashing](#emergency-slashing)
+4. [Network Partition Recovery](#network-partition-recovery)
+5. [Node Upgrade](#node-upgrade)
+6. [Snapshot and Restore](#snapshot-and-restore)
+7. [Trusted Setup Ceremony](#trusted-setup-ceremony)
+8. [REST API Reference](#rest-api-reference)
+
+---
+
+## Node Startup
+
+### Starting a New Node
+
+```sh
+# Generate a validator keypair (use --passphrase for production!)
+omnia-node keygen --output-dir ./keys --passphrase "your-secure-passphrase"
+
+# Start the node with default settings
+omnia-node --node-id 1 --http-port 8080
+
+# Or start with a config file
+omnia-node --config omnia-node.toml
+
+# Or use environment variables
+OMNIA_NODE_ID=1 OMNIA_HTTP_PORT=8080 OMNIA_LOG_LEVEL=info omnia-node
+```
+
+**Important:** `--node-id` accepts a `u64` value (not a string). Values like `bootstrap` or `node1` are invalid.
+
+### Starting with Bootstrap Peers
+
+```sh
+omnia-node \
+  --node-id 2 \
+  --http-port 8081 \
+  --bootstrap-nodes "/ip4/1.2.3.4/udp/4001/quic/p2p/12D3KooWExample"
+```
+
+### Starting with Docker Compose
+
+```sh
+cd docker
+cp .env.example .env
+# Edit .env to change GRAFANA_ADMIN_PASSWORD from the default
+docker compose up -d
+
+# With monitoring
+docker compose --profile monitoring up -d
+```
+
+### Verifying Node Health
+
+```sh
+curl http://localhost:8080/healthz     # Liveness probe
+curl http://localhost:8080/readyz       # Readiness probe
+curl http://localhost:8080/api/v1/node/info  # Node info
+curl http://localhost:8080/metrics      # Prometheus metrics
+```
+
+---
+
+## Key Rotation
+
+### Step 1: Backup Current Keys
+
+```sh
+cp -r ./keys ./keys-backup-$(date +%Y%m%d)
+```
+
+### Step 2: Generate New Keys
+
+```sh
+omnia-node keygen --output-dir ./keys-new --passphrase "your-secure-passphrase"
+```
+
+### Step 3: Rotate Keys
+
+The key rotation is performed via the keystore API. The rotation produces a `KeyRotationProof` that must be broadcast to other validators so they update their trusted key set.
+
+### Step 4: Verify Rotation
+
+```sh
+cat ./keys/validator_pubkey.txt
+omnia-node --node-id 1 --http-port 8080
+curl http://localhost:8080/healthz
+```
+
+### Step 5: Distribute Rotation Proof
+
+The `KeyRotationProof` must be shared with all other validators. They verify the signature from the old key over the new public key. Once >2/3 of validators acknowledge the rotation, it is finalized.
+
+---
+
+## Emergency Slashing
+
+The `SlashingEngine` tracks three offense types with gradual escalation:
+
+| Offense | 1st | 2nd | 3rd+ |
+|---------|-----|-----|-------|
+| Equivocation | Jailed (5%, 1000r) | Jailed (25%, 5000r) | Ejected (100%) |
+| LivenessViolation | Warning (1%) | Warning (1%) | Jailed (5%, 500r) |
+| InvalidAttestation | Warning (2%) | Jailed (10%, 2000r) | Ejected (100%) |
+
+### Detecting Slashing Events
+
+```sh
+# Check slashing metrics
+curl -s http://localhost:8080/metrics | grep omnia_slashing
+
+# Check Grafana dashboard (Slashing Events panel)
+```
+
+### Responding to a Slash
+
+```sh
+# 1. Identify the slashed validator from logs
+journalctl -u omnia-node | grep "slash"
+
+# 2. Check slashing metrics
+curl -s http://localhost:8080/metrics | grep omnia_slashing
+
+# 3. If ejected (exceeded threshold): validator automatically removed from active set
+
+# 4. For emergency ejection via governance:
+curl -X POST http://localhost:8080/api/v1/governance/proposals \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $JWT" \
+  -d '{"id": "emergency-slash-validator-xyz", "description": "Emergency slash", "expires_at_epoch": 100}'
+```
+
+**Important:** Production nodes must use `RedbSlashingStore` for persistence. If using in-memory slashing, all slash points are lost on restart.
+
+---
+
+## Network Partition Recovery
+
+### Detecting a Partition
+
+```sh
+# Check peer count
+curl -s http://localhost:8080/metrics | grep omnia_node_peers_connected
+
+# Check connected peers
+curl http://localhost:8080/api/v1/node/peers
+```
+
+### Recovery Steps
+
+```sh
+# 1. Identify disconnected peers
+curl http://localhost:8080/api/v1/node/peers
+
+# 2. Check network connectivity
+ping 172.20.0.3
+traceroute 1.2.3.4
+
+# 3. Gossip protocol will auto-reconnect when peers are reachable
+
+# 4. Verify recovery
+curl -s http://localhost:8080/metrics | grep omnia_node_peers_connected
+```
+
+### Handling Split-Brain
+
+```sh
+# 1. Stop all nodes
+docker compose down
+
+# 2. Identify the longer chain (higher finalized event count)
+# Check each node's data directory
+
+# 3. The partition with >2/3 of validators has the canonical chain
+# Reset minority partition nodes and restart
+docker compose up -d
+```
+
+---
+
+## Node Upgrade
+
+### Rolling Upgrade (Zero-Downtime)
+
+```sh
+# For each node (maintaining >2/3 validator availability):
+
+# 1. Stop the node
+docker stop omnia-node-1
+
+# 2. Backup data
+cp -r /path/to/data /path/to/backup/data-$(date +%Y%m%d)
+
+# 3. Replace the binary
+cp target/release/omnia-node /usr/local/bin/omnia-node
+
+# 4. Start the node
+docker start omnia-node-1
+
+# 5. Verify health
+curl http://localhost:8080/healthz
+
+# 6. Wait for sync, then repeat for next node
+```
+
+### Protocol Version Check
+
+```sh
+omnia-node --version
+curl http://localhost:8080/api/v1/node/info | jq .protocol_version
+```
+
+---
+
+## Snapshot and Restore
+
+### Taking a Snapshot
+
+```sh
+omnia-node snapshot --output snapshot.bin
+```
+
+### Restoring from a Snapshot
+
+```sh
+omnia-node restore --input snapshot.bin
+```
+
+### Automated Snapshots
+
+Configure in `omnia-node.toml`:
+
+```toml
+snapshot_interval = 10000  # Snapshot every 10,000 events
+```
+
+### Pruning Configuration
+
+```toml
+pruning_depth = 10000  # Keep last 10,000 rounds
+# pruning_depth = 0    # Archive mode (no pruning)
+```
+
+---
+
+## Trusted Setup Ceremony
+
+### Contributing to the Ceremony
+
+```sh
+# Contribute with default parameters
+omnia-node setup-contribute
+
+# With custom parameters
+omnia-node setup-contribute --degree 65536 --min-participants 3
+```
+
+### Verifying the Ceremony
+
+```sh
+omnia-node setup-verify --degree 65536 --num-contributions 3
+```
+
+**Security Consideration:** The trusted setup is critical for Groth16 proof soundness. Production requires multi-party coordination with independent participants.
+
+---
+
+## REST API Reference
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/healthz` | Liveness probe |
+| GET | `/readyz` | Readiness probe |
+| GET | `/metrics` | Prometheus metrics |
+| GET | `/api/v1/node/info` | Node identity and status |
+| GET | `/api/v1/node/peers` | Connected peer list |
+| POST | `/api/v1/events` | Submit a new event |
+| GET | `/api/v1/events/:id` | Retrieve event by ID |
+| POST | `/api/v1/shards/:shard_id/operations` | Submit shard operation |
+| POST | `/api/v1/governance/proposals` | Create governance proposal |
+| POST | `/api/v1/governance/vote` | Cast quadratic-weighted vote |
+| GET | `/api/v1/economics/balance/:did` | Check UBC balance |
+| POST | `/api/v1/economics/transfer` | Spend UBC tokens |
+
+**Security:** All endpoints require JWT authentication. Privileged operations require admin JWT. See [validator-setup.md](./validator-setup.md) for configuration.
+
+Swagger UI: `http://localhost:8080/swagger-ui`
+OpenAPI spec: `http://localhost:8080/api-docs/openapi.json`
+
+---
+🔙 **Back**: [operations/](./) | 🔄 **Related**: [validator-setup.md](./validator-setup.md)
+🚀 **Next**: [feature-flags.md](./feature-flags.md) | 📜 **Source of Truth**: [Restructuring Blueprint](../reference/blueprint-reference.md)

--- a/docs/operations/validator-setup.md
+++ b/docs/operations/validator-setup.md
@@ -1,0 +1,157 @@
+# Validator Setup Guide
+> 🎯 Audience: Operators
+> 🔗 Context: Step-by-step guide for setting up and running an Omnia Protocol validator node
+> 📅 Last Updated: 2026-05-20
+
+## Prerequisites
+
+- Omnia binary installed at `/usr/local/bin/omnia-node`
+- Data directory exists (default: `./data`)
+- Config file prepared (optional: `omnia-node.toml`)
+- Rust 1.85+ runtime (Docker image: `rust:1.85-slim-bookworm`)
+
+## Step 1: Generate Validator Keypair
+
+```sh
+# Generate a keypair with encrypted storage (RECOMMENDED for production)
+omnia-node keygen --output-dir ./keys --passphrase "your-secure-passphrase"
+
+# This creates:
+# - validator_pubkey.txt — hex-encoded Ed25519 public key
+# - validator_key.enc  — AES-256-GCM encrypted private key
+```
+
+⚠️ **Security Warning:** Without `--passphrase`, the private key file is written as raw bytes without encryption. Always use `--passphrase` for production.
+
+The `keygen` subcommand also supports BIP-39 mnemonic key generation for HD key derivation (SLIP-0010: `m/44'/6061'/{purpose}'/{index}'`).
+
+## Step 2: Configure the Node
+
+### Via CLI Flags
+
+```sh
+omnia-node \
+  --node-id 1 \
+  --http-port 8080 \
+  --data-dir ./data \
+  --log-level info
+```
+
+### Via TOML Config File
+
+```sh
+cat > omnia-node.toml <<EOF
+node_id = 1
+http_port = 8081
+data_dir = "./data"
+log_level = "info"
+snapshot_interval = 10000
+EOF
+
+omnia-node --config omnia-node.toml
+```
+
+### Via Environment Variables
+
+```sh
+OMNIA_NODE_ID=1 OMNIA_HTTP_PORT=8080 OMNIA_LOG_LEVEL=info omnia-node
+```
+
+**Configuration precedence:** CLI flags > env vars > TOML config file > defaults.
+
+### Important Configuration Notes
+
+- `node_id` must be a non-zero `u64` value (strings like `bootstrap` or `node1` are invalid)
+- `http_port` must be non-zero
+- `protocol-version` defaults to `"4.0.0"`
+- `snapshot_interval` defaults to 10,000 events
+- `pruning_depth` of 0 means archive mode (no events pruned)
+
+## Step 3: Start with Bootstrap Peers
+
+```sh
+omnia-node \
+  --node-id 2 \
+  --http-port 8081 \
+  --bootstrap-nodes "/ip4/1.2.3.4/udp/4001/quic/p2p/12D3KooWExample"
+```
+
+## Step 4: Verify Node Health
+
+```sh
+# Liveness probe (always returns 200 if process is alive)
+curl http://localhost:8080/healthz
+
+# Readiness probe (returns 200 when node has peers, not syncing, recent finalization)
+curl http://localhost:8080/readyz
+
+# Node info
+curl http://localhost:8080/api/v1/node/info
+
+# Prometheus metrics
+curl http://localhost:8080/metrics
+```
+
+## Startup Sequence
+
+When `omnia-node` starts, it follows this sequence:
+
+1. Parse CLI arguments and dispatch subcommands (keygen, setup-contribute, etc.)
+2. Build `NodeConfig` from CLI args, env vars, and optional TOML file
+3. Validate configuration (`node_id != 0`, `http_port != 0`, valid log level)
+4. Initialize structured logging (tracing) — supports JSON output via `RUST_LOG_FORMAT=json`
+5. Create data directory if it doesn't exist
+6. Initialize substrate with persistent slashing engine (redb)
+7. Create shard router with persistent nonce store (redb) and register all 6 shard types
+8. Initialize economics state (10% decay, 1000 UBC/month quota)
+9. Initialize Prometheus metrics (`NodeMetrics`)
+10. Build shared `AppState` and mount HTTP router
+11. Start axum HTTP server on `0.0.0.0:{http_port}`
+12. Wait for SIGINT/SIGTERM for graceful shutdown
+
+## Data Directory Layout
+
+```
+data/
+├── slashing/          # RedbSlashingStore database
+│   └── slashing.redb
+├── nonces/            # RedbNonceStore database
+│   └── nonces.redb
+├── consensus/         # RedbConsensusStore database
+│   └── consensus.redb
+└── snapshots/         # State snapshots (via CLI subcommand)
+```
+
+## Docker Deployment
+
+```sh
+cd docker
+cp .env.example .env
+# Edit .env to set GRAFANA_ADMIN_PASSWORD
+docker compose up -d
+
+# With monitoring
+docker compose --profile monitoring up -d
+```
+
+## REST API Security
+
+The REST API requires JWT authentication:
+
+```sh
+# Set required environment variables
+export OMNIA_JWT_SECRET="your-hmac-secret"
+export OMNIA_AUTHORIZED_CALLERS="caller1,caller2"
+export OMNIA_RATE_LIMIT_RPS=10
+
+omnia-node --node-id 1 --http-port 8080
+```
+
+- `OMNIA_JWT_SECRET` — HMAC secret for JWT validation (required; API returns 401 if not set)
+- `OMNIA_AUTHORIZED_CALLERS` — Comma-separated list of authorized caller IDs
+- `OMNIA_RATE_LIMIT_RPS` — Maximum requests per second per IP
+- Privileged operations (mint, advance_epoch) require admin JWT
+
+---
+🔙 **Back**: [operations/](./) | 🔄 **Related**: [runbook.md](./runbook.md)
+🚀 **Next**: [monitoring.md](./monitoring.md) | 📜 **Source of Truth**: [Restructuring Blueprint](../reference/blueprint-reference.md)

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -1,0 +1,21 @@
+# Reference Documentation
+> 🎯 Audience: All
+> 🔗 Context: Index for reference material including roadmaps, benchmarks, ADRs, and policy documents
+> 📅 Last Updated: 2026-05-20
+
+## Reference Documents
+
+| Document | Description |
+|----------|-------------|
+| [roadmap.md](roadmap.md) | Implementation roadmap — Phase 0 through Phase 5+ |
+| [benchmark-gates.md](benchmark-gates.md) | Performance baselines and benchmark data |
+| [blueprint-reference.md](blueprint-reference.md) | Blueprint/spec reference — implementation status |
+| [metrics-glossary.md](metrics-glossary.md) | Metrics and terminology glossary |
+| [adr-index.md](adr-index.md) | Architecture Decision Record index (ADR-001 through ADR-021) |
+| [security-audit.md](security-audit.md) | Security audit package — findings, validated audits, attack surface |
+| [dependency-policy.md](dependency-policy.md) | Dependency policy — pinning, audits, exemptions |
+| [crypto-migration.md](crypto-migration.md) | Cryptographic migration playbook |
+
+---
+🔙 **Back**: [docs/](../) | 🔄 **Related**: [architecture/](../architecture/)
+🚀 **Next**: [roadmap.md](./roadmap.md) | 📜 **Source of Truth**: [Restructuring Blueprint](./blueprint-reference.md)

--- a/docs/reference/adr-index.md
+++ b/docs/reference/adr-index.md
@@ -1,0 +1,60 @@
+# Architecture Decision Record Index
+> 🎯 Audience: Developers
+> 🔗 Context: Index and summaries of all Architecture Decision Records (ADRs)
+> 📅 Last Updated: 2026-05-20
+
+## ADR Summary
+
+| ADR | Title | Status | Key Decision |
+|-----|-------|--------|-------------|
+| ADR-001 | Event Processor Trait | ✅ Adopted | `validate(&self)`, `process_event(&mut self)`, `state_snapshot(&self)` — no interior mutability |
+| ADR-002 | Settlement Layer Trait | ✅ Adopted | Settlement-agnostic interface for L1 adapters |
+| ADR-003 | Gossip Substrate Interface | ✅ Adopted | Boundary between gossip propagation and substrate ordering |
+| ADR-005 | Proof Bundle Format | ✅ Adopted | Serialized format for ZK proof bundles |
+| ADR-006 | Shard Trait Contract | ✅ Adopted | `Shard` trait with fee enforcement and nonce tracking |
+| ADR-007 | Binding Shard Interface | ✅ Adopted | Provenance and quantum commitment integration |
+| ADR-008 | Crypto Dependency Audit | ✅ Adopted | Audit of cryptographic dependency versions |
+| ADR-009 | Poseidon Parameter Justification | ✅ Adopted | Cauchy MDS + BLAKE3-derived round constants |
+| ADR-010 | Encrypted Keystore Design | ✅ Adopted | AES-256-GCM + HKDF-SHA256 for key storage |
+| ADR-011 | Gradual Slashing Model | ✅ Adopted | 3-tier: Warning → Jail → Ejection |
+| ADR-012 | VRF Construction Choice | ✅ Adopted | V1 (legacy Ed25519+BLAKE3) + V2 (ECVRF per RFC 9381) |
+| ADR-013 | DKG Protocol Selection | ✅ Adopted | Feldman VSS-based DKG |
+| ADR-014 | Poseidon Parameter Migration | ✅ Adopted | Dual-hash transition: Custom → Reference (Filecoin/Neptune) |
+| ADR-015 | Leader Selection in Consensus Loop | ✅ Adopted | VRF-based, stake-weighted leader selection |
+| ADR-016 | Kademlia DHT Configuration | ✅ Adopted | `/omnia/kad/1.0.0`, AutoNAT/Relay/DCutr |
+| ADR-017 | GossipSub Peer Scoring Thresholds | ✅ Adopted | Graylist at -100, 1-min decay |
+| ADR-018 | Consensus State Persistence | ✅ Adopted | `RedbConsensusStore`, `load_or_new` |
+| ADR-019 | Fast-Sync Protocol | ✅ Adopted | BLAKE3 checkpoints, supermajority selection, P2P download |
+| ADR-020 | Kyber KEM / ML-KEM Integration | ✅ Adopted | FIPS-203 ML-KEM-768 (replaces pqc_kyber after KyberSlash) |
+| ADR-021 | Gossip Message Compression | ✅ Adopted | Snappy compression for messages >256 bytes |
+
+## Source Files
+
+All ADRs are located in `docs/adr/`:
+
+| File | Title |
+|------|-------|
+| `ADR-001-event-processor-trait.md` | Event Processor Trait |
+| `ADR-002-settlement-layer-trait.md` | Settlement Layer Trait |
+| `ADR-003-gossip-substrate-interface.md` | Gossip Substrate Interface |
+| `ADR-005-proof-bundle-format.md` | Proof Bundle Format |
+| `ADR-006-shard-trait-contract.md` | Shard Trait Contract |
+| `ADR-007-binding-shard-interface.md` | Binding Shard Interface |
+| `ADR-008-crypto-dependency-audit.md` | Crypto Dependency Audit |
+| `009-poseidon-parameter-justification.md` | Poseidon Parameter Justification |
+| `ADR-010-encrypted-keystore-design.md` | Encrypted Keystore Design |
+| `ADR-011-gradual-slashing-model.md` | Gradual Slashing Model |
+| `ADR-012-vrf-construction-choice.md` | VRF Construction Choice |
+| `ADR-013-dkg-protocol-selection.md` | DKG Protocol Selection |
+| `ADR-014-poseidon-parameter-migration.md` | Poseidon Parameter Migration |
+| `ADR-015-leader-selection-consensus-loop.md` | Leader Selection in Consensus Loop |
+| `ADR-016-kademlia-dht-configuration.md` | Kademlia DHT Configuration |
+| `ADR-017-gossipsub-peer-scoring-thresholds.md` | GossipSub Peer Scoring Thresholds |
+| `ADR-018-consensus-state-persistence.md` | Consensus State Persistence |
+| `ADR-019-fast-sync-protocol.md` | Fast-Sync Protocol |
+| `ADR-020-kyber-kem-ml-kem-integration.md` | Kyber KEM / ML-KEM Integration |
+| `ADR-021-gossip-message-compression.md` | Gossip Message Compression |
+
+---
+🔙 **Back**: [reference/](./) | 🔄 **Related**: [../architecture/trait-boundaries.md](../architecture/trait-boundaries.md)
+🚀 **Next**: [security-audit.md](./security-audit.md) | 📜 **Source of Truth**: [Restructuring Blueprint](./blueprint-reference.md)

--- a/docs/reference/benchmark-gates.md
+++ b/docs/reference/benchmark-gates.md
@@ -1,0 +1,93 @@
+# Performance Baselines & Benchmark Gates
+> 🎯 Audience: Developers
+> 🔗 Context: Measured performance data and benchmark gates for the Omnia Protocol
+> 📅 Last Updated: 2026-05-20
+
+## Test Environment
+
+```bash
+OS: Linux 5.10.134 (x86_64, cloud instance)
+CPU: Intel(R) Xeon(R) Processor, 4 cores
+RAM: 8.1 GiB
+Rust: rustc 1.95.0 (59807616e 2026-04-14)
+Build: cargo build --release
+Runtime: tokio multi-thread
+Consensus: BFT with configurable total_nodes
+Event size: 256 bytes (default)
+```
+
+## Consensus Throughput
+
+### Methodology
+- In-memory consensus benchmark using `chaos-tests/src/load_test.rs`
+- Varying event submission rates (100, 500, 1000, 5000 events/sec)
+- 10-second measurement duration per configuration
+- 5-second warmup period
+- Memory measurement via `/proc/self/status` VmRSS on Linux
+
+### Results
+
+| Config | Events/sec Submitted | Events/sec Finalized | p50 Latency | p90 Latency | p99 Latency | Peak Memory |
+|--------|---------------------|---------------------|-------------|-------------|-------------|-------------|
+| 100/s  | 100.0               | 100.0               | 0.21 ms     | 0.29 ms     | 0.38 ms     | 5.8 MB      |
+| 500/s  | 500.0               | 500.0               | 1.21 ms     | 1.53 ms     | 1.79 ms     | 14.4 MB     |
+| 1000/s | 527.2               | 527.2               | 1.91 ms     | 2.25 ms     | 2.78 ms     | 22.5 MB     |
+| 5000/s | 429.9               | 429.9               | 2.19 ms     | 2.66 ms     | 2.95 ms     | 23.2 MB     |
+
+### Analysis
+
+- **Peak single-node throughput: ~527 events/sec** (at 1000 events/sec target rate)
+- The system saturates above 500 events/sec
+- Latency increases proportionally with load, from 0.21ms at 100/s to 2.19ms at saturation
+- Memory usage scales with active event count, from 5.8 MB to 23.2 MB
+
+### Multi-Node BFT Note
+
+Multi-node BFT finality has been validated in `substrate/tests/multi_node_test.rs` with 4 honest nodes successfully reaching agreement. Real distributed throughput will be lower than single-node numbers due to network latency, gossip overhead, and the supermajority requirement.
+
+## ZK Performance
+
+| Operation | Time |
+|-----------|------|
+| Trusted setup (basic) | ~6.5 ms |
+| Trusted setup (expanded, 4 events) | ~423 ms |
+| Merkle tree build (64 leaves) | ~138 µs |
+| Merkle tree build (256 leaves) | ~732 µs |
+| Merkle tree build (1024 leaves) | ~74.4 ms |
+
+## VRF Performance
+
+| Operation | Time |
+|-----------|------|
+| VRF compute (V1) | ~15.6 µs |
+| VRF verify (V1) | ~37.7 µs |
+| Leader selection (100 validators) | ~597 ns |
+| ECVRF prove (V2) | ~16 µs (estimated) |
+| ECVRF verify (V2) | ~38 µs (estimated) |
+
+## Throughput Bottleneck Analysis
+
+The ~527 events/sec ceiling is likely caused by:
+- Single-threaded consensus processing
+- Per-event graph insertion and consensus state update overhead
+- Tokio async runtime overhead for sleep-based rate limiting
+- No batching optimization in the single-node test
+
+To reach higher throughput, consider:
+- Multi-threaded event processing with sharded consensus state
+- Batch event submission and processing
+- Optimized graph insertion (pre-allocated data structures)
+- Network-optimized gossip protocol for multi-node deployment
+
+## Benchmark Gates (Performance Regression Thresholds)
+
+| Metric | Baseline | Gate | Action if Exceeded |
+|--------|----------|------|-------------------|
+| Single-node throughput | ~527 events/sec | <80% of baseline | Block merge, investigate regression |
+| p99 latency (at 500/s) | 1.79 ms | >3× baseline | Block merge, investigate regression |
+| Memory at 1000/s | 22.5 MB | >2× baseline | Block merge, investigate |
+| ZK proof generation | ~423 ms (expanded) | >2× baseline | Block merge, investigate |
+
+---
+🔙 **Back**: [reference/](./) | 🔄 **Related**: [roadmap.md](./roadmap.md)
+🚀 **Next**: [blueprint-reference.md](./blueprint-reference.md) | 📜 **Source of Truth**: [Restructuring Blueprint](./blueprint-reference.md)

--- a/docs/reference/blueprint-reference.md
+++ b/docs/reference/blueprint-reference.md
@@ -1,0 +1,111 @@
+# Blueprint Reference
+> 🎯 Audience: Architects
+> 🔗 Context: Implementation specification reference — status of all protocol components and milestones
+> 📅 Last Updated: 2026-05-20
+
+## Implementation Status
+
+```
+[█████████████████████████░░░] 90% Complete
+```
+
+| Layer | Status | Tests |
+|-------|--------|-------|
+| Layer 1: Substrate | ✅ Implemented | 454+ |
+| Layer 2: Domain Shards | ✅ Implemented | 62+ |
+| Layer 3: Binding | ✅ Implemented | 61+ |
+| Layer 4: Identity (in shards) | ✅ Implemented | — |
+| Layer 5: Economics | ✅ Implemented | 58+ |
+| Phase 0: ZK-Rollup | ✅ Implemented | 129+ |
+| Node Binary | ✅ Implemented | 30+ |
+| Chaos Tests | ✅ Implemented | ~15 scenarios |
+
+**Total: 800+ lib tests + chaos/integration tests, all passing.**
+
+## Technology Stack
+
+### Core Crates (7 + support)
+
+| Crate | Purpose | Key Dependencies |
+|-------|---------|------------------|
+| `substrate/` | Causal graph, consensus, gossip, crypto, CRDTs, slashing, snapshots | ed25519-dalek, blake3, redb, libp2p, postcard |
+| `shards/` | 6 domain shards + cross-shard messaging + fee enforcement + nonce store | redb (nonce persistence) |
+| `binding/` | Provenance log, RF stub, quantum commitments, key rotation | ed25519-dalek, ml-kem, aes-gcm, hkdf |
+| `economics/` | UBC token, quota, governance, useful work, fixed-point | thiserror |
+| `omnia-adapters/` | ZK-rollup (arkworks R1CS + Groth16), settlement adapters | ark-bn254, ark-groth16, alloy (feature-gated) |
+| `node/` | CLI binary, HTTP server, REST API, Swagger UI, Prometheus metrics | axum, utoipa, clap, jsonwebtoken |
+| `chaos-tests/` | Network partition, crash, drop-rate, equivocation simulation | tokio |
+
+### Cryptographic Primitives
+
+| Primitive | Implementation | File Reference |
+|-----------|---------------|----------------|
+| Groth16 SNARK | `ark-groth16` on BN254 | `omnia-adapters/src/prover.rs` |
+| Poseidon hash | Custom (Cauchy MDS + BLAKE3 RC) + Reference | `omnia-adapters/src/poseidon.rs` |
+| BLAKE3 | `blake3` 1.5 (domain-separated) | Multiple files |
+| Ed25519 | `ed25519-dalek` 2.1 | `binding/src/quantum_commit.rs` |
+| CRYSTALS-Dilithium | `pqc_dilithium` 0.2 | `binding/src/quantum_commit.rs` |
+| ML-KEM-768 | `ml-kem` 0.2 (FIPS-203) | `binding/src/quantum_commit.rs` |
+| BLS12-381 | `blst` | `substrate/src/bls.rs` |
+| Shamir's SSS | GF(256) with AES irreducible polynomial | `shards/src/identity/recovery.rs` |
+
+### State Management
+
+| Component | Implementation | Persistence |
+|-----------|---------------|-------------|
+| CRDTs | GCounter, OrSet, LWWRegister | In-memory |
+| Merkle state root | BLAKE3 off-circuit, Poseidon on-circuit | Snapshots |
+| Slashing state | `RedbSlashingStore` | redb (ACID) |
+| Nonce tracking | `RedbNonceStore` | redb (ACID) |
+| Consensus state | `RedbConsensusStore` | redb (ACID) |
+| Keystore | `EncryptedKeyStore` | AES-256-GCM encrypted files |
+
+## What's Fully Implemented ✅
+
+- Causal graph consensus with vector clock ordering
+- 6 domain shards with cross-shard messaging
+- Fee enforcement via FeeSchedule + QuotaSystem
+- Replay protection with persistent nonce store
+- Slashing engine with persistent redb storage (3-tier gradual model)
+- Provenance tracking (full lifecycle)
+- DID method (`did:omnia:`) with validation
+- Shamir's Secret Sharing for social recovery (AES-256-GCM encrypted shares)
+- Biometric anchors (BLAKE3-based)
+- AI agent identity with 5 capability types
+- UBC token (soulbound quota with reputation decay)
+- Quadratic voting with exponential decay and time-locked voting
+- Real ML-KEM-768 / FIPS-203 post-quantum key encapsulation
+- Real Dilithium signature verification
+- Real Groth16 ZK proving/verification with Poseidon hash
+- Settlement-agnostic ZK-rollup with real Ethereum settlement (Alloy)
+- Full node binary with CLI, REST API, Swagger UI, Prometheus metrics
+- JWT authentication, ACL authorization, rate limiting, CORS
+- Chaos testing framework
+- Docker deployment with 5-node testnet + monitoring
+- BIP-39 mnemonic key generation
+- DKG for threshold signatures
+- ECVRF (V2) leader selection
+- Fast-sync protocol
+- Message compression (Snappy)
+- Genesis tooling
+
+## What's a Stub ⚠️
+
+| Feature | Status | What's Needed |
+|---------|--------|---------------|
+| ZK circuit hash | ⚠️ Poseidon implemented | Round constants use BLAKE3 derivation; dual-hash transition started |
+| RF fingerprinting | ⚠️ Stub | SDR hardware (HackRF/USRP) |
+| Proof-of-useful-work | ⚠️ Stub | Production verification |
+
+## What Doesn't Exist Yet 🌑
+
+- Mobile wallet
+- JavaScript/Python client libraries
+- Validator network (single-node operator for Phase 0)
+- Sybil resistance / staking requirement
+- Conviction voting and delegation
+- Constant-time guarantee for Dilithium verify() (pending formal audit)
+
+---
+🔙 **Back**: [reference/](./) | 🔄 **Related**: [roadmap.md](./roadmap.md)
+🚀 **Next**: [metrics-glossary.md](./metrics-glossary.md) | 📜 **Source of Truth**: [Restructuring Blueprint](./blueprint-reference.md)

--- a/docs/reference/crypto-migration.md
+++ b/docs/reference/crypto-migration.md
@@ -1,0 +1,108 @@
+# Cryptographic Migration Playbook
+> 🎯 Audience: Developers
+> 🔗 Context: Migration path for each cryptographic primitive if it is compromised
+> 📅 Last Updated: 2026-05-20
+
+## Overview
+
+This document describes the migration path for each cryptographic primitive used by the Omnia Protocol if it is compromised. Each migration follows a 4-phase process:
+
+1. **Disclosure**: Vulnerability announced via security advisory
+2. **Deprecation**: Old scheme marked deprecated, new scheme available
+3. **Migration**: Nodes upgrade, both schemes accepted during transition
+4. **Sunset**: Old scheme no longer accepted, minimum version enforced
+
+The protocol's cryptographic dependencies span two crates:
+
+- **`omnia-adapters`** (`omnia-adapters/Cargo.toml`): Groth16 proofs on BN254, Poseidon hash, Powers of Tau ceremony, Merkle tree verification
+- **`omnia-binding`** (`binding/Cargo.toml`): Ed25519 signatures via `ed25519-dalek` 2.1, CRYSTALS-Dilithium via `pqc_dilithium` 0.2, BLAKE3 1.5, ML-KEM-768 via `ml-kem` 0.2, hybrid commitment verification
+
+## Cryptographic Primitives in Use
+
+| Primitive | Crate | Implementation | File Reference |
+|-----------|-------|---------------|----------------|
+| Groth16 SNARK | `omnia-adapters` | `ark-groth16` 0.4 on Bn254 | `omnia-adapters/src/prover.rs` |
+| Poseidon hash | `omnia-adapters` | Custom (Cauchy MDS + BLAKE3 RC) + Reference | `omnia-adapters/src/poseidon.rs` |
+| BLAKE3 | both | `blake3` 1.5 | `omnia-adapters/src/merkle.rs`, `binding/src/quantum_commit.rs` |
+| Ed25519 | `omnia-binding` | `ed25519-dalek` 2.1 | `binding/src/quantum_commit.rs` |
+| CRYSTALS-Dilithium | `omnia-binding` | `pqc_dilithium` 0.2 | `binding/src/quantum_commit.rs` |
+| ML-KEM-768 | `omnia-binding` | `ml-kem` 0.2 (FIPS-203) | `binding/src/quantum_commit.rs` |
+| Powers of Tau (PoK) | `omnia-adapters` | Fiat-Shamir on BN254 G1 | `omnia-adapters/src/setup/contribution.rs` |
+
+## Migration Paths
+
+### If Ed25519 is Compromised
+
+The binding crate already implements a phased commitment model via the `CommitmentPhase` enum:
+
+| Step | Action | Timeline |
+|------|--------|----------|
+| 1 | Announce advisory, set deprecation date | Day 0 |
+| 2 | Set `CommitmentPhase::Hybrid` as default | Day 1 |
+| 3 | Nodes generate Dilithium keys, submit PoP | Week 1 |
+| 4 | Both Ed25519 and Dilithium accepted via `Hybrid` | Weeks 1-6 |
+| 5 | Require `Hybrid` or `PostQuantum` for new commitments | Week 6 |
+| 6 | Sunset `ClassicalOnly` | Week 8 |
+
+### If BLAKE3 Has a Collision
+
+BLAKE3 is used for off-circuit Merkle tree construction, batch commitment hashing, data hashing, and transcript hashing. On-circuit Poseidon hash is unaffected.
+
+| Step | Action | Timeline |
+|------|--------|----------|
+| 1 | Announce advisory | Day 0 |
+| 2 | Add SHA3-256 fallback hash function | Week 1 |
+| 3 | New events use SHA3-256 hashes | Week 2 |
+| 4 | Both hash schemes accepted | Weeks 2-4 |
+| 5 | Re-hash all stored events | Weeks 4-8 |
+| 6 | Sunset BLAKE3-only mode | Week 8 |
+
+### If BN254 Curve is Compromised
+
+The most complex migration — requires new circuit, new Poseidon parameters, new trusted setup, and re-generation of all proofs.
+
+| Step | Action | Timeline |
+|------|--------|----------|
+| 1 | Announce advisory | Day 0 |
+| 2 | Parameterize circuit for BLS12-381 | Week 2 |
+| 3 | Derive new Poseidon parameters for BLS12-381 Fr | Week 3 |
+| 4 | New trusted setup ceremony on BLS12-381 | Week 4 |
+| 5 | Migrate all active proofs | Weeks 4-12 |
+| 6 | Sunset BN254 Groth16 proofs | Week 12 |
+
+### If CRYSTALS-Dilithium is Compromised
+
+| Step | Action | Timeline |
+|------|--------|----------|
+| 1 | Announce advisory | Day 0 |
+| 2 | Revert to `ClassicalOnly` | Day 1 |
+| 3 | Deploy replacement PQC (SPHINCS+ or next NIST standard) | Week 2-4 |
+| 4 | New hybrid mode with replacement | Week 4-8 |
+| 5 | Sunset Dilithium | Week 8 |
+
+### If a Quantum Computer Breaks Classical Crypto (Q-Day)
+
+| Step | Action | Timeline |
+|------|--------|----------|
+| 1 | Emergency advisory | Day 0 |
+| 2 | Require `Hybrid` or `PostQuantum` immediately | Day 1 |
+| 3 | All `ClassicalOnly` commitments invalid | Day 1 |
+| 4 | Emergency key generation for validators without Dilithium keys | Day 1-3 |
+| 5 | Resume with `PostQuantum` mode | Day 3 |
+
+**Mitigation:** Deploy `Hybrid` as default BEFORE Q-Day.
+
+### If Poseidon Hash is Compromised
+
+| Step | Action | Timeline |
+|------|--------|----------|
+| 1 | Announce advisory | Day 0 |
+| 2 | Select replacement SNARK-friendly hash (Rescue, Vision) | Week 1 |
+| 3 | Implement new hash gadget | Week 2-3 |
+| 4 | Regenerate trusted setup | Week 4 |
+| 5 | Migrate active proofs | Weeks 4-8 |
+| 6 | Sunset Poseidon-based proofs | Week 8 |
+
+---
+🔙 **Back**: [reference/](./) | 🔄 **Related**: [dependency-policy.md](./dependency-policy.md)
+🚀 **Next**: [../use-cases/](../use-cases/) | 📜 **Source of Truth**: [Restructuring Blueprint](./blueprint-reference.md)

--- a/docs/reference/dependency-policy.md
+++ b/docs/reference/dependency-policy.md
@@ -1,0 +1,92 @@
+# Dependency Policy
+> 🎯 Audience: Developers
+> 🔗 Context: Policy for managing dependencies — pinning, audits, and exemptions
+> 📅 Last Updated: 2026-05-20
+
+## Pinning
+
+- All dependencies MUST be pinned via `Cargo.lock`
+- `Cargo.lock` MUST be committed to the repository
+- CI MUST fail if `Cargo.lock` is out of date (enforced via `cargo test --locked --workspace --no-run`)
+
+## Audit Requirements
+
+- All dependencies MUST pass `cargo audit --deny warnings`
+- All dependencies SHOULD pass `cargo vet` (exemptions allowed with justification)
+- RUSTSEC critical/high advisories MUST be patched within 48 hours
+- RUSTSEC medium advisories MUST be patched within 1 week
+
+## Adding New Dependencies
+
+New dependencies MUST be reviewed for:
+
+- **Maintenance status**: Recent commits, responsive maintainer, active issue tracker
+- **Known vulnerabilities**: `cargo audit` must be clean
+- **License compatibility**: Must be MIT, Apache-2.0, BSD-2/3, or MPL-2.0
+- **Transitive dependency count**: Prefer minimal dependencies
+- **Unsafe code**: Crates with `unsafe` in their public API must be explicitly approved
+
+### Review Process
+
+1. Run `cargo audit` and `cargo vet` after adding the dependency
+2. Review the crate's README, CHANGELOG, and any security advisories
+3. Check the crate's transitive dependency tree for unexpected additions
+4. Document the review in the commit message or PR description
+
+## Forbidden Dependencies
+
+- Crates with `unsafe` in their public API that haven't been audited
+- Crates with known unpatched RUSTSEC advisories
+- Crates that don't build with `--deny warnings`
+- Crates with obfuscated or minified source code
+- Crates that download code at build time (supply chain attack risk)
+
+## Database Dependencies
+
+### redb
+
+**Used by:** `omnia-node` (via `omnia-substrate` and `omnia-shards`)
+
+**Purpose:** Embedded key-value database for persistent slashing state (`RedbSlashingStore`), nonce tracking (`RedbNonceStore`), and consensus state (`RedbConsensusStore`).
+
+**Properties:**
+- ACID transactions with crash-safe durability
+- Pure Rust implementation with no unsafe code in the storage layer
+- Single-file database with forward compatibility guarantees
+- Actively maintained with regular releases
+
+**Migration note:** The codebase previously used sled 0.34 (alpha-quality), which has been replaced with redb. Sled has been fully removed from the dependency tree.
+
+## Supply Chain Auditing
+
+### cargo-audit
+
+Checks the `Cargo.lock` against the RustSec advisory database for known vulnerabilities.
+
+```bash
+cargo audit --deny warnings
+```
+
+### cargo-vet
+
+Audits dependencies for correctness and safety by importing audit records from trusted sources (Mozilla, Google) and maintaining our own audit records in `supply-chain/audits.toml`.
+
+```bash
+cargo vet --check
+```
+
+### CycloneDX SBOM
+
+Generate a Software Bill of Materials for supply chain transparency:
+
+```bash
+./scripts/generate-sbom.sh
+```
+
+## Exemptions
+
+Crates that cannot be fully audited should be listed in `supply-chain/config.toml` under `[[exemptions]]` with a comment explaining why. Exemptions MUST be reviewed at least quarterly and either audited or removed.
+
+---
+🔙 **Back**: [reference/](./) | 🔄 **Related**: [security-audit.md](./security-audit.md)
+🚀 **Next**: [crypto-migration.md](./crypto-migration.md) | 📜 **Source of Truth**: [Restructuring Blueprint](./blueprint-reference.md)

--- a/docs/reference/metrics-glossary.md
+++ b/docs/reference/metrics-glossary.md
@@ -1,0 +1,88 @@
+# Metrics & Terminology Glossary
+> 🎯 Audience: All
+> 🔗 Context: Definitions of key metrics, terms, and abbreviations used across Omnia Protocol documentation
+> 📅 Last Updated: 2026-05-20
+
+## Protocol Terms
+
+| Term | Definition |
+|------|-----------|
+| **Causal Graph** | A directed acyclic graph (DAG) where nodes represent events and edges represent causal relationships between them |
+| **Vector Clock** | A data structure (`NodeId → LogicalClock`) that tracks what each node has seen, enabling partial ordering of events |
+| **Event** | The fundamental unit of the protocol — a node in the causal graph containing a vector clock, payload, and signature |
+| **Shard** | A specialized domain lane that processes a specific type of transaction (Financial, Identity, Physical, etc.) |
+| **ShardRouter** | The dispatcher that routes events to the correct shard by domain |
+| **CRDT** | Conflict-free Replicated Data Type — a data structure that can be replicated across nodes and merged without conflicts |
+| **GCounter** | Grow-only counter CRDT — each node tracks its own monotonically increasing contribution |
+| **OrSet** | Observed-remove set CRDT — add-wins semantics for concurrent add/remove |
+| **LWWRegister** | Last-write-wins register CRDT — deterministic tiebreaker (version > timestamp > node_id) |
+| **UBC** | Universal Basic Compute — soulbound monthly quota token issued to every identity |
+| **DID** | Decentralized Identifier — self-sovereign identity in the format `did:omnia:<hex>` |
+| **PQC** | Post-Quantum Cryptography — cryptographic algorithms resistant to quantum computing attacks |
+| **BFT** | Byzantine Fault Tolerance — ability to maintain correct operation despite up to 1/3 malicious nodes |
+| **Supermajority** | Greater than 2/3 of validator nodes — required for BFT consensus finality |
+| **Slashing** | Penalty mechanism for misbehaving validators (equivocation, liveness violations, invalid attestations) |
+| **Settlement Layer** | An L1 blockchain (Ethereum, Bitcoin, etc.) where ZK-rollup proofs are verified and state transitions are finalized |
+| **Groth16** | A zero-knowledge proof system used for the ZK-rollup circuit |
+| **Poseidon** | A SNARK-friendly hash function used for on-circuit Merkle path verification |
+| **Mempool** | A bounded queue of pending events waiting to be processed by consensus |
+| **Epoch** | A time period in the economics layer (default: 30 days) used for UBC quota resets and reputation decay |
+| **ECVRF** | Elliptic Curve Verifiable Random Function — used for leader selection in consensus |
+| **DKG** | Distributed Key Generation — a protocol for generating threshold key shares without a trusted dealer |
+
+## Prometheus Metrics
+
+| Metric Name | Type | Description |
+|-------------|------|-------------|
+| `omnia_node_events_submitted_total` | Counter | Total events submitted via the API |
+| `omnia_node_events_finalized_total` | Counter | Total events finalized by consensus |
+| `omnia_node_peers_connected` | Gauge | Current number of connected peers |
+| `omnia_node_consensus_round` | Gauge | Current consensus round |
+| `omnia_node_shard_operations_total` | Counter | Total shard operations processed |
+| `omnia_node_http_requests_total` | Counter | Total HTTP requests served |
+| `omnia_consensus_round_duration_seconds` | Histogram | Consensus round latency |
+| `omnia_gossip_events_sent_total` | Counter | Total gossip events sent |
+| `omnia_gossip_events_received_total` | Counter | Total gossip events received |
+| `omnia_slashing_events_total` | Counter | Total slashing events |
+| `omnia_fees_collected_total` | Counter | Total UBC fees collected |
+| `omnia_causal_graph_total_events` | Gauge | Total events in the causal graph |
+
+## Economic Terms
+
+| Term | Definition |
+|------|-----------|
+| **Soulbound** | Non-transferable — UBC tokens cannot be moved between identities |
+| **QuotaSystem** | Manages monthly UBC allocation with epoch-based advancement |
+| **Quadratic Voting** | Voting power = √stake, preventing whale dominance |
+| **PPM** | Parts per million — used for fixed-point reputation decay arithmetic (no f64) |
+| **DecayRate** | Rate at which reputation decreases per epoch of inactivity (default: 10% = 100,000 PPM) |
+| **Time-Lock** | Stake locked for a minimum duration before gaining voting power (anti flash-loan) |
+| **FeeSchedule** | Maps shard operations to fixed UBC fees |
+| **Gradual Slashing** | 3-tier penalty escalation: Warning → Jail → Ejection |
+
+## Abbreviations
+
+| Abbreviation | Full Form |
+|-------------|-----------|
+| ADR | Architecture Decision Record |
+| DAG | Directed Acyclic Graph |
+| SSS | Shamir's Secret Sharing |
+| GF(256) | Galois Field with 256 elements |
+| R1CS | Rank-1 Constraint System |
+| BN254 | Barreto-Naehrig 254-bit elliptic curve |
+| SRS | Structured Reference String (Powers of Tau) |
+| PoK | Proof of Knowledge |
+| LTO | Link-Time Optimization |
+| AEAD | Authenticated Encryption with Associated Data |
+| HKDF | HMAC-based Key Derivation Function |
+| HD | Hierarchical Deterministic (key derivation) |
+| NAT | Network Address Translation |
+| DHT | Distributed Hash Table |
+| mDNS | Multicast DNS |
+| QUIC | Quick UDP Internet Connections |
+| RPC | Remote Procedure Call |
+| SBOM | Software Bill of Materials |
+
+---
+🔙 **Back**: [reference/](./) | 🔄 **Related**: [benchmark-gates.md](./benchmark-gates.md)
+🚀 **Next**: [adr-index.md](./adr-index.md) | 📜 **Source of Truth**: [Restructuring Blueprint](./blueprint-reference.md)

--- a/docs/reference/roadmap.md
+++ b/docs/reference/roadmap.md
@@ -1,0 +1,123 @@
+# Implementation Roadmap
+> 🎯 Audience: All
+> 🔗 Context: Consolidated roadmap from Phase 0 through Phase 5, with remaining milestones
+> 📅 Last Updated: 2026-05-20
+
+## Phase 0: The Seed ✅ Complete
+
+*Goal: Proof of Concept*
+
+- ✅ Causal graph consensus (Rust, 454+ tests)
+- ✅ Self-sovereign identity system (DIDs, Shamir, biometrics)
+- ✅ Universal Basic Compute (UBC)
+- ✅ 6 domain shards with cross-shard messaging
+- ✅ Settlement-agnostic ZK-rollup architecture
+- ✅ Full ZK circuit (arkworks R1CS + Groth16 + Poseidon)
+- ✅ Real PQC signatures (ML-KEM-768 / FIPS-203)
+- ✅ REST API with JWT auth, rate limiting, CORS
+- ✅ Encrypted keystore (AES-256-GCM)
+- ✅ Gradual slashing (3-tier: Warning → Jail → Ejection)
+- ✅ BFT consensus with VRF leader selection
+- ✅ Docker 5-node testnet + monitoring stack
+
+## Phase 1: Hardening ✅ Complete
+
+- ✅ FIND-024: Typed Error Migration — 34 typed error enums with `thiserror`
+- ✅ FIND-023: `unwrap()` Replacement — `#![deny(clippy::unwrap_used)]` on all 7 crates
+- ✅ E2E REST API Integration Tests — 19 test functions
+- ✅ Code Coverage Integration — `cargo llvm-cov` in CI
+- ✅ FIND-033: RUSTSEC Advisory Review — stale ignores removed
+- ✅ FIND-034: Documentation Sprint — 50+ discrepancy fixes
+- ✅ Solidity Groth16 Verifier — production-quality with BN254 precompiles
+- ✅ FIND-026: Rustdoc Coverage (partial) — 35 documentation items
+
+## Phase 2: Cryptographic Key Management & ZK Hardening ✅ Complete
+
+- ✅ C-1: Fix SSS recovery flow with encrypted shares and key derivation
+- ✅ C-2: Fix trusted setup ceremony with real EC scalar multiplication
+- ✅ H-1: Populate ZK circuit dummy fields with event semantics constraints
+- ✅ H-2: ZK-SNARK benchmark suite
+- ✅ H-3: Groth16 batch verification
+- ✅ H-4: Integrate PQC key rotation with encrypted keystore
+- ✅ H-5: Gradual slashing with jail/suspension and events
+- ✅ M-1: BIP-39 mnemonic support to keystore
+- ✅ M-2: DKG for threshold signatures (Feldman VSS)
+- ✅ M-3: Complete sled removal
+- ✅ M-4: ADRs 010–014
+- ✅ M-5: Project dashboard and status documentation
+
+## Phase 3: Network Optimization & Security Closure ✅ Complete
+
+- ✅ C-1: SSS share encryption — XOR to AES-256-GCM
+- ✅ C-2: DKG share encryption — XOR to AES-256-GCM
+- ✅ C-3: SSS recovery DID authentication update
+- ✅ H-1: ZK circuit trusted setup dummy values
+- ✅ H-2: Trusted setup transcript hash initialization
+- ✅ H-3: Wire leader selection into consensus block production
+- ✅ H-4: Kademlia DHT + NAT Traversal
+- ✅ H-5: GossipSub peer scoring configuration
+- ✅ H-6: Consensus state persistence across restarts
+- ✅ H-7: Real Ethereum settlement adapter (architecture + feature flag)
+- ✅ M-1: ML-KEM-768 key encapsulation
+- ✅ M-2: Fast-sync protocol
+- ✅ M-3: Message compression (Snappy)
+- ✅ M-4: Load testing infrastructure
+- ✅ M-5: RUSTSEC advisory cleanup
+
+## Phase 4: Mainnet Readiness ✅ Complete
+
+- ✅ C-1: Real Ethereum settlement with Alloy
+- ✅ H-1: Gradual slashing implementation — close ADR-011
+- ✅ H-2: Migrate pqc_kyber → ml-kem (fix KyberSlash)
+- ✅ H-3: Fast-sync P2P automation
+- ✅ H-4: Separate liveness and readiness probes
+- ✅ M-1: Multi-party trusted setup ceremony automation
+- ✅ M-2: Documentation sprint — dashboard, ADRs, FAQ
+- ✅ M-3: Load testing baseline capture
+- ✅ M-4: Supply chain hardening
+
+## Phase 5: Testnet Launch & Validation ✅ Complete
+
+- ✅ C-1: Real performance benchmarking (~527 events/sec single-node)
+- ✅ H-1: Multi-node BFT testnet validation
+- ✅ H-2: VRF migration to ECVRF per RFC 9381
+- ✅ H-3: Genesis tooling — network bootstrap procedure
+- ✅ H-4: Ethereum testnet integration test
+- ✅ M-1: Poseidon dual-hash transition foundation
+- ✅ M-2: Bug bounty program setup
+- ✅ M-3: External audit preparation package
+- ✅ M-4: Side-channel audit for ZK and binding crates
+
+## Remaining Work (Post-Phase 5)
+
+### Before Public Testnet
+1. Docker Compose multi-node verification
+2. External security audit
+3. Anvil E2E test execution
+
+### Before Mainnet
+4. Sybil resistance / stake-weighted validator registry
+5. Causal graph GC with pruning
+6. Comprehensive rustdoc coverage (100% public API)
+7. Formal Dilithium timing side-channel audit
+8. Poseidon standard parameter migration (Phase B of dual-hash transition)
+
+### Long-Term
+9. Multi-party trusted setup ceremony over network
+10. Extended formal verification (unbounded TLA+, Rust verification)
+11. RF fingerprint hardware integration
+12. Bitcoin/Solana/Celestia settlement adapters
+13. Mobile wallet
+14. Throughput optimization (multi-threaded, sharded consensus)
+
+### Timeline
+
+| Milestone | Target | Blockers |
+|-----------|--------|-----------|
+| Public Testnet | Q2 2026 | External audit |
+| Mainnet | Q4 2026 | Audit findings, Sybil resistance, GC |
+| Hardened Mainnet | Q1 2027 | Multi-party ceremony, formal verification |
+
+---
+🔙 **Back**: [reference/](./) | 🔄 **Related**: [benchmark-gates.md](./benchmark-gates.md)
+🚀 **Next**: [benchmark-gates.md](./benchmark-gates.md) | 📜 **Source of Truth**: [Restructuring Blueprint](./blueprint-reference.md)

--- a/docs/reference/security-audit.md
+++ b/docs/reference/security-audit.md
@@ -1,0 +1,92 @@
+# Security Audit Package
+> 🎯 Audience: Developers
+> 🔗 Context: Consolidated security audit findings, validated audits, and attack surface documentation
+> 📅 Last Updated: 2026-05-20
+
+## Phase 0 Security Findings
+
+**Version:** v4.0.0 | **Scope:** Full codebase — 7 crates | **Total findings:** 19
+
+### Critical (All Fixed)
+
+| ID | Finding | Status |
+|----|---------|--------|
+| FIND-001 | REST API has no authentication | ✅ Fixed — JWT + AuthorizedCallers + rate limiting + CORS |
+| FIND-002 | Permissionless MintUbc / AdvanceEpoch | ✅ Fixed — ACL authorization |
+| FIND-003 | Creator ↔ Pubkey binding gap | ✅ Fixed — Constant-time `validate_creator_binding()` |
+
+### High (All Fixed)
+
+| ID | Finding | Status |
+|----|---------|--------|
+| FIND-010 | Unencrypted private key storage | ✅ Fixed — AES-256-GCM + HKDF-SHA256 |
+| FIND-011 | Slashing persistence failure not rolled back | ✅ Fixed — Snapshot-and-rollback pattern |
+| FIND-012 | Docker Compose invalid OMNIA_NODE_ID values | ✅ Fixed — Valid u64 integers |
+| FIND-013 | node_id type mismatch (u16 vs u64) | ✅ Fixed — `Option<u64>` |
+
+### Medium
+
+| ID | Finding | Status |
+|----|---------|--------|
+| FIND-020 | No governance quorum | ✅ Fixed — `quorum_percentage` (67%) + time-lock |
+| FIND-021 | No MAX_PAYLOAD_SIZE at gossip level | ✅ Fixed — Early rejection |
+| FIND-022 | Missing BLAKE3 domain separation | ✅ Fixed — `blake3_hash_domain()` with 4 prefixes |
+| FIND-023 | Extensive unwrap() in production code | ✅ Fixed — `#![deny(clippy::unwrap_used)]` on all crates |
+| FIND-024 | Result<_, String> errors in critical paths | ✅ Fixed — 34 typed error enums |
+| FIND-025 | f64 in gossip stats | ✅ Fixed — u64 pairs |
+
+### Low / Informational
+
+| ID | Finding | Status |
+|----|---------|--------|
+| FIND-030 | No unsafe code | ✅ Clean — `#![forbid(unsafe_code)]` on all 7 crates |
+| FIND-031 | No interior mutability in shard state | ✅ Clean — correct pattern |
+| FIND-032 | Grafana default password | ✅ Fixed — Required env var |
+| FIND-033 | 9 ignored RUSTSEC advisories | 🔄 Open — Quarterly review |
+| FIND-034 | Documentation severely out of date | 🔄 Partial — Major gaps resolved |
+
+## Phase 2 Findings
+
+**Scope:** Cryptographic subsystems, ZK circuit integrity, identity recovery | **Total findings:** 5
+
+| ID | Severity | Finding | Status |
+|----|----------|---------|--------|
+| FIND-P2-001 | Critical | SSS recovery doesn't update DID authentication | ✅ Closed (Phase 3) |
+| FIND-P2-002 | Critical | SSS shares use XOR encryption | ✅ Closed (Phase 3) — AES-256-GCM |
+| FIND-P2-003 | Critical | DKG shares use XOR encryption | ✅ Closed (Phase 3) — AES-256-GCM |
+| FIND-P2-010 | High | ZK circuit uses Fr::zero() for witnesses | ✅ Closed (Phase 3) — `for_setup()` with non-zero values |
+| FIND-P2-011 | Medium | Transcript hash zero-initialized | ✅ Closed (Phase 3) — BLAKE3 initialization |
+
+## Remaining Open Risks
+
+| # | Risk | Severity | Mitigation Plan |
+|---|------|----------|-----------------|
+| R1 | `unwrap()` panics in production | Medium → ✅ Resolved | Systematic replacement complete |
+| R2 | String errors | Medium → ✅ Resolved | Typed error migration complete |
+| R3 | No Sybil resistance | Medium | Stake-weighted validator registry |
+| R4 | Causal graph grows unboundedly | Medium | GC mechanism |
+| R5 | Poseidon non-standard round constants | Medium | Migration to Filecoin/Neptune parameters |
+| R6 | Solidity Groth16 verifier was stub | High → ✅ Resolved | Production-quality verifier |
+| R7 | No multi-party trusted setup | Medium | Ceremony automation implemented |
+| R8 | Single primary developer | High | Organizational action needed |
+| R9 | No formal verification beyond bounded TLA+ | High | Extended verification planned |
+| R10 | RF fingerprinting is a stub | Medium | Hardware integration needed |
+| R11 | pqc_dilithium no constant-time guarantee | Medium → ✅ Mitigated | ML-KEM migration, hybrid mode |
+
+## Key Audit Documents
+
+| Document | Location |
+|----------|----------|
+| Threat Model | `docs/security/THREAT_MODEL.md` |
+| Side-Channel Audit (Substrate) | `docs/security/SIDE_CHANNEL_AUDIT.md` |
+| Side-Channel Audit (ZK + Binding) | `docs/security/SIDE_CHANNEL_AUDIT_ZK_BINDING.md` |
+| Self-Assessment | `docs/audit/SELF_ASSESSMENT.md` |
+| Audit Scope | `docs/audit/AUDIT_SCOPE.md` |
+| Attack Surface | `docs/audit/ATTACK_SURFACE.md` |
+| Audit Package | `docs/audit/AUDIT_PACKAGE.md` |
+| Findings Template | `docs/audit/AUDIT_FINDINGS_TEMPLATE.md` |
+| Phase 0 Roadmap | `PHASE_0_ROADMAP.md` |
+
+---
+🔙 **Back**: [reference/](./) | 🔄 **Related**: [../architecture/trait-boundaries.md](../architecture/trait-boundaries.md)
+🚀 **Next**: [dependency-policy.md](./dependency-policy.md) | 📜 **Source of Truth**: [Restructuring Blueprint](./blueprint-reference.md)

--- a/docs/use-cases/README.md
+++ b/docs/use-cases/README.md
@@ -1,0 +1,19 @@
+# Use Cases — Scenarios & Community
+> 🎯 Audience: All
+> 🔗 Context: Real-world application scenarios, phase deliverables mapped to user impact, and community documentation
+> 📅 Last Updated: 2026-05-20
+
+This directory contains user-facing documentation: real-world scenarios that demonstrate Omnia's capabilities, an FAQ for common questions, and the governance system documentation.
+
+## 📂 Documents
+
+| Document | Audience | Description |
+|----------|----------|-------------|
+| [real-world-scenarios.md](real-world-scenarios.md) | Laymen, All | 10 real-world use cases — financial inclusion, supply chain, healthcare, IP, AI, interplanetary trade, refugee identity, governance, energy, science |
+| [phase-alignment.md](phase-alignment.md) | All | Phase 0–5 deliverables mapped to user impact and feature availability |
+| [faq.md](faq.md) | All | Frequently asked questions about the protocol, economics, security, and practical usage |
+| [governance.md](governance.md) | All | Governance system — quadratic voting, reputation decay, time-locked voting, treasury, AI agent participation |
+
+---
+🔙 **Back**: [docs/](../) | 🔄 **Related**: [reference/roadmap.md](../reference/roadmap.md)  
+🚀 **Next**: [real-world-scenarios.md](./real-world-scenarios.md) | 📜 **Source of Truth**: [Restructuring Blueprint](../reference/blueprint-reference.md)

--- a/docs/use-cases/faq.md
+++ b/docs/use-cases/faq.md
@@ -1,0 +1,337 @@
+# Frequently Asked Questions
+> 🎯 Audience: All
+> 🔗 Context: Common questions about the Omnia Protocol, its economics, security model, and practical usage
+> 📅 Last Updated: 2026-05-20
+
+## General Questions
+
+### Q: What is Omnia?
+
+**A:** Omnia is a universal coordination layer for reality — a decentralized protocol that replaces trust with mathematics. It enables value exchange, identity verification, and physical-digital fusion without intermediaries.
+
+Think of it like the internet. No one owns the internet; it's just a set of rules (TCP/IP) that lets computers talk to each other. Omnia is the same idea, but for **value, identity, and trust**.
+
+### Q: Is Omnia a cryptocurrency?
+
+**A:** No. Omnia is a protocol, not a coin. While Omnia has a token model (UBC — Universal Basic Compute), the protocol itself is much broader. It's a framework for:
+
+- Identity management (DIDs, social recovery, biometric anchors, AI agents)
+- Supply chain tracking (append-only provenance logs)
+- AI agent governance (5 capability types with bounded permissions)
+- Economic coordination (quadratic voting, time-locked voting, useful-work rewards)
+- Physical-digital binding (RF fingerprints, quantum commitments)
+
+### Q: Who controls Omnia?
+
+**A:** No one. Omnia is decentralized and governed by the community through transparent, mathematical processes. There is no central authority, company, or government that controls it.
+
+### Q: Is Omnia open source?
+
+**A:** Yes. All code is open source and available on GitHub. The protocol is public domain (CC0), meaning anyone can use, modify, or build on it.
+
+### Q: What is the current state of the project?
+
+**A:** All 5 core layers are implemented and tested (938+ tests passing). The protocol has causal graph consensus with VRF-based leader selection, 6 domain shards (Financial, Computational, Physical, Biological, Identity, Economics), a binding layer with provenance tracking, identity hardening with DIDs and Shamir's Secret Sharing, and an economics layer with UBC and quadratic voting. The ZK-rollup settlement layer uses real arkworks R1CS + Groth16 + Poseidon proofs on BN254 with Merkle path verification. ML-KEM-768 (FIPS-203) post-quantum cryptography and fee enforcement are implemented. Phase 3 added Kademlia DHT peer discovery, GossipSub peer scoring, consensus state persistence, fast-sync protocol, message compression, and gradual slashing. Some features like real RF fingerprinting remain stubs awaiting hardware. Bitcoin/Solana/Celestia settlement adapters are stubs. There is no mobile wallet and no validator network yet.
+
+### Q: How do I run the tests?
+
+**A:** Clone the repository and run:
+
+```bash
+git clone https://github.com/Willow7737/omnia-protocol.git
+cd omnia-protocol
+cargo test --workspace
+```
+
+You should see 938+ tests passing.
+
+---
+
+## Technical Questions
+
+### Q: How does causal graph consensus work?
+
+**A:** Instead of organizing events into sequential blocks, Omnia maintains a directed acyclic graph (DAG) where:
+
+- Each event (transaction) is a node
+- Edges represent causal relationships (event A must happen before event B)
+- Unrelated events can be processed in parallel
+- The graph naturally captures causality without artificial ordering
+
+**Example:**
+```
+If Alice pays Bob, and Carol pays Dave:
+- These are independent events
+- They can happen simultaneously
+- Only when Bob pays Carol do we need to establish order
+```
+
+This is much faster than traditional blockchains where every transaction waits in a single queue.
+
+### Q: What are zero-knowledge proofs?
+
+**A:** Zero-knowledge proofs let you prove something is true without revealing the underlying information.
+
+**Analogy:** You and a friend are looking for Wally in a crowded picture. You found him. How do you prove it without showing where he is?
+
+You take a massive piece of paper with a small hole in it. You place it over the picture so only Wally is visible through the hole. Your friend sees Wally and knows you found him — but learns nothing about where he is in the full picture.
+
+**In Omnia:**
+- Prove you're over 18 without revealing your birth date
+- Prove you have enough money without revealing your balance
+- Prove a medicine is authentic without revealing supply chain details
+
+**Current status:** The ZK circuit uses arkworks R1CS + Groth16 + Poseidon hash for proof generation and verification. The Biological shard's `QueryWithZkProof` operation uses a stub verifier that checks consent but does not perform real ZK proof verification.
+
+### Q: How does physical anchoring work?
+
+**A:** The provenance log is fully implemented — it provides an append-only CRDT log for tracking the lifecycle of physical items (create, transfer, verify). This gives every tracked item a cryptographic birth certificate and ownership history. The `PhysicalState` (in `shards/src/physical/state.rs`) maintains a `HashMap<ItemId, Vec<ProvenanceEvent>>` where each entry records the owner, event type, vector clock, and optional metadata.
+
+RF fingerprinting remains a stub requiring real SDR hardware (HackRF/USRP) for production use. The quantum commitment implementation is no longer a stub — it now uses real ML-KEM-768 (FIPS-203 standardized Kyber768) for post-quantum key encapsulation, with constant-time comparisons via `subtle::ConstantTimeEq` (see ADR-020). The hybrid mode combines classical X25519 ECDH with ML-KEM-768 for defense-in-depth.
+
+Physical time anchors (previously described as "Gravitational Timestamps") are not implemented. The protocol currently relies on logical time via vector clocks rather than physical time anchors.
+
+### Q: What's a Decentralized Identifier (DID)?
+
+**A:** A DID is a permanent, self-created digital address that you own forever.
+
+**Format:** `did:omnia:<hex_public_key>` where `<hex_public_key>` is a 64-character hex string representing a 32-byte Ed25519 public key.
+
+**Example:** `did:omnia:ab01cdef0123456789abcdef0123456789abcdef0123456789abcdef01234567`
+
+The validation rules (implemented in `shards/src/identity/did.rs`) are:
+- Must start with `did:omnia:` (the `DID_PREFIX` constant)
+- The method-specific identifier must be exactly 64 hex characters (32 bytes)
+- The hex must be valid (no non-hex characters)
+
+**Properties:**
+- You create it yourself (no authority issues it)
+- It's cryptographically verifiable
+- It cannot be revoked or censored
+- It's portable across platforms
+
+The `format_did()` function constructs DIDs from 32-byte public keys:
+```rust
+// shards/src/identity/did.rs
+pub fn format_did(public_key: &[u8; 32]) -> String {
+    format!("{}{}", DID_PREFIX, hex::encode(public_key))
+}
+```
+
+### Q: How does social recovery work?
+
+**A:** Social recovery uses **Shamir's Secret Sharing over GF(256)** (implemented in `shards/src/identity/recovery.rs`). Your private key is split into shares using threshold cryptography, and each share is given to a trusted guardian.
+
+1. Your key is split into N shares using `ShamirRecovery::split(secret, threshold, total)`
+2. Any threshold number of shares (e.g., 3 of 5) can reconstruct the key via `ShamirRecovery::reconstruct(shares)`
+3. If you lose your key, guardians provide their shares
+4. The key is reconstructed from the threshold number of shares using Lagrange interpolation
+5. No single guardian has your full key (K-1 shares reveal nothing)
+
+The GF(256) arithmetic uses the AES irreducible polynomial (0x11B) for reduction, ensuring byte-level operations without big-integer arithmetic. The threshold must be at least 2.
+
+### Q: What's Universal Basic Compute (UBC)?
+
+**A:** Every identity on Omnia receives a free monthly quota via the UBC token (implemented in `economics/src/ubc.rs`). The UBC token is soulbound (non-transferable) and provides a baseline of compute and transaction capacity. This ensures participation doesn't require money.
+
+Key parameters (from `economics/src/quota.rs`):
+- **Default quota**: 1,000 UBC/month (`DEFAULT_UBC_QUOTA`)
+- **Epoch duration**: 30 days (2,592,000,000 ms, `DEFAULT_EPOCH_DURATION_MS`)
+- **Monthly reset**: Balances are reset to the monthly quota at each epoch boundary; unspent balance is forfeited (anti-hoarding)
+- **Useful-work rewards**: Extra UBC can be earned via `UbcToken::reward()` (additive, not reset)
+
+### Q: How does governance work?
+
+**A:** Quadratic voting with multiplicative reputation decay is currently implemented in `economics/src/governance.rs` and `economics/src/fixed_point.rs`. This means:
+
+- Voting power scales as the integer square root of stake (preventing whale dominance)
+- Reputation decays per epoch of inactivity using fixed-point PPM arithmetic (no floating-point)
+- Default decay rate: 10% per epoch (`DecayRate::ten_percent()` = 100,000 PPM)
+- All decay calculations are bit-for-bit identical across platforms (x86, ARM, etc.)
+- After voting, the voter's `last_active` is updated, resetting the decay clock
+
+**Time-locked voting** is also implemented (in `economics/src/time_lock.rs`), preventing flash loan attacks:
+- Stake must be locked for a minimum duration (default: 100 blocks) before it grants voting power
+- Freshly-locked stake has zero voting power until the lock matures
+- Supports multiple concurrent locks per node
+
+**Planned for Phase 1 (not yet implemented):**
+- Conviction voting (graduated multipliers based on lock duration)
+- Delegation (delegating your vote to a trusted representative)
+
+**AI agent governance:** AI agents with `AgentCapability::GovernanceVote { max_weight }` can participate in governance with a bounded maximum voting weight.
+
+---
+
+## Economic Questions
+
+### Q: How is Omnia currency created?
+
+**A:** Omnia uses the UBC (Universal Basic Compute) token model. UBC tokens are soulbound — they are issued monthly to each identity and cannot be transferred. The `UbcToken::mint_monthly()` method resets the balance to the monthly quota at epoch boundaries. The `UbcToken::spend()` method consumes UBC for transactions (destroyed, not transferred). The `UbcToken::reward()` method adds UBC for useful-work contributions (additive, not reset at epoch boundaries).
+
+Proof-of-useful-work is implemented with 3 work types defined in `economics/src/useful_work.rs`:
+- `AiTraining { model_hash, training_data_hash }` — AI model training
+- `ScientificSimulation { simulation_id, params_hash }` — Distributed computation
+- `DistributedStorage { data_hash, storage_duration }` — Data hosting
+
+Verification is currently a stub (`UsefulWorkProof::verify_stub()`) that checks for non-zero result hash and positive compute units. Reward amount equals compute units consumed (1:1 ratio).
+
+There is no validator reward mechanism or staking system yet. Gradual slashing is implemented (ADR-011) with a 3-tier model: Warning → Jail → Ejection.
+
+### Q: What's the fee structure?
+
+**A:** Fee enforcement is **implemented** via the `FeeSchedule` struct (in `shards/src/fee_schedule.rs`) and the `ShardRouter` (in `shards/src/router.rs`). The standard fee schedule has flat per-operation-type fees:
+
+| Domain | Fee (UBC) |
+|--------|-----------|
+| Financial | 10 |
+| Computational | 5 |
+| Physical | 3 |
+| Identity | 2 |
+| Biological | 3 |
+| Cross-Shard | 15 |
+| Economics/Default | 3 |
+
+When `ShardRouter::route_event()` processes an event, it:
+1. Deserializes the payload into a `ShardPayload`
+2. Checks the nonce for replay protection
+3. Looks up the fee via `FeeSchedule::fee_for_op()`
+4. Deducts the fee from the caller's UBC quota via `QuotaSystem::spend()`
+5. Routes the operation to the target shard
+
+If the caller has insufficient UBC, the operation is rejected with `ShardError::InsufficientFee`.
+
+A `ShardRouter::new_without_fees()` constructor is available for testing.
+
+### Q: Can I convert Omnia to other currencies?
+
+**A:** No DEX integration exists yet. There is currently no way to exchange Omnia tokens for other currencies.
+
+---
+
+## Security Questions
+
+### Q: Is Omnia secure?
+
+**A:** Omnia uses multiple layers of security that are implemented and tested:
+
+| Security Layer | Status |
+|---------------|--------|
+| Ed25519 signatures | Implemented |
+| BLAKE3 hashing | Implemented |
+| BFT consensus (<1/3 faulty nodes) | Implemented |
+| Replay protection (nonce tracking with redb persistence) | Implemented |
+| State commitments (Merkle root) | Implemented |
+| Event pruning (sustainability) | Implemented |
+| Fee enforcement (FeeSchedule + QuotaSystem) | Implemented |
+| Time-locked voting (flash loan prevention) | Implemented |
+| Shamir's Secret Sharing social recovery (GF(256)) | Implemented |
+| Biometric anchors (BLAKE3 salted commitments) | Implemented |
+| Post-quantum cryptography (ML-KEM-768 / FIPS-203) | Implemented |
+| Gradual slashing (3-tier: Warning → Jail → Ejection) | Implemented |
+| Economic security (staking rewards) | Not started |
+| Real ZK proofs | Implemented (arkworks R1CS + Groth16 + Poseidon) |
+
+### Q: What if my private key is compromised?
+
+**A:** You can use social recovery via Shamir's Secret Sharing to reconstruct your key from guardian shares. The implementation (in `shards/src/identity/recovery.rs`) supports configurable thresholds (minimum K=2, with configurable N total shares). The `IdentityOp::ConfigureRecovery` operation splits the secret and stores the threshold/total configuration. The `IdentityOp::RecoverDid` operation reconstructs the secret from K+ shares.
+
+The reconstructed secret is used to rotate the DID's public key and authentication methods via `complete_recovery()`, which adds the recovered key to DID authentication (rotation, not replacement). A `recovery_count` is incremented to prevent replay attacks.
+
+---
+
+## Practical Questions
+
+### Q: How do I get started?
+
+**A:** You can interact with Omnia via the Rust library or the `omnia-node` binary with REST API (Sprint 3). There is no wallet and no mobile app yet. To experiment:
+
+1. Clone the repository
+2. Run `cargo test --workspace` to see all tests passing
+3. Run `cargo run -p omnia-node` to start a node with HTTP health/metrics/Swagger UI
+4. Explore the crate APIs in `substrate/`, `shards/`, `binding/`, `economics/`, `zk/`
+
+### Q: Which wallet should I use?
+
+**A:** No wallet exists yet. All interaction is via the Rust library API. A mobile wallet is planned for Phase 1.
+
+### Q: Can I use Omnia on my phone?
+
+**A:** No mobile app exists yet. A mobile wallet is planned for Phase 1.
+
+### Q: How long does a transaction take?
+
+**A:** Performance has not been benchmarked at scale yet. The consensus engine processes only new events each round (O(new_events)), which is designed for low latency, but specific TPS and finality numbers have not been measured.
+
+### Q: How does fast-sync work for new nodes?
+
+**A:** Fast-sync (implemented in `substrate/src/fast_sync.rs`) allows new nodes to skip full genesis replay by downloading a verified state snapshot from peers:
+
+1. **Query peers** for their latest checkpoint (round, state root, event count)
+2. **Select a target** checkpoint via supermajority agreement (2/3+ stake must agree)
+3. **Download the snapshot** from a peer via P2P request-response
+4. **Verify integrity** using BLAKE3 domain-separated hashes (`OMNIA-FAST-SYNC-V1`)
+5. **Replay delta events** since the snapshot to reach the current state
+
+If fast-sync fails (no peers, insufficient agreement), the node falls back to genesis replay via `try_sync_or_fallback()`. Fast-sync is enabled when `config.fast_sync && !config.is_genesis`.
+
+### Q: What are the liveness and readiness probes?
+
+**A:** The `omnia-node` binary exposes separate Kubernetes liveness (`/healthz`) and readiness (`/readyz`) endpoints:
+
+- **Liveness** (`/healthz`): Always returns 200 with `{"status": "alive", "node_id", "uptime_seconds"}`. Indicates the process is running. If this fails, Kubernetes restarts the pod.
+- **Readiness** (`/readyz`): Returns 200 when the node has peers, is not syncing, and has recent finalization. Returns 503 with `{"status": "not_ready", "reason": "no_peers"|"syncing"|"no_finalization"}` otherwise. If this fails, Kubernetes removes the pod from service but does not restart it.
+- **Legacy** (`/health`): Maps to the liveness handler for backward compatibility.
+
+Configuration: `readiness_min_peers` (default: 1) and `readiness_max_finalization_age` (default: 600 rounds) can be tuned via TOML config.
+
+### Q: How can I participate in the trusted setup ceremony?
+
+**A:** The Omnia Protocol uses a Powers of Tau style trusted setup ceremony for the Groth16 ZK circuit. The ceremony is multi-party: each participant contributes randomness to the transcript, and only one honest participant is needed for security. The transcript hash is initialized using BLAKE3 domain separation (`OMNIA-SETUP-TRANSCRIPT-V1`) and includes Fiat-Shamir Proof of Knowledge on BN254 G1 with real EC operations. See `zk/src/setup/contribution.rs` for the implementation.
+
+### Q: How does gradual slashing work?
+
+**A:** The gradual slashing model (ADR-011) replaces the previous binary slash-point system with a 3-tier escalation:
+
+1. **Warning**: Minor offenses (e.g., brief liveness failure). The validator is flagged but remains active.
+2. **Jail**: Repeated or moderate offenses. The validator is temporarily suspended from consensus and cannot produce blocks or earn rewards. Auto-release occurs after a configurable jail period.
+3. **Ejection**: Severe or persistent offenses (e.g., equivocation). The validator is permanently removed and their stake is partially burned.
+
+This approach avoids the "nothing to lose" perverse incentive of binary slashing, where a validator close to the threshold has no reason not to cause maximum damage.
+
+---
+
+## Long-Term Vision
+
+*The following describes the long-term vision for Omnia. These are aspirational goals, not current capabilities.*
+
+### Q: Will Omnia work on Mars?
+
+**A:** This is a long-term vision. Omnia's causal graph consensus is designed to support partitioned operation (local finality with eventual global consistency via `VectorClock::happened_before()` and `CrossShardMessage`), which could in principle work across interplanetary distances. However, no testing or implementation for interplanetary scenarios has been done.
+
+### Q: Will AI agents run Omnia?
+
+**A:** AI agent identity is implemented with 5 capability types (in `shards/src/identity/agent.rs`):
+- `FinancialTransfer { max_amount, currency }` — Bounded financial operations
+- `DataProcessing { domains, max_records }` — Scoped data access
+- `ContractExecution { contract_types }` — Limited contract interaction
+- `ComputeProof { max_compute_units }` — Bounded compute submission
+- `GovernanceVote { max_weight }` — Bounded governance participation
+
+AI agents can currently have identities on the network with these capabilities. Full governance rights for AI agents and AI-driven decision-making are aspirational goals for Phase 3 (Years 5-10).
+
+---
+
+## Troubleshooting
+
+### Q: I have a question not answered here
+
+**A:**
+- Check the documentation: [ARCHITECTURE.md](../ARCHITECTURE.md)
+- Ask on Discord: [Join our Discord](https://discord.gg/qYkpAeSYR)
+- Open an issue: [GitHub Issues](https://github.com/Willow7737/omnia-protocol/issues)
+- Start a discussion: [GitHub Discussions](https://github.com/Willow7737/omnia-protocol/discussions)
+
+---
+🔙 **Back**: [use-cases/](./) | 🔄 **Related**: [governance.md](./governance.md)  
+🚀 **Next**: [governance.md](./governance.md) | 📜 **Source of Truth**: [Restructuring Blueprint](../reference/blueprint-reference.md)

--- a/docs/use-cases/governance.md
+++ b/docs/use-cases/governance.md
@@ -1,0 +1,455 @@
+# Governance System
+> 🎯 Audience: All
+> 🔗 Context: Omnia's governance system — quadratic voting, reputation decay, time-locked voting, AI agent participation, and future plans
+> 📅 Last Updated: 2026-05-20
+
+> **This document describes the governance system as implemented. Sections are labeled with their implementation status.**
+
+## Principles
+
+### 1. Decentralization
+
+No single entity controls Omnia. Decisions are made by the community through transparent, mathematical processes.
+
+### 2. Meritocracy
+
+Voting power is earned through contribution, not bought. Quadratic voting prevents whale dominance; time-locked staking prevents flash loan attacks.
+
+### 3. Transparency
+
+All governance decisions are recorded on-chain and auditable by anyone.
+
+### 4. Inclusivity
+
+Everyone — humans, AI agents, collectives — has a voice in governance. AI agents can hold `GovernanceVote` capabilities with a configurable `max_weight` limit.
+
+### 5. Adaptability
+
+The protocol evolves to meet changing needs without requiring hard forks.
+
+---
+
+## Governance Structure
+
+### Three Pillars
+
+#### 1. Technical Governance (Protocol Changes) — Planned
+
+**Who decides:** Core developers and researchers
+
+**Process:**
+1. Proposal submitted (RFC format)
+2. Community discussion (2 weeks)
+3. Technical review (1 week)
+4. Implementation (if approved)
+5. Staged rollout (shadow fork → testnet → mainnet)
+
+**Voting:** Weighted by code contributions and reputation
+
+#### 2. Economic Governance (Monetary Policy) — Partially Implemented
+
+**Who decides:** Token holders and UBC recipients
+
+**Voting:** Quadratic voting (voting power = isqrt(stake)) — **Implemented** in `economics/src/governance.rs`
+
+Full economic governance process (proposal submission, impact analysis, voting periods) is planned but not yet implemented as an end-to-end flow. The `GovernanceState` type supports creating proposals, casting votes, and tracking participation:
+
+```rust
+// economics/src/governance.rs
+pub struct GovernanceState {
+    pub voting_weights: HashMap<String, u64>,
+    pub last_active: HashMap<String, u64>,
+    pub decay_rate: DecayRate,
+    pub proposals: HashMap<String, Proposal>,
+}
+```
+
+#### 3. Social Governance (Community Standards) — Planned
+
+**Who decides:** Community members
+
+**Process:**
+1. Issue raised (GitHub, [Discord](https://discord.gg/qYkpAeSYR))
+2. Community discussion
+3. Consensus-building
+4. Implementation (if consensus reached)
+
+**Voting:** Simple majority (>50%)
+
+---
+
+## Voting Mechanisms
+
+### Quadratic Voting — Implemented
+
+Voting power = isqrt(stake), where `isqrt` is the integer square root via Newton's method defined in `economics/src/fixed_point.rs`.
+
+**Example:**
+- Alice stakes 100 tokens → voting power = 10
+- Bob stakes 10,000 tokens → voting power = 100
+- Carol stakes 1,000,000 tokens → voting power = 1,000
+
+**Effect:** One large stakeholder (Carol) has 10× power, not 10,000×. This prevents whale dominance while still rewarding commitment.
+
+This is implemented in `economics/src/governance.rs` with multiplicative reputation decay using fixed-point PPM arithmetic (no floating-point). The `VoteChoice` enum supports three options:
+
+```rust
+// economics/src/governance.rs
+pub enum VoteChoice {
+    For,
+    Against,
+    Abstain,
+}
+```
+
+The `GovernanceState::vote()` method casts a vote using the DID's effective weight (base weight reduced by inactivity decay):
+
+```rust
+pub fn vote(
+    &mut self,
+    did: &str,
+    proposal_id: &str,
+    choice: VoteChoice,
+    current_epoch: u64,
+) -> Result<(), EconomicsError>
+```
+
+### Time-Locked Voting — Implemented
+
+Time-locked voting is **implemented** in `economics/src/time_lock.rs`. Stake must be locked for a minimum duration before it grants voting power, preventing flash loan attacks where an attacker borrows stake, votes, and repays in the same block.
+
+**Configuration** (`TimeLockConfig`):
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `min_lock_duration` | 100 blocks | Minimum lock (~8 min at 5s finality) |
+| `max_lock_duration` | 100,000 blocks | Maximum lock (~6 days at 5s finality) |
+| `strict_enforcement` | true | No early withdrawals |
+
+**How it works:**
+
+1. A user locks stake via `TimeLockVoting::lock(owner, amount, current_height, duration)`.
+2. The stake has zero voting power until `current_height >= lock_start + duration`.
+3. After the lock matures, the full stake amount contributes to voting power.
+4. The user can release matured stakes via `release_expired()`, which removes them from voting power.
+
+**Flash loan resistance**: Freshly-locked stake has zero voting power. Borrowed funds cannot be used for voting because the lock must mature over multiple blocks.
+
+```rust
+// economics/src/time_lock.rs
+pub fn voting_power(&self, current_height: u64) -> u64 {
+    if self.released { 0 }
+    else if self.is_mature(current_height) { self.amount }
+    else { 0 }
+}
+```
+
+### Conviction Voting — Planned
+
+Voters can lock tokens for longer periods to increase voting power beyond the time-lock mechanism. The current time-locked voting implementation provides a binary power model (0 if immature, full amount if mature). Conviction voting would add graduated multipliers based on lock duration.
+
+This is planned for Phase 1 but not yet implemented.
+
+### Delegation — Planned
+
+Voters can delegate their voting power to trusted representatives.
+
+**Process:**
+1. Voter selects delegate
+2. Delegate votes on behalf of voter
+3. Voter can revoke delegation anytime
+4. Delegate's voting power is public
+
+This is planned for Phase 1 but not yet implemented.
+
+---
+
+## Governance Cycles — Planned
+
+### Monthly Governance
+
+**First Monday of each month:**
+- Governance call (1 hour)
+- Community presents proposals
+- Voting begins
+
+**Second Monday:**
+- Voting ends
+- Results announced
+- Implementation planning
+
+### Quarterly Reviews
+
+**Every 3 months:**
+- Review protocol performance
+- Assess community health
+- Plan next quarter's initiatives
+
+---
+
+## Proposal Types — Planned
+
+### Tier 1: Minor Updates (Fast Track)
+
+| Property | Value |
+|----------|-------|
+| **Examples** | Bug fixes, documentation, small parameter adjustments |
+| **Timeline** | 1 week |
+| **Voting** | Simple majority |
+| **Implementation** | Immediate |
+
+### Tier 2: Standard Proposals (Normal Track)
+
+| Property | Value |
+|----------|-------|
+| **Examples** | New features, protocol improvements, economic policy changes |
+| **Timeline** | 4 weeks |
+| **Voting** | Quadratic voting (>66% approval) |
+| **Implementation** | Staged rollout |
+
+### Tier 3: Major Changes (Extended Track)
+
+| Property | Value |
+|----------|-------|
+| **Examples** | Consensus mechanism changes, new domain shards |
+| **Timeline** | 12 weeks |
+| **Voting** | Quadratic voting (>75% approval) |
+| **Implementation** | Shadow fork → testnet → mainnet (3+ months) |
+
+The `Proposal` struct in the codebase supports the basic fields needed for proposals:
+
+```rust
+// economics/src/governance.rs
+pub struct Proposal {
+    pub id: String,
+    pub description: String,
+    pub created_at_epoch: u64,
+    pub expires_at_epoch: u64,
+    pub votes_for: u64,
+    pub votes_against: u64,
+    pub votes_abstain: u64,
+}
+```
+
+---
+
+## Dispute Resolution — Planned
+
+### Conflict Resolution Process
+
+| Step | Duration | Description |
+|------|----------|-------------|
+| 1 | 1 week | Negotiation — Parties discuss directly; mediator facilitates |
+| 2 | 2 weeks | Arbitration — Neutral arbitrator reviews evidence, proposes solution |
+| 3 | 2 weeks | Community Vote — If parties disagree with arbitration; decision is binding |
+
+### Slashing — Aspirational
+
+Validators can be slashed (lose stake) for:
+
+| Offense | Slash Amount | Reason |
+|---------|--------------|--------|
+| Double-signing | 100% | Attempting to finalize conflicting blocks |
+| Offline >24h | 1% per day | Failing to participate in consensus |
+| Malicious behavior | 50-100% | Attacking the network |
+| Censoring transactions | 25% | Refusing to include valid transactions |
+
+Slashing is aspirational — there is no validator network or staking system yet.
+
+---
+
+## Reputation System
+
+### Reputation Decay — Implemented
+
+Reputation decays via multiplicative decay per epoch of inactivity. This is implemented in `economics/src/governance.rs` and `economics/src/fixed_point.rs`. Active users experience slower decay than inactive users because voting updates `last_active` to the current epoch.
+
+**Decay formula** (fixed-point PPM arithmetic, no f64):
+
+```
+effective_weight = base_weight * remaining_ppm / BASIS_PPM
+where remaining_ppm = (BASIS_PPM - decay_rate.ppm())^epochs / BASIS_PPM^epochs
+```
+
+Default decay rate: `DecayRate::ten_percent()` = 100,000 PPM per epoch.
+
+**Effect:** Power cannot concentrate. Even early adopters must stay active to maintain influence.
+
+### Reputation Scoring — Not Started
+
+The full reputation scoring system (transaction history, credential issuance, community votes, validator performance) is not yet implemented. Only the decay mechanism and quadratic weight calculation exist.
+
+### AI Agent Participation — Implemented
+
+AI agents can participate in governance through the `AgentCapability::GovernanceVote` capability type, defined in `shards/src/identity/agent.rs`:
+
+```rust
+// shards/src/identity/agent.rs
+pub enum AgentCapability {
+    FinancialTransfer { max_amount: u64, currency: String },
+    DataProcessing { domains: Vec<String>, max_records: u64 },
+    ContractExecution { contract_types: Vec<String> },
+    ComputeProof { max_compute_units: u64 },
+    GovernanceVote { max_weight: u64 },
+}
+```
+
+The `GovernanceVote` capability includes a `max_weight` parameter that limits the agent's maximum quadratic voting weight, ensuring that AI agents cannot exceed their authorized governance influence.
+
+### Reputation Thresholds — Planned
+
+| Threshold | Privileges |
+|-----------|-----------|
+| **0-10** | Read-only access |
+| **10-25** | Can vote on Tier 1 proposals |
+| **25-50** | Can vote on Tier 2 proposals |
+| **50-75** | Can vote on Tier 3 proposals |
+| **75-100** | Can propose Tier 3 changes |
+
+---
+
+## Treasury Management — Aspirational
+
+### Revenue Sources
+
+| Source | Amount | Use | Status |
+|--------|--------|-----|--------|
+| Transaction fees | Implemented (FeeSchedule) | RPGF pool | Not yet distributed |
+| High-frequency fees | Not implemented | UBC subsidies | Not started |
+| Validator rewards | Not implemented | Incentivize validation | Not started |
+| Slashing proceeds | Not implemented | RPGF pool | Not started |
+
+### Spending Categories
+
+| Category | Allocation | Purpose | Status |
+|----------|-----------|---------|--------|
+| RPGF | 40% | Reward public goods | Aspirational |
+| UBC subsidies | 30% | Free access for all | Aspirational |
+| Research | 15% | Academic partnerships | Aspirational |
+| Infrastructure | 10% | Nodes, storage, bandwidth | Aspirational |
+| Emergency reserve | 5% | Crisis response | Aspirational |
+
+All treasury distribution is aspirational — there are no transaction fee distribution mechanisms, no validator rewards, and no treasury mechanism implemented yet. The `FeeSchedule` collects fees via the `ShardRouter`, but the collected UBC is simply consumed (burned), not redirected to a treasury.
+
+### RPGF Process — Aspirational
+
+**Quarterly RPGF Rounds:**
+
+1. **Nomination Phase** (2 weeks) — Community nominates projects
+2. **Evaluation Phase** (2 weeks) — Community evaluates impact
+3. **Voting Phase** (2 weeks) — Quadratic voting on allocations
+4. **Distribution Phase** (1 week) — Funds automatically distributed
+
+---
+
+## Amending Governance — Planned
+
+### Governance Change Process
+
+To change the governance system itself:
+
+1. **Proposal:** Detailed proposal submitted (Tier 3)
+2. **Discussion:** 4-week community discussion
+3. **Voting:** 75% approval required
+4. **Implementation:** 3-month shadow fork testing
+5. **Activation:** Community vote to activate
+
+### Constitutional Constraints
+
+Governance cannot:
+
+- Centralize power in a single entity
+- Eliminate quadratic voting
+- Remove transparency requirements
+- Violate privacy of users
+- Discriminate based on identity type (human, AI, collective)
+
+---
+
+## Community Participation
+
+### How to Get Involved
+
+#### 1. Contribute Code
+
+**Process:**
+1. Fork repository
+2. Create feature branch
+3. Implement with tests
+4. Submit pull request
+5. Code review (1 approval for now — small team)
+6. Merge
+
+#### 2. Participate in Governance
+
+**Process:**
+1. Run the protocol locally
+2. Test governance features (quadratic voting, reputation decay, time-locked voting)
+3. Propose changes via GitHub Issues or Discussions
+
+#### 3. Build Applications
+
+**Process:**
+1. Build tool/service using the Omnia Rust library
+2. Attract users
+3. Apply for RPGF funding (when implemented)
+
+---
+
+## Governance FAQ
+
+### Q: What if I disagree with a governance decision?
+
+**A:** You have several options:
+
+1. **Propose a change:** Submit a proposal to reverse the decision
+2. **Exit:** Withdraw your stake and leave the network
+3. **Fork:** Create an alternative version of the protocol (requires community support)
+
+### Q: Can governance decisions be reversed?
+
+**A:** Yes. Any decision can be reversed through the same process that created it. This requires:
+
+- Tier 3 proposal (if it was a Tier 3 decision)
+- 75% approval
+- 3-month implementation period
+
+---
+
+## Governance Roadmap
+
+### Year 1: Foundation — In Progress
+
+- Implement quadratic voting with reputation decay
+- Implement time-locked voting (flash loan prevention)
+- Implement AI agent governance capability
+- Establish governance processes
+- Build community participation
+- Launch RPGF program
+
+### Year 2: Maturation — Planned
+
+- Expand validator participation
+- Increase governance frequency
+- Introduce conviction voting (graduated multipliers)
+- Establish academic partnerships
+
+### Year 3: Decentralization — Planned
+
+- Reduce core team influence
+- Empower community governance
+- Implement self-modifying protocol
+- Enable full AI agent governance participation
+
+### Year 4+: Post-Human Governance — Aspirational
+
+*This section describes a long-term vision. It is not currently being developed.*
+
+- AI agents have full voting rights
+- Collective intelligence guides decisions
+- Protocol evolves without human intervention
+- Governance becomes mathematical
+
+---
+🔙 **Back**: [use-cases/](./) | 🔄 **Related**: [../architecture/layer-5-economics.md](../architecture/layer-5-economics.md)  
+🚀 **Next**: [real-world-scenarios.md](./real-world-scenarios.md) | 📜 **Source of Truth**: [Restructuring Blueprint](../reference/blueprint-reference.md)

--- a/docs/use-cases/phase-alignment.md
+++ b/docs/use-cases/phase-alignment.md
@@ -1,0 +1,199 @@
+# Phase Alignment & User Impact
+> 🎯 Audience: All
+> 🔗 Context: Maps each development phase to concrete user-facing capabilities and feature availability
+> 📅 Last Updated: 2026-05-20
+
+This document maps Omnia's development phases to the capabilities available to users, operators, and developers at each stage. Understanding phase alignment helps stakeholders know what they can do today and what's coming next.
+
+## Phase 0: The Seed — Foundation Layer
+
+**Status**: ✅ Complete
+
+Phase 0 delivered the core protocol: a causal graph consensus engine, six domain shards, identity hardening, economics with UBC, and a settlement-agnostic ZK-rollup architecture. At this stage, users can interact with the protocol through the Rust API and the `omnia-node` REST binary.
+
+### What Users Can Do
+
+- **Developers**: Build on the Omnia Rust library — create events, submit shard operations, query state, use the REST API
+- **Operators**: Run a single-node instance via Docker Compose (5-node testnet configuration available), monitor via Grafana/Prometheus
+- **Architects**: Evaluate the six-layer architecture, review ADRs (001–009), audit the ZK circuit design
+- **Laymen**: Read use cases and understand the protocol's vision — no direct interaction yet (no wallet or mobile app)
+
+### Key Deliverables
+
+| Capability | Implementation | Notes |
+|-----------|---------------|-------|
+| Causal graph consensus | ✅ | 454+ substrate tests, ~527 events/sec single-node |
+| 6 domain shards | ✅ | Financial, Computational, Physical, Biological, Identity, Economics |
+| DID identity system | ✅ | `did:omnia:` method, Shamir recovery, biometric anchors |
+| UBC economics | ✅ | 1,000 UBC/month soulbound quota, quadratic voting |
+| ZK-rollup (arkworks) | ✅ | Groth16 + Poseidon on BN254 |
+| PQC signatures | ✅ | ML-KEM-768 (FIPS-203) + Ed25519 hybrid |
+| REST API | ✅ | JWT auth, rate limiting, 9 endpoints |
+
+---
+
+## Phase 1: Hardening — Code Quality Sprint
+
+**Status**: ✅ Complete
+
+Phase 1 eliminated the most dangerous code quality issues: production `unwrap()` calls and string-typed errors. This phase also added E2E API tests and code coverage integration.
+
+### What Changed for Users
+
+- **Developers**: All 7 crates enforce `#![deny(clippy::unwrap_used)]` and use 34 typed error enums. E2E API test suite covers 9 endpoints across 4 auth states.
+- **Operators**: API is now production-hardened with comprehensive auth testing. No functional changes to node operation.
+- **Architects**: Rustdoc coverage improved for 7 security-critical modules (35 documentation items).
+
+### Key Deliverables
+
+| Capability | Implementation | Notes |
+|-----------|---------------|-------|
+| Typed errors | ✅ | 34 `thiserror` enums, zero `Result<_, String>` |
+| `unwrap()` removal | ✅ | `#![deny(clippy::unwrap_used)]` on all crates |
+| E2E API tests | ✅ | 19 test functions, 4 auth states |
+| Code coverage CI | ✅ | `cargo llvm-cov`, 70% target |
+| Solidity Groth16 verifier | ✅ | Pre-existing, production-quality |
+
+---
+
+## Phase 2: Cryptographic Key Management & ZK Hardening
+
+**Status**: ✅ Complete
+
+Phase 2 closed critical security findings in SSS recovery, DKG share encryption, and the ZK trusted setup ceremony. This phase also introduced gradual slashing, DKG, BIP-39 mnemonics, and PQC key rotation.
+
+### What Changed for Users
+
+- **Developers**: SSS recovery now works end-to-end — shares are persisted with encryption, reconstruction produces a keypair that updates DID authentication. DKG produces valid threshold key shares. ZK circuit constrains event semantics (operation type, payload hash).
+- **Operators**: Gradual slashing (3-tier: Warning → Jail → Ejection) replaces binary point system. Encrypted keystore supports BIP-39 mnemonic key derivation.
+- **Architects**: ADRs 010–014 document key design decisions (encrypted keystore, slashing, VRF, DKG, Poseidon migration).
+
+### Key Deliverables
+
+| Capability | Implementation | Notes |
+|-----------|---------------|-------|
+| SSS recovery flow | ✅ | End-to-end: encrypt → persist → reconstruct → rotate |
+| Trusted setup ceremony | ✅ | Real EC operations on BN254 G1 |
+| ZK circuit constraints | ✅ | Operation type + payload hash constraints |
+| Gradual slashing | ✅ | ADR-011: Warning → Jail → Ejection |
+| DKG | ✅ | Feldman VSS-based, AES-256-GCM share encryption |
+| BIP-39 mnemonics | ✅ | SLIP-0010 HD derivation |
+| PQC key rotation bridge | ✅ | KeyStoreBridge: persistent rotation across restarts |
+| sled removal | ✅ | Fully migrated to redb |
+
+---
+
+## Phase 3: Network Optimization & Production Deployment
+
+**Status**: ✅ Complete
+
+Phase 3 closed all 5 open Phase 2 findings (3 critical, 1 high, 1 medium) and delivered network production readiness: leader selection, Kademlia DHT, GossipSub peer scoring, consensus persistence, fast-sync, and message compression.
+
+### What Changed for Users
+
+- **Operators**: Nodes can now discover peers via Kademlia DHT, traverse NATs with AutoNAT/Relay/DCutr, and persist consensus state across restarts. Fast-sync enables new nodes to bootstrap without full genesis replay. Gossip messages are compressed with Snappy.
+- **Developers**: ML-KEM-768 (FIPS-203) replaces pqc_kyber, eliminating the KyberSlash vulnerability. Ethereum settlement adapter architecture is ready (live mode behind `ethereum-live` feature flag).
+- **Architects**: Network layer is production-ready with peer scoring, graylisting, and NAT traversal.
+
+### Key Deliverables
+
+| Capability | Implementation | Notes |
+|-----------|---------------|-------|
+| SSS/DKG share encryption | ✅ | XOR → AES-256-GCM with HKDF-SHA256 |
+| Leader selection in consensus | ✅ | VRF-based, stake-weighted, mempool |
+| Kademlia DHT + NAT traversal | ✅ | AutoNAT, Relay, DCutr, TCP fallback |
+| GossipSub peer scoring | ✅ | Graylisting at -100, penalty weights |
+| Consensus state persistence | ✅ | RedbConsensusStore, load_or_new |
+| ML-KEM-768 | ✅ | FIPS-203, replaces pqc_kyber |
+| Fast-sync | ✅ | BLAKE3 checkpoints, supermajority, P2P download |
+| Message compression | ✅ | Snappy for >256 bytes |
+
+---
+
+## Phase 4: Mainnet Readiness & Settlement Integration
+
+**Status**: ✅ Complete
+
+Phase 4 delivered real Ethereum settlement via Alloy, wired gradual slashing per ADR-011, and added operational improvements: separate liveness/readiness probes, fast-sync P2P automation, and ceremony server/client.
+
+### What Changed for Users
+
+- **Operators**: Kubernetes liveness (`/healthz`) and readiness (`/readyz`) probes are now separate. Grafana admin password requires env var. Fast-sync has a full P2P download loop.
+- **Developers**: Ethereum settlement adapter has real Alloy RPC integration (behind `ethereum-live` feature flag). Gradual slashing is wired into `record_offense_gradued()` per ADR-011 tiers. pqc_kyber fully replaced by ml-kem.
+- **Architects**: ADRs 015–021 document leader selection, Kademlia, peer scoring, consensus persistence, fast-sync, ML-KEM, and message compression decisions.
+
+### Key Deliverables
+
+| Capability | Implementation | Notes |
+|-----------|---------------|-------|
+| Real Ethereum settlement | ✅ | Alloy v1, feature-gated |
+| Gradual slashing (wired) | ✅ | ADR-011 tiers: Warning → Jail → Ejection |
+| KyberSlash fix | ✅ | pqc_kyber → ml-kem migration |
+| Fast-sync P2P automation | ✅ | Full download loop with MockSyncNetwork |
+| Liveness/readiness probes | ✅ | `/healthz`, `/readyz`, `/health` |
+| Ceremony server/client | ✅ | Multi-party coordinator + CLI subcommands |
+| Supply chain hardening | ✅ | First-party audits for ml-kem, snap, libp2p crates |
+
+---
+
+## Phase 5: Testnet Launch & Performance Validation
+
+**Status**: ✅ Complete
+
+Phase 5 captured real benchmark data (~527 events/sec single-node), validated multi-node BFT consensus, migrated VRF to ECVRF per RFC 9381, added genesis tooling, and prepared the external audit package.
+
+### What Changed for Users
+
+- **All Users**: The "10K+ TPS" aspirational claim has been replaced with honest measured data: ~527 events/sec single-node. This transparency allows realistic planning.
+- **Operators**: Genesis tooling enables network bootstrapping with a validated initial validator set. VRF leader selection now uses a standard ECVRF construction.
+- **Developers**: Poseidon dual-hash foundation enables future migration to Filecoin/Neptune reference parameters. Bug bounty program is active ($100–$50,000).
+- **Architects**: External audit package assembled. Side-channel audit for ZK and binding crates completed.
+
+### Key Deliverables
+
+| Capability | Implementation | Notes |
+|-----------|---------------|-------|
+| Real benchmarks | ✅ | ~527 events/sec, ZK setup ~423ms expanded |
+| Multi-node BFT | ✅ | 4-node test validated |
+| ECVRF (RFC 9381) | ✅ | V2 with Fiat-Shamir + Ed25519 |
+| Genesis tooling | ✅ | GenesisConfig, ValidatorInfo, TOML templates |
+| Poseidon dual-hash | ✅ | Custom + Reference, LazyLock-based |
+| Bug bounty program | ✅ | $100–$50,000, 90-day embargo |
+| External audit package | ✅ | AUDIT_PACKAGE.md + findings template |
+| Side-channel audit | ✅ | ZK + binding crates, 5 findings |
+
+---
+
+## Post-Phase 5: What's Coming Next
+
+### Before Public Testnet
+1. Docker Compose multi-node verification (5-node network validation)
+2. External security audit (commission professional audit firm)
+3. Anvil E2E test (deploy → submit → verify on local Ethereum)
+
+### Before Mainnet
+4. Sybil resistance / stake-weighted validator registry
+5. Causal graph garbage collection with pruning
+6. Comprehensive rustdoc coverage (100% of public API)
+7. Formal Dilithium timing side-channel audit
+8. Poseidon standard parameter migration (Phase B)
+
+### Long-Term Vision
+9. Multi-party trusted setup ceremony over network
+10. Extended formal verification (unbounded TLA+, Rust verification)
+11. RF fingerprint hardware integration
+12. Bitcoin/Solana/Celestia settlement adapters
+13. Mobile wallet
+14. Throughput optimization (multi-threaded, sharded consensus)
+
+### Timeline
+
+| Milestone | Target | Blockers |
+|-----------|--------|-----------|
+| Public Testnet | Q2 2026 | External audit completion |
+| Mainnet | Q4 2026 | Audit findings, Sybil resistance, GC |
+| Hardened Mainnet | Q1 2027 | Multi-party ceremony, formal verification |
+
+---
+🔙 **Back**: [use-cases/](./) | 🔄 **Related**: [../reference/roadmap.md](../reference/roadmap.md)  
+🚀 **Next**: [faq.md](./faq.md) | 📜 **Source of Truth**: [Restructuring Blueprint](../reference/blueprint-reference.md)

--- a/docs/use-cases/real-world-scenarios.md
+++ b/docs/use-cases/real-world-scenarios.md
@@ -1,0 +1,453 @@
+# Real-World Scenarios
+> 🎯 Audience: Laymen, All
+> 🔗 Context: 10 real-world use cases demonstrating how Omnia solves problems across financial inclusion, supply chain, healthcare, IP, AI, and governance
+> 📅 Last Updated: 2026-05-20
+
+## 1. Financial Inclusion for the Unbanked
+
+### The Problem
+
+1.7 billion people worldwide lack access to basic financial services. They cannot:
+- Save money safely
+- Borrow for education or business
+- Send money to family
+- Access credit history
+
+### Omnia's Solution
+
+**Scenario:** Amara, a farmer in rural Kenya
+
+1. **Identity:** Amara creates a DID on her phone (no government ID needed). The `did:omnia:` method (implemented in `shards/src/identity/did.rs`) creates a self-sovereign identifier from her Ed25519 public key.
+2. **Reputation:** She completes small tasks on Omnia, building reputation. Proof-of-Useful-Work submissions (`UsefulWorkProof` in `economics/src/useful_work.rs`) earn her additional UBC via `UbcToken::reward()`.
+3. **Borrowing:** With reputation as collateral, she borrows 1,000 Omnia for seeds. The `FinancialShard` (`shards/src/lib.rs`) processes the `FinancialOp::Transfer` operation with strict causal ordering to prevent double-spends.
+4. **Selling:** She sells her harvest directly to buyers globally, receiving payment instantly. The `ShardRouter` enforces fees via `FeeSchedule` and deducts UBC from the caller's quota.
+5. **Saving:** Her savings earn interest through RPGF rewards.
+
+**Impact:**
+- Amara has a financial identity without a bank
+- She can access credit based on reputation, not collateral
+- She eliminates middlemen and keeps more profit
+- Her children can attend school
+
+### Implementation
+
+```
+Phase 1: Mobile wallet with offline support
+- Works on 2G networks
+- Transactions sync when online
+- Biometric authentication via BiometricAnchor (shards/src/identity/biometric.rs)
+
+Phase 2: Peer-to-peer lending
+- Amara can borrow from other users
+- Reputation determines interest rate
+- Smart contracts handle repayment
+
+Phase 3: Global marketplace
+- Amara sells directly to global buyers
+- Instant settlement
+- No currency exchange fees
+```
+
+---
+
+## 2. Supply Chain Transparency
+
+### The Problem
+
+Global supply chains are opaque. Consumers cannot verify:
+- Product authenticity
+- Ethical sourcing
+- Environmental impact
+- Fair labor practices
+
+### Omnia's Solution
+
+**Scenario:** A coffee buyer in New York
+
+**The Journey:**
+1. **Farming (Ethiopia):** Farmer registers coffee batch with RF fingerprint and quantum seal. The `PhysicalOp::AnchorItem` operation (in `shards/src/physical/ops.rs`) creates an immutable provenance entry.
+2. **Cooperative:** Beans are washed, graded, and RF fingerprint is updated. `PhysicalOp::TransferOwnership` records the transfer in the append-only provenance log.
+3. **Export:** Container is sealed with quantum seal and GPS tracking. A `CrossShardMessage` (in `shards/src/cross_shard.rs`) may trigger a financial payment to the cooperative.
+4. **Roasting (Portland):** Roaster verifies quantum seal, roasts to specification. `PhysicalOp::VerifyChain` validates the complete provenance chain.
+5. **Retail:** Retailer scans QR code, verifies full chain
+6. **Consumer:** Buys coffee, scans with phone, sees complete provenance
+
+**What the Consumer Sees:**
+```
+Your Coffee's Journey
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Origin: Ethiopia, Yirgacheffe Region
+Farmer: Abebe Kebede (verified identity, 4.8 reputation)
+Harvest: March 2026 (satellite-verified weather data)
+Cooperative: Cooperative #47 (RF: 0x9a2f..., quantum seal intact)
+Shipping: Container MSCU2847561 (quantum seal verified, temp: 15-20C)
+Roasting: Portland Roasters (carbon footprint: 0.3kg CO2)
+Fair Trade: Price to farmer: $4.20/kg (verified)
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+All claims cryptographically proven.
+Trust no one. Verify everything.
+```
+
+**Impact:**
+- Farmers get fair prices (no middlemen taking cuts)
+- Consumers know exactly where their coffee comes from
+- Environmental impact is transparent
+- Counterfeiting becomes impossible
+
+---
+
+## 3. Healthcare and Vaccination Records
+
+### The Problem
+
+Healthcare records are fragmented across providers. Patients cannot:
+- Access their full medical history
+- Prove vaccination status without revealing full records
+- Share data for research without losing privacy
+- Verify prescription authenticity
+
+### Omnia's Solution
+
+**Scenario:** Sarah, traveling to a conference
+
+1. **Vaccination Proof:** Sarah proves she's vaccinated without revealing her full medical record
+   - Uses zero-knowledge proof via `BiologicalOp::QueryWithZkProof` (defined in `shards/src/biological/ops.rs`)
+   - The Biological shard's consent registry (`ConsentRecord` in `shards/src/biological/state.rs`) verifies that Sarah has granted the conference access
+   - No personal data is shared beyond the verified claim
+
+2. **Medical History:** Sarah's doctor can access her full history across providers
+   - `BiologicalOp::GrantAccess` authorizes the doctor
+   - `BiologicalOp::RevokeAccess` allows Sarah to withdraw consent at any time
+   - Sarah controls access through the consent registry
+
+3. **Research Participation:** Sarah contributes her anonymized data to cancer research
+   - Her data is encrypted
+   - Researchers can analyze without seeing her identity
+   - She earns UBC rewards for contribution via `UsefulWorkProof`
+
+**Implementation:**
+```
+Phase 1: Vaccination records
+- Verifiable credentials for vaccines
+- Zero-knowledge proofs for travel
+- Integration with health authorities
+
+Phase 2: Medical history
+- Patient-controlled health records
+- Provider integration
+- Emergency access protocols
+
+Phase 3: Research participation
+- Privacy-preserving data sharing
+- Automated consent management
+- Reward distribution
+```
+
+---
+
+## 4. Intellectual Property and Digital Rights
+
+### The Problem
+
+Artists, musicians, and creators lose control of their work:
+- Streaming platforms take 70% of revenue
+- Piracy is rampant
+- Attribution is lost
+- Derivative works are untracked
+
+### Omnia's Solution
+
+**Scenario:** Maya, a musician
+
+1. **Registration:** Maya registers her song on Omnia with cryptographic proof of creation. The `PhysicalOp::AnchorItem` operation creates a permanent provenance entry for the digital work.
+2. **Distribution:** She sells directly to listeners (no Spotify middleman). The `FinancialOp::Transfer` operation handles payments with strict causal ordering.
+3. **Royalties:** Every derivative work automatically pays her
+4. **Attribution:** Her name is cryptographically linked to her work forever
+5. **Licensing:** Other artists can license her work with automatic payment
+
+**Impact:**
+- Maya keeps 99% of revenue (only 1% fee for Omnia)
+- Her work is protected from piracy (cryptographically verified)
+- She earns royalties on derivatives
+- Her attribution is permanent
+
+---
+
+## 5. Decentralized AI Training
+
+### The Problem
+
+AI models are trained on centralized data, controlled by a few companies:
+- Users' data is exploited without consent
+- Only large companies can afford to train models
+- Model ownership is centralized
+- Bias is hidden
+
+### Omnia's Solution
+
+**Scenario:** A medical AI model trained by a distributed network
+
+1. **Data Contribution:** Hospitals contribute anonymized patient data
+   - Data is encrypted
+   - Hospitals retain control via `BiologicalOp::GrantAccess` with scoped consent
+   - Hospitals earn rewards via `UsefulWorkType::AiTraining` (in `economics/src/useful_work.rs`)
+
+2. **Model Training:** Thousands of devices train the model in parallel
+   - Each device trains on a subset of data
+   - No single entity sees all data
+   - Proof-of-useful-work is verified via `UsefulWorkProof::validate()` and `verify_stub()`
+   - The `ComputationalOp::SubmitTask`, `SubmitProof`, and `VerifyProof` operations manage the task lifecycle
+
+3. **Model Ownership:** The model is owned by all contributors
+   - Voting power is proportional to contribution (quadratic voting via `GovernanceState`)
+   - Model improvements are shared
+   - Revenue is distributed
+
+4. **Deployment:** The model is deployed on Omnia
+   - Hospitals can use it for free (UBC quota: 1,000 UBC/month default)
+   - Commercial users pay small fee (enforced by `FeeSchedule::computational_op_fee = 5`)
+   - Fees go to RPGF pool
+
+**Impact:**
+- Hospitals keep their data private
+- Medical AI is more accurate (trained on more diverse data)
+- Smaller organizations can participate in AI development
+- Model bias is reduced through diverse training data
+
+---
+
+## 6. Interplanetary Trade
+
+### The Problem
+
+As humanity expands to Mars and beyond, traditional finance breaks:
+- Earth-Mars communication takes 3-22 minutes
+- Traditional blockchains require global synchronization
+- Currency exchange is complex
+- Trust is difficult to establish
+
+### Omnia's Solution
+
+**Scenario:** A Mars colony trades with Earth
+
+1. **Local Autonomy:** Mars has its own validators and local finality
+   - Transactions finalize in minutes
+   - No waiting for Earth
+
+2. **Periodic Sync:** Mars and Earth synchronize every 22 minutes
+   - Causal graph merges
+   - Conflicts resolved by causal ordering via `VectorClock::happened_before()`
+   - No hard fork needed
+
+3. **Atomic Swaps:** Martian resources trade for Earth resources
+   - Peer-to-peer settlement
+   - Time-locked contracts via `TimeLockVoting` (in `economics/src/time_lock.rs`)
+   - Automatic execution
+
+**Example Transaction:**
+```
+Mars Colony sells 100 tons of water ice to Earth
+Earth sends 50,000 Omnia
+
+Timeline:
+T+0: Mars sends transaction (local finality in 2 minutes)
+T+3: Earth receives transaction (via satellite)
+T+5: Earth sends payment (local finality in 2 minutes)
+T+8: Mars receives payment (via satellite)
+T+22: Full synchronization (causal graph merges)
+
+Result: Trade complete, both parties satisfied, no intermediary needed
+```
+
+---
+
+## 7. Refugee Identity and Resettlement
+
+### The Problem
+
+Refugees lack official documentation:
+- Cannot prove identity
+- Cannot access banking
+- Cannot prove education/skills
+- Cannot get jobs
+
+### Omnia's Solution
+
+**Scenario:** Ahmed, a Syrian refugee
+
+1. **Identity:** Ahmed creates a DID
+   - No government ID needed — the `did:omnia:` method requires only a 32-byte Ed25519 public key
+   - `BiometricAnchor::enroll()` (in `shards/src/identity/biometric.rs`) proves he's a living human via a salted BLAKE3 commitment — the raw template is never stored
+   - Social recovery via `ShamirRecovery::split()` (in `shards/src/identity/recovery.rs`) — configurable K-of-N threshold
+
+2. **Credentials:** Ahmed's skills are verified
+   - Former employer issues credential (encrypted)
+   - Ahmed proves he's a skilled engineer
+   - Doesn't reveal employer details
+
+3. **Employment:** Ahmed applies for jobs in Turkey
+   - Employer verifies his skills
+   - Ahmed's reputation is visible
+   - He gets hired based on merit, not documentation
+
+4. **Banking:** Ahmed opens an account on Omnia
+   - Receives UBC quota (1,000 UBC/month default via `DEFAULT_UBC_QUOTA`)
+   - Can send money to family
+   - Can borrow for housing
+
+**Impact:**
+- Ahmed has a digital identity that no government can revoke
+- He can prove his skills without official documents
+- He can access financial services
+- He can rebuild his life
+
+---
+
+## 8. Decentralized Governance and DAOs
+
+### The Problem
+
+Traditional organizations are hierarchical:
+- Decisions are made by a few people
+- Transparency is limited
+- Corruption is common
+- Participation is difficult
+
+### Omnia's Solution
+
+**Scenario:** A global climate action DAO
+
+1. **Membership:** Anyone can join by staking Omnia
+   - Quadratic voting (`GovernanceState::set_weight()`) prevents whale dominance — voting power = isqrt(stake)
+   - Reputation determines voting power
+   - Transparent voting via `Proposal` and `VoteChoice` types (in `economics/src/governance.rs`)
+
+2. **Proposals:** Members propose climate initiatives
+   - Reforestation in Amazon
+   - Solar farm in Sahara
+   - Wind turbines in North Sea
+
+3. **Funding:** Community votes on funding allocation
+   - `GovernanceState::vote()` casts a weighted vote using effective weight (including decay)
+   - Funds are distributed automatically
+   - Progress is tracked on-chain
+
+4. **Execution:** Projects are executed by contractors
+   - Proof-of-work verifies completion via `UsefulWorkProof::verify_stub()`
+   - Payments are released automatically
+   - Results are auditable
+
+5. **Flash loan prevention:** Time-locked voting (`TimeLockVoting` in `economics/src/time_lock.rs`) ensures that freshly-locked stake has zero voting power until the lock matures (default: 100 blocks minimum)
+
+6. **AI agent participation:** AI agents with `AgentCapability::GovernanceVote { max_weight }` can participate with bounded influence
+
+**Impact:**
+- Climate action is coordinated globally
+- Funding is transparent and efficient
+- Corruption is eliminated
+- Anyone can participate
+
+---
+
+## 9. Energy Grid Optimization
+
+### The Problem
+
+Centralized energy grids are inefficient:
+- Renewable energy is wasted
+- Demand peaks cause blackouts
+- Storage is expensive
+- Consumers have no incentive to conserve
+
+### Omnia's Solution
+
+**Scenario:** A neighborhood with solar panels and batteries
+
+1. **Peer-to-Peer Trading:** Neighbors trade energy directly
+   - Alice has excess solar → sells to Bob
+   - Bob has excess battery → sells to Carol
+   - All transactions are automatic via `FinancialOp::Transfer`
+
+2. **Smart Contracts:** Contracts optimize energy flow
+   - Charge batteries when solar is abundant
+   - Discharge when demand peaks
+   - Minimize grid load
+
+3. **Carbon Credits:** Renewable energy is tokenized
+   - Each kWh of solar = 1 carbon credit
+   - Credits can be traded
+   - Polluters must buy credits
+
+4. **Incentives:** Users are rewarded for conservation
+   - Reducing peak demand = rewards
+   - Sharing renewable energy = rewards
+   - Rewards are distributed via `UsefulWorkType::DistributedStorage`
+
+**Impact:**
+- Renewable energy is maximized
+- Grid is more stable
+- Consumers save money
+- Carbon emissions decrease
+
+---
+
+## 10. Scientific Research and Open Science
+
+### The Problem
+
+Scientific research is siloed:
+- Data is locked behind paywalls
+- Researchers cannot collaborate easily
+- Reproducibility is difficult
+- Funding is limited
+
+### Omnia's Solution
+
+**Scenario:** A global research network studying climate change
+
+1. **Data Sharing:** Researchers share data on Omnia
+   - Data is encrypted
+   - Researchers retain control via biological consent management
+   - Collaboration is easy
+
+2. **Proof-of-Useful-Work:** Compute power is used for research
+   - `UsefulWorkType::ScientificSimulation { simulation_id, params_hash }` allows researchers to submit climate models
+   - Validators run models on their hardware
+   - Validators are rewarded via `UbcToken::reward()` at a 1:1 ratio with compute units consumed
+
+3. **Reproducibility:** All research is verifiable
+   - Code is on-chain
+   - Data is on-chain
+   - Results are reproducible
+
+4. **Funding:** RPGF rewards impactful research
+   - Researchers apply for funding
+   - Community votes on impact using quadratic voting
+   - Funding is distributed automatically
+
+**Impact:**
+- Climate research is accelerated
+- Findings are reproducible
+- Collaboration is seamless
+- Funding is merit-based
+
+---
+
+## Implementation Timeline
+
+| Use Case | Phase | Timeline |
+|----------|-------|----------|
+| Financial Inclusion | Phase 0 | Months 0-18 |
+| Supply Chain | Phase 1 | Years 1-2 |
+| Healthcare | Phase 1 | Years 1-2 |
+| IP and Digital Rights | Phase 1 | Years 1-2 |
+| Decentralized AI | Phase 2 | Years 3-5 |
+| Interplanetary Trade | Phase 3 | Years 5-10 |
+| Refugee Identity | Phase 1 | Years 1-2 |
+| Decentralized Governance | Phase 0 | Months 0-18 |
+| Energy Grid | Phase 2 | Years 3-5 |
+| Scientific Research | Phase 1 | Years 1-2 |
+
+---
+🔙 **Back**: [use-cases/](./) | 🔄 **Related**: [phase-alignment.md](./phase-alignment.md)  
+🚀 **Next**: [phase-alignment.md](./phase-alignment.md) | 📜 **Source of Truth**: [Restructuring Blueprint](../reference/blueprint-reference.md)


### PR DESCRIPTION
Migration of all markdown documentation into a cohesive, audience-segmented
structure per the restructuring blueprint:

- docs/architecture/ — 11 files: layer specifications, trait boundaries,
  pipeline design, CRDT convergence, vector clock reconciliation
- docs/building/ — 4 files: feature matrix, cross-compilation, binary optimization
- docs/operations/ — 6 files: validator setup, monitoring, deployment,
  runbook, feature flags
- docs/reference/ — 9 files: roadmap, benchmarks, blueprint reference,
  ADR index, security audit, dependency policy, crypto migration
- docs/use-cases/ — 5 files: real-world scenarios, phase alignment, FAQ,
  governance

All files include standard header (title, audience, context, date) and
footer (back/related/next navigation links). Root README.md updated
with audience router. Root-level .md files updated with headers/footers.

Target branch: docs/restructure-migration
Legacy files preserved (not deleted) for backward compatibility.