### PR TITLE
fix(ci): comprehensive Clippy fixes, udeps nightly, and deprecated warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,6 @@ jobs:
           shared-key: "omnia-test-${{ matrix.os }}-${{ hashFiles('**/Cargo.lock') }}"
       - name: Verify Cargo.lock is up to date
         run: cargo test --locked --workspace --exclude omnia-fuzz --no-run
-        continue-on-error: true  # Lockfile drift is caught by the build-reproducibility job
       # Skip settlement::live tests on all PRs — they require a live Ethereum
       # endpoint which is only available on main branch with secrets.
       # Mock settlement tests always pass (MSRV 1.88, zero alloy).
@@ -261,23 +260,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      # cargo-udeps requires -Z binary-dep-depinfo which is nightly-only.
+      # Use a pinned nightly to avoid regressions with the latest nightly.
       - uses: dtolnay/rust-toolchain@v1
         with:
-          # cargo-udeps v0.1.61+ depends on cargo v0.96+ which requires rustc ≥1.93
-          toolchain: "1.93.0"
-      # Override rust-toolchain.toml which pins 1.88 — cargo-udeps needs 1.93+
+          toolchain: nightly-2025-12-01
+          components: rust-src
       - name: Override toolchain for cargo-udeps
-        run: rustup override set 1.93.0
+        run: rustup override set nightly-2025-12-01
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: "omnia-udeps"
       - name: Install cargo-udeps
-        run: cargo +1.93.0 install cargo-udeps --locked
+        run: cargo +nightly-2025-12-01 install cargo-udeps --locked
       - name: Check for unused dependencies
-        run: cargo +1.93.0 udeps --workspace --all-features --exclude omnia-fuzz
-        continue-on-error: true  # cargo-udeps may require newer rustc than stable
+        run: cargo +nightly-2025-12-01 udeps --workspace --all-features --exclude omnia-fuzz
+        continue-on-error: true  # cargo-udeps may report false positives
       # NOTE: omnia-adapters with --all-features includes ethereum-live
-      # which requires rustc ≥1.91. The udeps check runs on stable.
+      # which requires rustc ≥1.91. The udeps check runs on nightly which
+      # satisfies this requirement.
 
   mutation-testing:
     name: Mutation Testing

--- a/benches/benches/hot_path_iai.rs
+++ b/benches/benches/hot_path_iai.rs
@@ -5,6 +5,8 @@
 //! Unlike criterion (statistical), iai-callgrind produces reproducible
 //! results ideal for CI regression detection.
 
+#![allow(clippy::unwrap_used)]
+
 use iai_callgrind::{black_box, library_benchmark, library_benchmark_group, main};
 use omnia_consensus::CausalGraph;
 use omnia_crypto::generate_keypair;
@@ -40,7 +42,8 @@ fn bench_vector_clock_merge_100() {
 fn bench_event_validate() {
     let creator: NodeId = [0u8; 32];
     let event = create_signed_event(creator, 0, None);
-    black_box(event.validate().unwrap());
+    event.validate().unwrap();
+    black_box(());
 }
 
 #[library_benchmark]

--- a/binding/src/quantum_commit.rs
+++ b/binding/src/quantum_commit.rs
@@ -663,14 +663,12 @@ mod tests {
         assert_eq!(
             keypair.encapsulation_key.len(),
             ML_KEM_768_ENCAPSULATION_KEY_SIZE,
-            "encapsulation key should be {} bytes",
-            ML_KEM_768_ENCAPSULATION_KEY_SIZE
+            "encapsulation key should be {ML_KEM_768_ENCAPSULATION_KEY_SIZE} bytes"
         );
         assert_eq!(
             keypair.decapsulation_key.len(),
             ML_KEM_768_DECAPSULATION_KEY_SIZE,
-            "decapsulation key should be {} bytes",
-            ML_KEM_768_DECAPSULATION_KEY_SIZE
+            "decapsulation key should be {ML_KEM_768_DECAPSULATION_KEY_SIZE} bytes"
         );
     }
 
@@ -713,8 +711,7 @@ mod tests {
         assert_eq!(
             ciphertext.len(),
             ML_KEM_768_CIPHERTEXT_SIZE,
-            "ciphertext should be {} bytes",
-            ML_KEM_768_CIPHERTEXT_SIZE
+            "ciphertext should be {ML_KEM_768_CIPHERTEXT_SIZE} bytes"
         );
     }
 
@@ -768,7 +765,7 @@ mod tests {
         assert!(result.is_err());
         match result.unwrap_err() {
             KyberError::InvalidEncapsulationKey(len) => assert_eq!(len, 100),
-            other => panic!("Expected InvalidEncapsulationKey, got: {:?}", other),
+            other => panic!("Expected InvalidEncapsulationKey, got: {other:?}"),
         }
     }
 
@@ -779,7 +776,7 @@ mod tests {
         assert!(result.is_err());
         match result.unwrap_err() {
             KyberError::InvalidDecapsulationKey(len) => assert_eq!(len, 100),
-            other => panic!("Expected InvalidDecapsulationKey, got: {:?}", other),
+            other => panic!("Expected InvalidDecapsulationKey, got: {other:?}"),
         }
     }
 
@@ -790,7 +787,7 @@ mod tests {
         assert!(result.is_err());
         match result.unwrap_err() {
             KyberError::InvalidCiphertext(len) => assert_eq!(len, 100),
-            other => panic!("Expected InvalidCiphertext, got: {:?}", other),
+            other => panic!("Expected InvalidCiphertext, got: {other:?}"),
         }
     }
 

--- a/chaos-tests/src/bin/load_test.rs
+++ b/chaos-tests/src/bin/load_test.rs
@@ -138,7 +138,7 @@ async fn main() {
             println!("Actual duration: {:?}", result.actual_duration);
         }
         Err(e) => {
-            eprintln!("Load test failed: {}", e);
+            eprintln!("Load test failed: {e}");
             std::process::exit(1);
         }
     }

--- a/chaos-tests/src/lib.rs
+++ b/chaos-tests/src/lib.rs
@@ -257,7 +257,7 @@ impl ChaosNetwork {
 
             // Insert into the node's own graph (graph only needs &mut graph)
             if let Err(e) = nodes[i].graph.insert(event.clone()) {
-                panic!("Genesis insert failed for node {}: {e}", i);
+                panic!("Genesis insert failed for node {i}: {e}");
             }
 
             // Track state — use event.creator (which is blake3(pubkey) after signing)
@@ -345,10 +345,10 @@ impl ChaosNetwork {
     /// already crashed.
     pub fn crash_node(&mut self, id: usize) -> anyhow::Result<()> {
         if id >= self.nodes.len() {
-            return Err(anyhow::anyhow!("Node {} does not exist", id));
+            return Err(anyhow::anyhow!("Node {id} does not exist"));
         }
         if self.nodes[id].crashed {
-            return Err(anyhow::anyhow!("Node {} is already crashed", id));
+            return Err(anyhow::anyhow!("Node {id} is already crashed"));
         }
         self.nodes[id].crashed = true;
         tracing::info!(node = id, "Node crashed");
@@ -370,10 +370,10 @@ impl ChaosNetwork {
     /// not crashed.
     pub fn restart_node(&mut self, id: usize) -> anyhow::Result<()> {
         if id >= self.nodes.len() {
-            return Err(anyhow::anyhow!("Node {} does not exist", id));
+            return Err(anyhow::anyhow!("Node {id} does not exist"));
         }
         if !self.nodes[id].crashed {
-            return Err(anyhow::anyhow!("Node {} is not crashed", id));
+            return Err(anyhow::anyhow!("Node {id} is not crashed"));
         }
         self.nodes[id].crashed = false;
         tracing::info!(node = id, "Node restarted, syncing missed events");
@@ -444,10 +444,10 @@ impl ChaosNetwork {
     /// inserted into the graph.
     pub fn submit_event(&mut self, node_id: usize, payload: Vec<u8>) -> anyhow::Result<()> {
         if node_id >= self.nodes.len() {
-            return Err(anyhow::anyhow!("Node {} does not exist", node_id));
+            return Err(anyhow::anyhow!("Node {node_id} does not exist"));
         }
         if self.nodes[node_id].crashed {
-            return Err(anyhow::anyhow!("Node {} is crashed", node_id));
+            return Err(anyhow::anyhow!("Node {node_id} is crashed"));
         }
 
         // Phase 1: Create the event (immutable reads)
@@ -523,10 +523,10 @@ impl ChaosNetwork {
     /// be inserted.
     pub fn inject_event(&mut self, target_idx: usize, event: Event) -> anyhow::Result<()> {
         if target_idx >= self.nodes.len() {
-            return Err(anyhow::anyhow!("Node {} does not exist", target_idx));
+            return Err(anyhow::anyhow!("Node {target_idx} does not exist"));
         }
         if self.nodes[target_idx].crashed {
-            return Err(anyhow::anyhow!("Node {} is crashed", target_idx));
+            return Err(anyhow::anyhow!("Node {target_idx} is crashed"));
         }
 
         // Propagate any missing parents first
@@ -934,7 +934,7 @@ impl ChaosNetwork {
         self.nodes[target_idx]
             .graph
             .insert(event.clone())
-            .map_err(|e| anyhow::anyhow!("Graph insert failed: {}", e))?;
+            .map_err(|e| anyhow::anyhow!("Graph insert failed: {e}"))?;
 
         // Process through consensus and update tracking
         {

--- a/chaos-tests/tests/byzantine.rs
+++ b/chaos-tests/tests/byzantine.rs
@@ -160,8 +160,7 @@ fn test_equivocation_detected_by_multiple_observers() {
     for observer in &[1, 2, 3] {
         assert!(
             network.is_node_slashed(*observer, &node0_id),
-            "Observer node {} should have slashed node 0 for equivocation",
-            observer
+            "Observer node {observer} should have slashed node 0 for equivocation"
         );
     }
 
@@ -298,13 +297,11 @@ fn test_repeated_liveness_violations_lead_to_slashing() {
 
     assert!(
         violation_count >= 5,
-        "Should have at least 5 liveness violations, got {}",
-        violation_count
+        "Should have at least 5 liveness violations, got {violation_count}"
     );
     assert!(
         is_slashed,
-        "Node should be slashed after {} violations with 100 points each (threshold 500)",
-        violation_count
+        "Node should be slashed after {violation_count} violations with 100 points each (threshold 500)"
     );
 
     tracing::info!(
@@ -342,8 +339,7 @@ fn test_honest_node_never_slashed() {
     for observer in 1..4 {
         assert!(
             !network.is_node_slashed(observer, &honest_node_id),
-            "Honest node should not be slashed on observer {}",
-            observer
+            "Honest node should not be slashed on observer {observer}"
         );
     }
 }

--- a/chaos-tests/tests/crash_recovery.rs
+++ b/chaos-tests/tests/crash_recovery.rs
@@ -69,8 +69,7 @@ fn test_crash_recovery() {
     let node2_events = network.nodes[2].graph.event_ids().len();
     assert!(
         node2_events > 0,
-        "Node 2 should have events after restart, got {}",
-        node2_events
+        "Node 2 should have events after restart, got {node2_events}"
     );
 
     // Submit events from node 2 after recovery
@@ -95,9 +94,7 @@ fn test_crash_recovery() {
     let final_committed = network.committed_count();
     assert!(
         final_committed >= committed_during_crash,
-        "Committed count should not decrease: before={}, after={}",
-        committed_during_crash,
-        final_committed
+        "Committed count should not decrease: before={committed_during_crash}, after={final_committed}"
     );
 
     tracing::info!(

--- a/chaos-tests/tests/message_loss.rs
+++ b/chaos-tests/tests/message_loss.rs
@@ -61,9 +61,7 @@ fn test_low_message_loss_liveness() {
     let committed_after = network.committed_count();
     assert!(
         committed_after >= committed_before,
-        "Committed count should not decrease: before={}, after={}",
-        committed_before,
-        committed_after
+        "Committed count should not decrease: before={committed_before}, after={committed_after}"
     );
 
     tracing::info!(

--- a/chaos-tests/tests/partition.rs
+++ b/chaos-tests/tests/partition.rs
@@ -32,8 +32,7 @@ fn test_partition_and_heal() {
     let committed_before = network.committed_count();
     assert!(
         committed_before > 0,
-        "Should have committed genesis events, got {}",
-        committed_before
+        "Should have committed genesis events, got {committed_before}"
     );
 
     // Create partition: {0,1} cannot communicate with {2,3}
@@ -45,16 +44,14 @@ fn test_partition_and_heal() {
             let result = network.submit_event(i, vec![0xAA]);
             assert!(
                 result.is_ok(),
-                "Node {} should be able to submit events during partition",
-                i
+                "Node {i} should be able to submit events during partition"
             );
         }
         for &i in &[2, 3] {
             let result = network.submit_event(i, vec![0xBB]);
             assert!(
                 result.is_ok(),
-                "Node {} should be able to submit events during partition",
-                i
+                "Node {i} should be able to submit events during partition"
             );
         }
     }
@@ -88,9 +85,7 @@ fn test_partition_and_heal() {
         let count = network.node_committed_count(i);
         assert!(
             count > 0,
-            "Node {} should have committed events after healing, got {}",
-            i,
-            count
+            "Node {i} should have committed events after healing, got {count}"
         );
     }
 

--- a/economics/src/fixed_point.rs
+++ b/economics/src/fixed_point.rs
@@ -408,25 +408,12 @@ mod tests {
             let r = isqrt(n);
             let r_sq: u128 = (r as u128) * (r as u128);
             let n128: u128 = n as u128;
-            assert!(
-                r_sq <= n128,
-                "isqrt({}) = {}, but {}^2 = {} > {}",
-                n,
-                r,
-                r,
-                r_sq,
-                n
-            );
+            assert!(r_sq <= n128, "isqrt({n}) = {r}, but {r}^2 = {r_sq} > {n}");
             if r < u64::MAX {
                 let r_plus_1_sq: u128 = ((r + 1) as u128) * ((r + 1) as u128);
                 assert!(
                     n128 < r_plus_1_sq,
-                    "isqrt({}) = {}, but {} >= ({}+1)^2 = {}",
-                    n,
-                    r,
-                    n,
-                    r,
-                    r_plus_1_sq
+                    "isqrt({n}) = {r}, but {n} >= ({r}+1)^2 = {r_plus_1_sq}"
                 );
             }
         }
@@ -447,20 +434,12 @@ mod tests {
             let r = isqrt(n);
             assert!(
                 r.saturating_mul(r) <= n,
-                "isqrt({}) = {}, but {}^2 > {}",
-                n,
-                r,
-                r,
-                n
+                "isqrt({n}) = {r}, but {r}^2 > {n}"
             );
             if r < u64::MAX {
                 assert!(
                     n < (r + 1).saturating_mul(r + 1),
-                    "isqrt({}) = {}, but {} >= ({}+1)^2",
-                    n,
-                    r,
-                    n,
-                    r
+                    "isqrt({n}) = {r}, but {n} >= ({r}+1)^2"
                 );
             }
         }

--- a/economics/src/governance.rs
+++ b/economics/src/governance.rs
@@ -619,7 +619,7 @@ mod tests {
         // 10 eligible voters, each with weight 10 (isqrt(100))
         // total_possible_weight = 100
         for i in 0..10 {
-            gov.set_weight(&format!("voter{}", i), 100);
+            gov.set_weight(&format!("voter{i}"), 100);
         }
 
         gov.create_proposal("prop1".to_string(), "test".to_string(), 10, 0)
@@ -761,8 +761,7 @@ mod proptests {
             let effective = gov.effective_weight("test", epoch);
             assert!(
                 effective <= base_weight,
-                "Effective weight {} exceeds base weight {} at epoch {}",
-                effective, base_weight, epoch
+                "Effective weight {effective} exceeds base weight {base_weight} at epoch {epoch}"
             );
         }
     }

--- a/economics/tests/governance_determinism.rs
+++ b/economics/tests/governance_determinism.rs
@@ -82,17 +82,10 @@ fn test_isqrt_key_values() {
         let r = isqrt(n);
         let r_sq: u128 = (r as u128) * (r as u128);
         let n128: u128 = n as u128;
-        assert!(r_sq <= n128, "isqrt({}) = {}, but {}^2 > {}", n, r, r, n);
+        assert!(r_sq <= n128, "isqrt({n}) = {r}, but {r}^2 > {n}");
         if r < u64::MAX {
             let r_plus_1_sq: u128 = ((r + 1) as u128) * ((r + 1) as u128);
-            assert!(
-                n128 < r_plus_1_sq,
-                "isqrt({}) = {}, but {} >= ({}+1)^2",
-                n,
-                r,
-                n,
-                r
-            );
+            assert!(n128 < r_plus_1_sq, "isqrt({n}) = {r}, but {n} >= ({r}+1)^2");
         }
     }
 }

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -161,7 +161,7 @@ impl NodeConfig {
         }
         match self.log_level.as_str() {
             "trace" | "debug" | "info" | "warn" | "error" => {}
-            other => anyhow::bail!("invalid log_level: '{}'", other),
+            other => anyhow::bail!("invalid log_level: '{other}'"),
         }
         Ok(())
     }

--- a/node/src/http.rs
+++ b/node/src/http.rs
@@ -42,13 +42,11 @@ use axum::Router;
 #[cfg(feature = "metrics")]
 use prometheus::{Encoder, TextEncoder};
 use serde_json::json;
-use utoipa::OpenApi;
 #[cfg(feature = "swagger-ui")]
 use utoipa_swagger_ui::SwaggerUi;
 
 use crate::api;
 use crate::api::auth::{self as api_auth, default_cors_layer, RateLimiter};
-use crate::api::ApiDoc;
 use crate::state::AppState;
 
 /// Build the complete HTTP router with all routes, CORS, and rate limiting.

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -14,6 +14,10 @@
 #![deny(clippy::unwrap_used)]
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
+// omnia-substrate is deprecated but omnia-node still uses its Substrate
+// runtime and re-exported types extensively. Allow deprecated until the
+// node is migrated to use the split crates directly.
+#![allow(deprecated)]
 
 pub mod api;
 pub mod config;

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -250,7 +250,7 @@ async fn main() -> Result<()> {
 
     let listener = tokio::net::TcpListener::bind(&listen_addr)
         .await
-        .with_context(|| format!("Failed to bind HTTP server to {}", listen_addr))?;
+        .with_context(|| format!("Failed to bind HTTP server to {listen_addr}"))?;
 
     tracing::info!(listen_addr = %listen_addr, "HTTP server starting");
 
@@ -367,7 +367,7 @@ fn run_keygen(output_dir: &str, passphrase: Option<&str>) -> Result<()> {
 
     let dir = std::path::Path::new(output_dir);
     std::fs::create_dir_all(dir)
-        .with_context(|| format!("Failed to create output directory: {}", output_dir))?;
+        .with_context(|| format!("Failed to create output directory: {output_dir}"))?;
 
     let keypair = generate_keypair();
     let pubkey_bytes = keypair.verifying_key().to_bytes();
@@ -375,7 +375,7 @@ fn run_keygen(output_dir: &str, passphrase: Option<&str>) -> Result<()> {
     // Write public key as hex
     let pubkey_path = dir.join("validator_pubkey.txt");
     std::fs::write(&pubkey_path, hex::encode(pubkey_bytes))
-        .with_context(|| format!("Failed to write public key to {:?}", pubkey_path))?;
+        .with_context(|| format!("Failed to write public key to {pubkey_path:?}"))?;
 
     let privkey_bytes = keypair.to_bytes();
 
@@ -393,7 +393,7 @@ fn run_keygen(output_dir: &str, passphrase: Option<&str>) -> Result<()> {
         // Encrypt: ciphertext includes the 16-byte GCM authentication tag appended
         let ciphertext = cipher
             .encrypt(nonce, privkey_bytes.as_slice())
-            .map_err(|e| anyhow::anyhow!("AES-256-GCM encryption failed: {}", e))?;
+            .map_err(|e| anyhow::anyhow!("AES-256-GCM encryption failed: {e}"))?;
 
         // Build the file: magic + nonce + ciphertext+tag
         let mut file_bytes = Vec::with_capacity(10 + 12 + ciphertext.len());
@@ -403,10 +403,7 @@ fn run_keygen(output_dir: &str, passphrase: Option<&str>) -> Result<()> {
 
         let privkey_path = dir.join("validator_key.enc");
         std::fs::write(&privkey_path, &file_bytes).with_context(|| {
-            format!(
-                "Failed to write encrypted private key to {:?}",
-                privkey_path
-            )
+            format!("Failed to write encrypted private key to {privkey_path:?}")
         })?;
 
         // Set file permissions to 0600 (owner read/write only) on Unix
@@ -415,7 +412,7 @@ fn run_keygen(output_dir: &str, passphrase: Option<&str>) -> Result<()> {
             use std::os::unix::fs::PermissionsExt;
             let perms = std::fs::Permissions::from_mode(0o600);
             std::fs::set_permissions(&privkey_path, perms)
-                .with_context(|| format!("Failed to set permissions on {:?}", privkey_path))?;
+                .with_context(|| format!("Failed to set permissions on {privkey_path:?}"))?;
         }
 
         tracing::info!(
@@ -427,12 +424,12 @@ fn run_keygen(output_dir: &str, passphrase: Option<&str>) -> Result<()> {
 
         println!("Validator keypair generated in {}", dir.display());
         println!("  Public key: {}", hex::encode(pubkey_bytes));
-        println!("  Private key: {:?} (AES-256-GCM encrypted)", privkey_path);
+        println!("  Private key: {privkey_path:?} (AES-256-GCM encrypted)");
     } else {
         // ---- Unencrypted path (NOT recommended for production) ----
         let privkey_path = dir.join("validator_key.bin");
         std::fs::write(&privkey_path, privkey_bytes)
-            .with_context(|| format!("Failed to write private key to {:?}", privkey_path))?;
+            .with_context(|| format!("Failed to write private key to {privkey_path:?}"))?;
 
         // Set file permissions to 0600 (owner read/write only) on Unix
         #[cfg(unix)]
@@ -440,7 +437,7 @@ fn run_keygen(output_dir: &str, passphrase: Option<&str>) -> Result<()> {
             use std::os::unix::fs::PermissionsExt;
             let perms = std::fs::Permissions::from_mode(0o600);
             std::fs::set_permissions(&privkey_path, perms)
-                .with_context(|| format!("Failed to set permissions on {:?}", privkey_path))?;
+                .with_context(|| format!("Failed to set permissions on {privkey_path:?}"))?;
         }
 
         tracing::warn!(
@@ -456,7 +453,7 @@ fn run_keygen(output_dir: &str, passphrase: Option<&str>) -> Result<()> {
         println!("║     to encrypt the key with AES-256-GCM.                  ║");
         println!("║     Unencrypted keys are NOT suitable for production.     ║");
         println!("╚══════════════════════════════════════════════════════════════╝");
-        println!("  Private key: {:?}", privkey_path);
+        println!("  Private key: {privkey_path:?}");
     }
 
     Ok(())
@@ -487,7 +484,7 @@ pub fn load_encrypted_key(path: &std::path::Path, passphrase: &str) -> Result<[u
     use aes_gcm::{Aes256Gcm, KeyInit, Nonce};
 
     let file_bytes =
-        std::fs::read(path).with_context(|| format!("Failed to read key file: {:?}", path))?;
+        std::fs::read(path).with_context(|| format!("Failed to read key file: {path:?}"))?;
 
     // Validate minimum length: magic(10) + nonce(12) + tag(16) = 38 bytes minimum
     // (ciphertext must be at least 0 bytes + 16-byte tag, but Ed25519 keypair is 64 bytes,
@@ -567,7 +564,7 @@ fn run_setup_contribute(
         .init();
 
     let mut srs = PowersOfTau::new(degree).context("Failed to initialize Powers of Tau")?;
-    println!("Powers of Tau ceremony initialized (degree={})", degree);
+    println!("Powers of Tau ceremony initialized (degree={degree})");
 
     // Parse optional seed
     let seed: Option<[u8; 32]> = seed_hex
@@ -589,10 +586,10 @@ fn run_setup_contribute(
     let transcript = srs.to_transcript();
     let tau_size = srs.g1_powers.len() + srs.g2_powers.len();
     let contribution = contribute(&transcript, tau_size, seed)
-        .map_err(|e| anyhow::anyhow!("Contribution failed: {}", e))?;
+        .map_err(|e| anyhow::anyhow!("Contribution failed: {e}"))?;
 
     srs.apply_contribution(&contribution)
-        .map_err(|e| anyhow::anyhow!("Failed to apply contribution: {}", e))?;
+        .map_err(|e| anyhow::anyhow!("Failed to apply contribution: {e}"))?;
 
     println!("Contribution accepted!");
     println!(
@@ -638,12 +635,11 @@ fn run_setup_verify(degree: usize, num_contributions: usize) -> Result<()> {
         .init();
 
     println!(
-        "Verifying Powers of Tau ceremony (degree={}, contributions={})...",
-        degree, num_contributions
+        "Verifying Powers of Tau ceremony (degree={degree}, contributions={num_contributions})..."
     );
 
     let srs = run_ceremony(degree, num_contributions)
-        .map_err(|e| anyhow::anyhow!("Ceremony verification failed: {}", e))?;
+        .map_err(|e| anyhow::anyhow!("Ceremony verification failed: {e}"))?;
 
     println!("Ceremony verification successful!");
     println!("  Total contributions: {}", srs.contribution_count);
@@ -676,13 +672,13 @@ fn run_snapshot(output_path: &str) -> Result<()> {
     let nonces = std::collections::HashMap::new();
 
     let snapshot = StateSnapshot::take(&graph, &slashing, &nonces, 0)
-        .map_err(|e| anyhow::anyhow!("Snapshot failed: {}", e))?;
+        .map_err(|e| anyhow::anyhow!("Snapshot failed: {e}"))?;
 
     snapshot
         .write_to_file(std::path::Path::new(output_path))
-        .map_err(|e| anyhow::anyhow!("Failed to write snapshot: {}", e))?;
+        .map_err(|e| anyhow::anyhow!("Failed to write snapshot: {e}"))?;
 
-    println!("Snapshot written to {}", output_path);
+    println!("Snapshot written to {output_path}");
     println!("  Height: {}", snapshot.height);
     println!("  Event count: {}", snapshot.event_count);
     println!("  State root: {}", hex::encode(&snapshot.state_root[..8]));
@@ -704,13 +700,13 @@ fn run_restore(input_path: &str) -> Result<()> {
         .init();
 
     let snapshot = StateSnapshot::read_from_file(std::path::Path::new(input_path))
-        .map_err(|e| anyhow::anyhow!("Failed to read snapshot: {}", e))?;
+        .map_err(|e| anyhow::anyhow!("Failed to read snapshot: {e}"))?;
 
     snapshot
         .verify()
-        .map_err(|e| anyhow::anyhow!("Snapshot integrity check failed: {}", e))?;
+        .map_err(|e| anyhow::anyhow!("Snapshot integrity check failed: {e}"))?;
 
-    println!("Snapshot restored from {}", input_path);
+    println!("Snapshot restored from {input_path}");
     println!("  Version: {}", snapshot.version);
     println!("  Height: {}", snapshot.height);
     println!("  Event count: {}", snapshot.event_count);
@@ -735,10 +731,10 @@ fn run_genesis_init(config_path: &str, output_path: &str) -> Result<()> {
         .with_target(true)
         .init();
 
-    println!("Loading genesis configuration from {}", config_path);
+    println!("Loading genesis configuration from {config_path}");
 
     let config_content = std::fs::read_to_string(config_path)
-        .with_context(|| format!("Failed to read genesis config: {}", config_path))?;
+        .with_context(|| format!("Failed to read genesis config: {config_path}"))?;
 
     let genesis_config: GenesisConfig = toml::from_str(&config_content)
         .with_context(|| "Failed to parse genesis configuration TOML")?;
@@ -748,7 +744,7 @@ fn run_genesis_init(config_path: &str, output_path: &str) -> Result<()> {
     println!("  Validators: {}", genesis_config.initial_validators.len());
 
     let genesis_block = generate_genesis(&genesis_config)
-        .map_err(|e| anyhow::anyhow!("Genesis generation failed: {}", e))?;
+        .map_err(|e| anyhow::anyhow!("Genesis generation failed: {e}"))?;
 
     println!("\nGenesis block generated successfully!");
     println!(
@@ -760,11 +756,11 @@ fn run_genesis_init(config_path: &str, output_path: &str) -> Result<()> {
 
     // Serialize and write
     let bytes = postcard::to_allocvec(&genesis_block)
-        .map_err(|e| anyhow::anyhow!("Serialization failed: {}", e))?;
+        .map_err(|e| anyhow::anyhow!("Serialization failed: {e}"))?;
     std::fs::write(output_path, &bytes)
-        .with_context(|| format!("Failed to write genesis block to {}", output_path))?;
+        .with_context(|| format!("Failed to write genesis block to {output_path}"))?;
 
-    println!("\nGenesis block written to {}", output_path);
+    println!("\nGenesis block written to {output_path}");
     println!("  Size: {} bytes", bytes.len());
 
     Ok(())
@@ -783,13 +779,13 @@ fn run_genesis_validate(block_path: &str) -> Result<()> {
         .with_target(true)
         .init();
 
-    println!("Loading genesis block from {}", block_path);
+    println!("Loading genesis block from {block_path}");
 
     let bytes = std::fs::read(block_path)
-        .with_context(|| format!("Failed to read genesis block: {}", block_path))?;
+        .with_context(|| format!("Failed to read genesis block: {block_path}"))?;
 
-    let genesis_block: GenesisBlock = postcard::from_bytes(&bytes)
-        .map_err(|e| anyhow::anyhow!("Deserialization failed: {}", e))?;
+    let genesis_block: GenesisBlock =
+        postcard::from_bytes(&bytes).map_err(|e| anyhow::anyhow!("Deserialization failed: {e}"))?;
 
     println!("  Chain ID: {}", genesis_block.chain_id);
     println!("  Validators: {}", genesis_block.validators.len());
@@ -800,7 +796,7 @@ fn run_genesis_validate(block_path: &str) -> Result<()> {
     );
 
     validate_genesis(&genesis_block)
-        .map_err(|e| anyhow::anyhow!("Genesis validation failed: {}", e))?;
+        .map_err(|e| anyhow::anyhow!("Genesis validation failed: {e}"))?;
 
     println!("\nGenesis block is VALID");
     Ok(())
@@ -920,27 +916,21 @@ fn run_ceremony_serve(
     let server = CeremonyServer::new(config);
     server.start().context("Failed to start ceremony")?;
 
-    println!("Ceremony server started (degree={})", degree);
-    println!(
-        "  Min participants: {} / Max participants: {}",
-        min_participants, max_participants
-    );
+    println!("Ceremony server started (degree={degree})");
+    println!("  Min participants: {min_participants} / Max participants: {max_participants}");
 
     // Simulate contributions (in a real server, these would come over HTTP)
-    println!(
-        "\nSimulating {} participant contributions...",
-        min_participants
-    );
+    println!("\nSimulating {min_participants} participant contributions...");
     for i in 0..min_participants {
         let (transcript, tau_size) = server.get_srs_state().context("Failed to get SRS state")?;
         let mut seed = [0u8; 32];
         seed[0] = i as u8;
         seed[1] = (i >> 8) as u8;
         let contribution = contribute(&transcript, tau_size, Some(seed))
-            .map_err(|e| anyhow::anyhow!("Contribution {} failed: {}", i, e))?;
+            .map_err(|e| anyhow::anyhow!("Contribution {i} failed: {e}"))?;
         let receipt = server
             .accept_contribution(contribution)
-            .map_err(|e| anyhow::anyhow!("Accept contribution {} failed: {}", i, e))?;
+            .map_err(|e| anyhow::anyhow!("Accept contribution {i} failed: {e}"))?;
         println!(
             "  Contribution {} accepted (index={})",
             i, receipt.contribution_index
@@ -951,7 +941,7 @@ fn run_ceremony_serve(
     let circuit = omnia_adapters::circuit::RollupCircuit::empty();
     let key_pair = server
         .finalize(&circuit)
-        .map_err(|e| anyhow::anyhow!("Finalize failed: {}", e))?;
+        .map_err(|e| anyhow::anyhow!("Finalize failed: {e}"))?;
 
     println!("\nCeremony finalized!");
     println!("  Total contributions: {}", server.contribution_count());
@@ -968,7 +958,7 @@ fn run_ceremony_serve(
     // Export and display transcript info
     let transcript = server
         .export_transcript()
-        .map_err(|e| anyhow::anyhow!("Export transcript failed: {}", e))?;
+        .map_err(|e| anyhow::anyhow!("Export transcript failed: {e}"))?;
     println!("\nTranscript exported:");
     println!("  Contributions: {}", transcript.contribution_count);
     println!(
@@ -998,7 +988,7 @@ fn run_ceremony_contribute(server_url: &str, seed_hex: Option<&str>) -> Result<(
         .with_target(true)
         .init();
 
-    println!("Connecting to ceremony server at {}...", server_url);
+    println!("Connecting to ceremony server at {server_url}...");
 
     // Parse optional seed
     let seed: Option<[u8; 32]> = seed_hex
@@ -1050,7 +1040,7 @@ fn run_ceremony_verify(server_url: &str) -> Result<()> {
         .with_target(true)
         .init();
 
-    println!("Fetching ceremony transcript from {}...", server_url);
+    println!("Fetching ceremony transcript from {server_url}...");
 
     // TODO: Implement HTTP client for fetching transcript from server
     // For now, this is a placeholder that demonstrates the client API

--- a/node/src/pipeline.rs
+++ b/node/src/pipeline.rs
@@ -209,6 +209,7 @@ impl Default for PipelineRouter {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
 
@@ -257,7 +258,7 @@ mod tests {
         let work = HotWork {
             event_bytes: vec![1, 2, 3],
         };
-        assert!(format!("{:?}", work).contains("HotWork"));
+        assert!(format!("{work:?}").contains("HotWork"));
     }
 
     #[test]
@@ -269,8 +270,8 @@ mod tests {
         let settlement = ColdWork::SettlementSubmit {
             batch_data: vec![4, 5, 6],
         };
-        assert!(format!("{:?}", proof).contains("GenerateProof"));
-        assert!(format!("{:?}", snapshot).contains("SnapshotReplication"));
-        assert!(format!("{:?}", settlement).contains("SettlementSubmit"));
+        assert!(format!("{proof:?}").contains("GenerateProof"));
+        assert!(format!("{snapshot:?}").contains("SnapshotReplication"));
+        assert!(format!("{settlement:?}").contains("SettlementSubmit"));
     }
 }

--- a/node/src/state.rs
+++ b/node/src/state.rs
@@ -4,6 +4,11 @@
 //! all HTTP handlers via `axum::extract::State`, and the [`NodeMetrics`]
 //! struct that tracks Prometheus counters and gauges.
 
+// omnia-substrate is deprecated but omnia-node still uses its Substrate
+// runtime and SlashingEngine types. Allow deprecated at crate level.
+use omnia_substrate::SlashingEngine;
+use omnia_substrate::Substrate;
+
 use std::collections::HashMap;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
@@ -16,8 +21,6 @@ use tokio::sync::{Mutex, RwLock};
 
 use omnia_economics::EconomicsState;
 use omnia_shards::ShardRouter;
-use omnia_substrate::SlashingEngine;
-use omnia_substrate::Substrate;
 
 use omnia_adapters::SettlementAdapter;
 

--- a/node/tests/api_integration.rs
+++ b/node/tests/api_integration.rs
@@ -208,7 +208,7 @@ async fn start_test_server() -> (String, tokio::task::JoinHandle<()>) {
     // Give the server a moment to start accepting connections
     tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
 
-    (format!("http://127.0.0.1:{}", port), handle)
+    (format!("http://127.0.0.1:{port}"), handle)
 }
 
 /// Holds a running test server together with the RAII guards that ensure
@@ -867,8 +867,7 @@ async fn test_rate_limit_events_endpoint() {
             let error_msg = body["error"].as_str().unwrap();
             assert!(
                 error_msg.contains("rate limit"),
-                "Error message should mention rate limit, got: {}",
-                error_msg
+                "Error message should mention rate limit, got: {error_msg}"
             );
             break;
         }
@@ -919,8 +918,7 @@ async fn test_mint_ubc_non_admin_forbidden() {
     let error_msg = body["error"].as_str().unwrap();
     assert!(
         error_msg.contains("not authorized"),
-        "Error message should mention authorization, got: {}",
-        error_msg
+        "Error message should mention authorization, got: {error_msg}"
     );
 }
 
@@ -991,8 +989,7 @@ async fn test_advance_epoch_non_admin_forbidden() {
     let error_msg = body["error"].as_str().unwrap();
     assert!(
         error_msg.contains("not authorized"),
-        "Error message should mention authorization, got: {}",
-        error_msg
+        "Error message should mention authorization, got: {error_msg}"
     );
 }
 
@@ -1074,8 +1071,7 @@ async fn test_cors_preflight() {
     let methods_str = allow_methods.to_str().unwrap();
     assert!(
         methods_str.contains("GET") && methods_str.contains("POST"),
-        "Allowed methods should include GET and POST, got: {}",
-        methods_str
+        "Allowed methods should include GET and POST, got: {methods_str}"
     );
 
     let allow_headers = resp
@@ -1085,8 +1081,7 @@ async fn test_cors_preflight() {
     let headers_str = allow_headers.to_str().unwrap();
     assert!(
         headers_str.contains("authorization") && headers_str.contains("content-type"),
-        "Allowed headers should include Authorization and Content-Type, got: {}",
-        headers_str
+        "Allowed headers should include Authorization and Content-Type, got: {headers_str}"
     );
 
     let max_age = resp
@@ -1149,15 +1144,13 @@ async fn test_error_format_401_unauthorized() {
     let body: Value = resp.json().await.unwrap();
     assert!(
         body["error"].is_string(),
-        "401 response should have 'error' string field, got: {:?}",
-        body
+        "401 response should have 'error' string field, got: {body:?}"
     );
     let error_msg = body["error"].as_str().unwrap();
     assert!(!error_msg.is_empty(), "Error message should not be empty");
     assert!(
         error_msg.contains("authorization"),
-        "Missing-auth error should mention 'authorization', got: {}",
-        error_msg
+        "Missing-auth error should mention 'authorization', got: {error_msg}"
     );
 
     // --- Expired token ---
@@ -1172,8 +1165,7 @@ async fn test_error_format_401_unauthorized() {
     let body: Value = resp.json().await.unwrap();
     assert!(
         body["error"].is_string(),
-        "401 response should have 'error' string field, got: {:?}",
-        body
+        "401 response should have 'error' string field, got: {body:?}"
     );
     assert!(
         body["error"].as_str().unwrap().contains("expired"),
@@ -1193,8 +1185,7 @@ async fn test_error_format_401_unauthorized() {
     let body: Value = resp.json().await.unwrap();
     assert!(
         body["error"].is_string(),
-        "401 response should have 'error' string field, got: {:?}",
-        body
+        "401 response should have 'error' string field, got: {body:?}"
     );
     assert!(
         !body["error"].as_str().unwrap().is_empty(),
@@ -1230,14 +1221,12 @@ async fn test_error_format_403_forbidden() {
     let body: Value = resp.json().await.unwrap();
     assert!(
         body["error"].is_string(),
-        "403 response should have 'error' string field, got: {:?}",
-        body
+        "403 response should have 'error' string field, got: {body:?}"
     );
     let error_msg = body["error"].as_str().unwrap();
     assert!(
         error_msg.contains("not authorized"),
-        "403 error should mention 'not authorized', got: {}",
-        error_msg
+        "403 error should mention 'not authorized', got: {error_msg}"
     );
 }
 
@@ -1261,8 +1250,7 @@ async fn test_error_format_404_not_found() {
     let body: Value = resp.json().await.unwrap();
     assert!(
         body["error"].is_string(),
-        "404 response should have 'error' string field, got: {:?}",
-        body
+        "404 response should have 'error' string field, got: {body:?}"
     );
     let error_msg = body["error"].as_str().unwrap();
     assert!(
@@ -1285,8 +1273,7 @@ async fn test_error_format_404_not_found() {
     let body: Value = resp.json().await.unwrap();
     assert!(
         body["error"].is_string(),
-        "Economics 404 response should have 'error' string field, got: {:?}",
-        body
+        "Economics 404 response should have 'error' string field, got: {body:?}"
     );
 }
 
@@ -1312,14 +1299,12 @@ async fn test_error_format_429_rate_limited() {
             let body: Value = resp.json().await.unwrap();
             assert!(
                 body["error"].is_string(),
-                "429 response should have 'error' string field, got: {:?}",
-                body
+                "429 response should have 'error' string field, got: {body:?}"
             );
             let error_msg = body["error"].as_str().unwrap();
             assert!(
                 error_msg.contains("rate limit"),
-                "429 error should mention 'rate limit', got: {}",
-                error_msg
+                "429 error should mention 'rate limit', got: {error_msg}"
             );
             got_429 = true;
             break;

--- a/node/tests/integration.rs
+++ b/node/tests/integration.rs
@@ -103,7 +103,7 @@ async fn start_test_server() -> (String, tokio::task::JoinHandle<()>) {
     // Give the server a moment to start
     tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
 
-    (format!("http://127.0.0.1:{}", port), handle)
+    (format!("http://127.0.0.1:{port}"), handle)
 }
 
 #[tokio::test]
@@ -111,7 +111,7 @@ async fn test_health_endpoint() -> Result<()> {
     let (base_url, _handle) = start_test_server().await;
 
     let client = reqwest::Client::new();
-    let resp = client.get(format!("{}/health", base_url)).send().await?;
+    let resp = client.get(format!("{base_url}/health")).send().await?;
 
     assert_eq!(resp.status(), 200);
 
@@ -128,7 +128,7 @@ async fn test_metrics_endpoint() -> Result<()> {
     let (base_url, _handle) = start_test_server().await;
 
     let client = reqwest::Client::new();
-    let resp = client.get(format!("{}/metrics", base_url)).send().await?;
+    let resp = client.get(format!("{base_url}/metrics")).send().await?;
 
     assert_eq!(resp.status(), 200);
 
@@ -167,7 +167,7 @@ async fn test_submit_event() -> Result<()> {
 
     let client = reqwest::Client::new();
     let resp = client
-        .post(format!("{}/api/v1/events", base_url))
+        .post(format!("{base_url}/api/v1/events"))
         .json(&json!({
             "payload": hex::encode(b"hello omnia"),
             "event_type": "test"
@@ -193,7 +193,7 @@ async fn test_get_event_not_found() -> Result<()> {
 
     let client = reqwest::Client::new();
     let resp = client
-        .get(format!("{}/api/v1/events/nonexistent", base_url))
+        .get(format!("{base_url}/api/v1/events/nonexistent"))
         .send()
         .await?;
 
@@ -235,10 +235,7 @@ async fn test_swagger_ui() -> Result<()> {
 async fn test_swagger_ui_disabled() -> Result<()> {
     let (base_url, _handle) = start_test_server().await;
     let client = reqwest::Client::new();
-    let resp = client
-        .get(format!("{}/swagger-ui/", base_url))
-        .send()
-        .await?;
+    let resp = client.get(format!("{base_url}/swagger-ui/")).send().await?;
     assert_eq!(
         resp.status(),
         404,
@@ -293,7 +290,7 @@ async fn test_openapi_json_disabled() -> Result<()> {
     let (base_url, _handle) = start_test_server().await;
     let client = reqwest::Client::new();
     let resp = client
-        .get(format!("{}/api-docs/openapi.json", base_url))
+        .get(format!("{base_url}/api-docs/openapi.json"))
         .send()
         .await?;
     assert_eq!(

--- a/omnia-adapters/build.rs
+++ b/omnia-adapters/build.rs
@@ -18,7 +18,7 @@ fn main() {
             println!("cargo:rustc-cfg=rustc_version_compatible");
         }
         // Print version for debugging
-        println!("cargo:rustc-env=OMNIA_RUSTC_VERSION={}", version);
+        println!("cargo:rustc-env=OMNIA_RUSTC_VERSION={version}");
     }
 
     // Enable FFI if pre-compiled library exists

--- a/omnia-adapters/src/merkle.rs
+++ b/omnia-adapters/src/merkle.rs
@@ -220,7 +220,7 @@ mod tests {
         for (i, item) in items.iter().enumerate() {
             let leaf = *blake3::hash(item).as_bytes();
             let computed = compute_root_from_proof(&leaf, &proofs[i]);
-            assert_eq!(root, computed, "proof for item {} should verify", i);
+            assert_eq!(root, computed, "proof for item {i} should verify");
         }
     }
 

--- a/omnia-adapters/src/poseidon.rs
+++ b/omnia-adapters/src/poseidon.rs
@@ -126,6 +126,7 @@ const ALPHA: u64 = 5;
 ///
 /// A 3×3 MDS matrix of field elements, or [`ZkError::MdsMatrixInversionFailed`]
 /// if a Cauchy denominator is unexpectedly zero.
+#[allow(clippy::needless_range_loop)]
 fn generate_mds_matrix() -> Result<[[Fr; T]; T], ZkError> {
     let xs: [u64; T] = [1, 2, 3];
     let ys: [u64; T] = [5, 6, 7];
@@ -192,6 +193,7 @@ fn generate_round_constants() -> Vec<Fr> {
 /// the custom module's x = [1, 2, 3], y = [5, 6, 7]. This ensures
 /// both parameter sets produce different hash outputs while both are
 /// valid Cauchy MDS matrices.
+#[allow(clippy::needless_range_loop)]
 fn generate_reference_mds_matrix() -> Result<[[Fr; T]; T], ZkError> {
     let xs: [u64; T] = [2, 3, 4];
     let ys: [u64; T] = [6, 7, 8];
@@ -325,6 +327,7 @@ fn sbox_gadget(x: &FpVar<Fr>) -> FpVar<Fr> {
 // ---------------------------------------------------------------------------
 
 /// Multiply a state vector by the MDS matrix (off-circuit).
+#[allow(clippy::needless_range_loop)]
 fn mds_multiply(mds: &[[Fr; T]; T], state: &[Fr; T]) -> [Fr; T] {
     let mut result = [Fr::zero(); T];
     for i in 0..T {

--- a/omnia-adapters/src/proof_bundle.rs
+++ b/omnia-adapters/src/proof_bundle.rs
@@ -211,8 +211,7 @@ mod tests {
         let err = bundle.verify_integrity().unwrap_err();
         assert!(
             matches!(err, ProofBundleError::InvalidVersion(99)),
-            "expected InvalidVersion(99), got {:?}",
-            err
+            "expected InvalidVersion(99), got {err:?}"
         );
     }
 
@@ -223,8 +222,7 @@ mod tests {
         let err = bundle.verify_integrity().unwrap_err();
         assert!(
             matches!(err, ProofBundleError::EmptyProof),
-            "expected EmptyProof, got {:?}",
-            err
+            "expected EmptyProof, got {err:?}"
         );
     }
 
@@ -237,8 +235,7 @@ mod tests {
         let err = bundle.verify_integrity().unwrap_err();
         assert!(
             matches!(err, ProofBundleError::SameStateRoots),
-            "expected SameStateRoots, got {:?}",
-            err
+            "expected SameStateRoots, got {err:?}"
         );
     }
 

--- a/omnia-adapters/src/settlement/ethereum/mod.rs
+++ b/omnia-adapters/src/settlement/ethereum/mod.rs
@@ -751,7 +751,7 @@ impl SettlementLayer for EthereumAdapter {
 
     async fn deposit(&self, l2_did: &str, amount: u64) -> Result<String, SettlementError> {
         match self.mode {
-            EthereumMode::Simulated => Ok(format!("0xdeposit_{}_{}", l2_did, amount)),
+            EthereumMode::Simulated => Ok(format!("0xdeposit_{l2_did}_{amount}")),
             EthereumMode::Live => {
                 #[cfg(feature = "ethereum-live")]
                 if let Some(ref client) = self.live_client {
@@ -781,7 +781,7 @@ impl SettlementLayer for EthereumAdapter {
         amount: u64,
     ) -> Result<String, SettlementError> {
         match self.mode {
-            EthereumMode::Simulated => Ok(format!("0xwithdraw_{}_{}", l2_did, amount)),
+            EthereumMode::Simulated => Ok(format!("0xwithdraw_{l2_did}_{amount}")),
             EthereumMode::Live => {
                 #[cfg(feature = "ethereum-live")]
                 if let Some(ref client) = self.live_client {

--- a/omnia-adapters/src/settlement/noop.rs
+++ b/omnia-adapters/src/settlement/noop.rs
@@ -40,7 +40,7 @@ impl SettlementLayer for NoopSettlementAdapter {
     }
 
     async fn deposit(&self, l2_did: &str, amount: u64) -> Result<String, SettlementError> {
-        Ok(format!("noop-deposit-{}-{}", l2_did, amount))
+        Ok(format!("noop-deposit-{l2_did}-{amount}"))
     }
 
     async fn request_withdrawal(
@@ -48,7 +48,7 @@ impl SettlementLayer for NoopSettlementAdapter {
         l2_did: &str,
         amount: u64,
     ) -> Result<String, SettlementError> {
-        Ok(format!("noop-withdrawal-{}-{}", l2_did, amount))
+        Ok(format!("noop-withdrawal-{l2_did}-{amount}"))
     }
 
     async fn submit_batch(&self, _bundle: &ProofBundle) -> Result<String, SettlementError> {

--- a/omnia-adapters/src/setup/ceremony_client.rs
+++ b/omnia-adapters/src/setup/ceremony_client.rs
@@ -128,8 +128,7 @@ impl CeremonyClient {
         for (i, contribution) in transcript.contributions.iter().enumerate() {
             replay_srs.apply_contribution(contribution).map_err(|e| {
                 CeremonyClientError::VerificationFailed(format!(
-                    "Contribution {} failed verification: {}",
-                    i, e
+                    "Contribution {i} failed verification: {e}"
                 ))
             })?;
         }

--- a/omnia-adapters/src/setup/ceremony_server.rs
+++ b/omnia-adapters/src/setup/ceremony_server.rs
@@ -622,7 +622,7 @@ mod tests {
         for (i, contribution) in transcript.contributions.iter().enumerate() {
             replay_srs
                 .apply_contribution(contribution)
-                .unwrap_or_else(|e| panic!("Contribution {} failed verification: {}", i, e));
+                .unwrap_or_else(|e| panic!("Contribution {i} failed verification: {e}"));
         }
 
         // Verify the final transcript hash matches

--- a/omnia-adapters/src/setup/circuit_setup.rs
+++ b/omnia-adapters/src/setup/circuit_setup.rs
@@ -431,7 +431,7 @@ mod tests {
             let mut slice = g1_bytes.as_slice();
             let g1_point = ark_bn254::G1Affine::deserialize_uncompressed(&mut slice)
                 .expect("G1 deserialization failed");
-            assert!(!g1_point.is_zero(), "G1 power {} is identity", i);
+            assert!(!g1_point.is_zero(), "G1 power {i} is identity");
         }
 
         // All G2 powers should be non-identity
@@ -439,7 +439,7 @@ mod tests {
             let mut slice = g2_bytes.as_slice();
             let g2_point = ark_bn254::G2Affine::deserialize_uncompressed(&mut slice)
                 .expect("G2 deserialization failed");
-            assert!(!g2_point.is_zero(), "G2 power {} is identity", i);
+            assert!(!g2_point.is_zero(), "G2 power {i} is identity");
         }
 
         // 3. Derive circuit keys from the SRS

--- a/omnia-adapters/src/setup/contribution.rs
+++ b/omnia-adapters/src/setup/contribution.rs
@@ -391,10 +391,7 @@ pub fn verify_ceremony_transcript(
     let mut transcript = initial_transcript.to_vec();
     for (i, contribution) in contributions.iter().enumerate() {
         verify_contribution(contribution, &transcript, tau_size).map_err(|e| {
-            SetupError::InvalidContribution(format!(
-                "Contribution {} failed verification: {}",
-                i, e
-            ))
+            SetupError::InvalidContribution(format!("Contribution {i} failed verification: {e}"))
         })?;
         transcript = contribution.transcript.clone();
     }
@@ -805,8 +802,7 @@ mod tests {
             assert_eq!(
                 &transcript[offset..offset + 64],
                 g1_bytes.as_slice(),
-                "G1 power {} should be the generator",
-                i
+                "G1 power {i} should be the generator"
             );
         }
     }

--- a/omnia-adapters/src/setup/powers_of_tau.rs
+++ b/omnia-adapters/src/setup/powers_of_tau.rs
@@ -280,8 +280,7 @@ impl PowersOfTau {
             let mut slice = g1_bytes.as_slice();
             let _g1 = G1Affine::deserialize_uncompressed(&mut slice).map_err(|e| {
                 SetupError::InvalidContribution(format!(
-                    "G1 power {} is not a valid curve point: {}",
-                    i, e
+                    "G1 power {i} is not a valid curve point: {e}"
                 ))
             })?;
         }
@@ -291,8 +290,7 @@ impl PowersOfTau {
             let mut slice = g2_bytes.as_slice();
             let _g2 = G2Affine::deserialize_uncompressed(&mut slice).map_err(|e| {
                 SetupError::InvalidContribution(format!(
-                    "G2 power {} is not a valid curve point: {}",
-                    i, e
+                    "G2 power {i} is not a valid curve point: {e}"
                 ))
             })?;
         }
@@ -416,14 +414,14 @@ mod tests {
         for (i, g1_bytes) in pot.g1_powers.iter().enumerate() {
             let mut slice = g1_bytes.as_slice();
             let point = G1Affine::deserialize_uncompressed(&mut slice).unwrap();
-            assert_eq!(point, g1_gen, "G1 power {} should be generator", i);
+            assert_eq!(point, g1_gen, "G1 power {i} should be generator");
         }
 
         // All G2 powers should be the generator
         for (i, g2_bytes) in pot.g2_powers.iter().enumerate() {
             let mut slice = g2_bytes.as_slice();
             let point = G2Affine::deserialize_uncompressed(&mut slice).unwrap();
-            assert_eq!(point, g2_gen, "G2 power {} should be generator", i);
+            assert_eq!(point, g2_gen, "G2 power {i} should be generator");
         }
     }
 
@@ -505,14 +503,14 @@ mod tests {
         for (i, g1_bytes) in pot.g1_powers.iter().enumerate() {
             let mut slice = g1_bytes.as_slice();
             let point = G1Affine::deserialize_uncompressed(&mut slice).unwrap();
-            assert!(!point.is_zero(), "G1 power {} should be non-identity", i);
+            assert!(!point.is_zero(), "G1 power {i} should be non-identity");
         }
 
         // All G2 powers should be non-identity after contributions
         for (i, g2_bytes) in pot.g2_powers.iter().enumerate() {
             let mut slice = g2_bytes.as_slice();
             let point = G2Affine::deserialize_uncompressed(&mut slice).unwrap();
-            assert!(!point.is_zero(), "G2 power {} should be non-identity", i);
+            assert!(!point.is_zero(), "G2 power {i} should be non-identity");
         }
     }
 }

--- a/omnia-consensus/src/consensus.rs
+++ b/omnia-consensus/src/consensus.rs
@@ -518,7 +518,7 @@ impl<S: SlashingBackend> ConsensusEngine<S> {
     pub fn stats(&self) -> ConsensusStats {
         let mut by_state: HashMap<String, usize> = HashMap::new();
         for state in self.event_states.values() {
-            let key = format!("{:?}", state);
+            let key = format!("{state:?}");
             *by_state.entry(key).or_insert(0) += 1;
         }
 

--- a/omnia-consensus/src/crdt/lww_register.rs
+++ b/omnia-consensus/src/crdt/lww_register.rs
@@ -174,7 +174,7 @@ impl<T: Clone + Serialize + Default> Default for LwwRegister<T> {
 impl<T: Clone + Serialize + fmt::Display> fmt::Display for LwwRegister<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self.value {
-            Some(v) => write!(f, "LWW({})", v),
+            Some(v) => write!(f, "LWW({v})"),
             None => write!(f, "LWW(<empty>)"),
         }
     }

--- a/omnia-consensus/src/slashing.rs
+++ b/omnia-consensus/src/slashing.rs
@@ -1918,6 +1918,29 @@ impl SlashingEngine {
     }
 }
 
+// ── SlashingBackend implementation ──────────────────────────────────
+
+impl crate::SlashingBackend for SlashingEngine {
+    fn is_slashed(&self, node: &NodeId) -> bool {
+        SlashingEngine::is_slashed(self, node)
+    }
+
+    fn record_offense(&mut self, node: NodeId, offense: SlashOffense) -> SlashOutcome {
+        SlashingEngine::record_offense(self, node, offense)
+    }
+
+    fn register_validator(&mut self, node: NodeId, stake: u64) {
+        SlashingEngine::register_validator(self, node, stake)
+    }
+}
+
+/// Type alias for the default slashing backend.
+///
+/// This wraps the existing [`SlashingEngine`] as the canonical
+/// implementation of [`SlashingBackend`]. Consumers that do not
+/// need a custom slashing backend can use this type directly.
+pub type DefaultSlashingBackend = SlashingEngine;
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
@@ -3053,26 +3076,3 @@ mod tests {
         assert_eq!(SlashingEngine::compute_burn_amount(999, 1.0), 9); // 999 * 0.01 = 9.99 → 9
     }
 }
-
-// ── SlashingBackend implementation ──────────────────────────────────
-
-impl crate::SlashingBackend for SlashingEngine {
-    fn is_slashed(&self, node: &NodeId) -> bool {
-        SlashingEngine::is_slashed(self, node)
-    }
-
-    fn record_offense(&mut self, node: NodeId, offense: SlashOffense) -> SlashOutcome {
-        SlashingEngine::record_offense(self, node, offense)
-    }
-
-    fn register_validator(&mut self, node: NodeId, stake: u64) {
-        SlashingEngine::register_validator(self, node, stake)
-    }
-}
-
-/// Type alias for the default slashing backend.
-///
-/// This wraps the existing [`SlashingEngine`] as the canonical
-/// implementation of [`SlashingBackend`]. Consumers that do not
-/// need a custom slashing backend can use this type directly.
-pub type DefaultSlashingBackend = SlashingEngine;

--- a/omnia-consensus/tests/multi_node_test.rs
+++ b/omnia-consensus/tests/multi_node_test.rs
@@ -105,8 +105,7 @@ fn test_multi_node_bft_finality() {
     for (i, &count) in committed_counts.iter().enumerate() {
         assert_eq!(
             count, first,
-            "Node {} committed {} events, expected {}",
-            i, count, first
+            "Node {i} committed {count} events, expected {first}"
         );
     }
 }
@@ -175,8 +174,7 @@ fn test_bft_safety_with_byzantine_node() {
     for (i, &count) in committed_counts.iter().enumerate() {
         assert_eq!(
             count, first,
-            "Honest node {} committed {} events, expected {}",
-            i, count, first
+            "Honest node {i} committed {count} events, expected {first}"
         );
     }
 }
@@ -222,7 +220,7 @@ fn test_consensus_progress_with_minority_faults() {
             let event = if self_parents[node_idx].is_none() {
                 Event::genesis(
                     creator,
-                    format!("round-{}-node-{}", round, node_idx).into_bytes(),
+                    format!("round-{round}-node-{node_idx}").into_bytes(),
                 )
             } else {
                 Event::new(
@@ -231,7 +229,7 @@ fn test_consensus_progress_with_minority_faults() {
                     vector_clocks[node_idx].clone(),
                     self_parents[node_idx],
                     other_parent,
-                    format!("round-{}-node-{}", round, node_idx).into_bytes(),
+                    format!("round-{round}-node-{node_idx}").into_bytes(),
                 )
             };
 
@@ -260,8 +258,7 @@ fn test_consensus_progress_with_minority_faults() {
     for (i, engine) in engines.iter().enumerate() {
         assert!(
             engine.committed_count() > 0,
-            "Honest node {} should have committed events, got 0",
-            i
+            "Honest node {i} should have committed events, got 0"
         );
     }
 
@@ -271,8 +268,7 @@ fn test_consensus_progress_with_minority_faults() {
     for (i, &count) in committed_counts.iter().enumerate() {
         assert_eq!(
             count, first,
-            "Honest node {} committed {} events, expected {}",
-            i, count, first
+            "Honest node {i} committed {count} events, expected {first}"
         );
     }
 }

--- a/omnia-crypto/src/bls.rs
+++ b/omnia-crypto/src/bls.rs
@@ -254,11 +254,11 @@ impl BlsPublicKey {
         }
 
         let pk = BlstPublicKey::from_bytes(bytes)
-            .map_err(|e| BlsError::InvalidPublicKey(format!("{:?}", e)))?;
+            .map_err(|e| BlsError::InvalidPublicKey(format!("{e:?}")))?;
 
         // Validate the public key (group check)
         pk.validate()
-            .map_err(|e| BlsError::InvalidPublicKey(format!("validation failed: {:?}", e)))?;
+            .map_err(|e| BlsError::InvalidPublicKey(format!("validation failed: {e:?}")))?;
 
         Ok(BlsPublicKey(bytes.to_vec()))
     }
@@ -300,10 +300,10 @@ impl BlsPublicKey {
     /// ```
     pub fn verify(&self, message: &[u8], signature: &BlsSignature) -> Result<(), BlsError> {
         let pk = BlstPublicKey::from_bytes(&self.0)
-            .map_err(|e| BlsError::InvalidPublicKey(format!("{:?}", e)))?;
+            .map_err(|e| BlsError::InvalidPublicKey(format!("{e:?}")))?;
 
         let sig = BlstSignature::from_bytes(&signature.0)
-            .map_err(|e| BlsError::InvalidSignature(format!("{:?}", e)))?;
+            .map_err(|e| BlsError::InvalidSignature(format!("{e:?}")))?;
 
         let result = sig.verify(true, message, BLS_DST, &[], &pk, false);
 
@@ -315,8 +315,7 @@ impl BlsPublicKey {
 
     /// Convert to the underlying blst public key type.
     fn to_blst(&self) -> Result<BlstPublicKey, BlsError> {
-        BlstPublicKey::from_bytes(&self.0)
-            .map_err(|e| BlsError::InvalidPublicKey(format!("{:?}", e)))
+        BlstPublicKey::from_bytes(&self.0).map_err(|e| BlsError::InvalidPublicKey(format!("{e:?}")))
     }
 }
 
@@ -342,7 +341,7 @@ impl BlsSignature {
 
         // Validate by attempting to deserialize
         let _sig = BlstSignature::from_bytes(bytes)
-            .map_err(|e| BlsError::InvalidSignature(format!("{:?}", e)))?;
+            .map_err(|e| BlsError::InvalidSignature(format!("{e:?}")))?;
 
         Ok(BlsSignature(bytes.to_vec()))
     }
@@ -358,8 +357,7 @@ impl BlsSignature {
 
     /// Convert to the underlying blst signature type.
     fn to_blst(&self) -> Result<BlstSignature, BlsError> {
-        BlstSignature::from_bytes(&self.0)
-            .map_err(|e| BlsError::InvalidSignature(format!("{:?}", e)))
+        BlstSignature::from_bytes(&self.0).map_err(|e| BlsError::InvalidSignature(format!("{e:?}")))
     }
 }
 
@@ -452,13 +450,13 @@ pub fn aggregate_signatures(signatures: &[BlsSignature]) -> Result<BlsSignature,
         .iter()
         .map(|s| s.to_blst())
         .collect::<Result<Vec<_>, _>>()
-        .map_err(|e| BlsError::AggregationFailed(format!("deserialization: {}", e)))?;
+        .map_err(|e| BlsError::AggregationFailed(format!("deserialization: {e}")))?;
 
     // Create references for the blst aggregate function
     let sig_refs: Vec<&BlstSignature> = blst_sigs.iter().collect();
 
     let agg = AggregateSignature::aggregate(&sig_refs, false)
-        .map_err(|e| BlsError::AggregationFailed(format!("blst aggregation: {:?}", e)))?;
+        .map_err(|e| BlsError::AggregationFailed(format!("blst aggregation: {e:?}")))?;
 
     let compressed = agg.to_signature().compress();
     Ok(BlsSignature(compressed.to_vec()))
@@ -504,13 +502,13 @@ pub fn aggregate_public_keys(public_keys: &[BlsPublicKey]) -> Result<BlsPublicKe
         .iter()
         .map(|pk| pk.to_blst())
         .collect::<Result<Vec<_>, _>>()
-        .map_err(|e| BlsError::AggregationFailed(format!("deserialization: {}", e)))?;
+        .map_err(|e| BlsError::AggregationFailed(format!("deserialization: {e}")))?;
 
     // Create references for the blst aggregate function
     let pk_refs: Vec<&BlstPublicKey> = blst_pks.iter().collect();
 
     let agg = AggregatePublicKey::aggregate(&pk_refs, false)
-        .map_err(|e| BlsError::AggregationFailed(format!("blst pk aggregation: {:?}", e)))?;
+        .map_err(|e| BlsError::AggregationFailed(format!("blst pk aggregation: {e:?}")))?;
 
     let compressed = agg.to_public_key().compress();
     Ok(BlsPublicKey(compressed.to_vec()))

--- a/omnia-crypto/src/keystore.rs
+++ b/omnia-crypto/src/keystore.rs
@@ -486,7 +486,7 @@ impl EncryptedKeyStore {
             .to_bytes();
 
         let purpose_index = purpose as u32;
-        let derivation_info = format!("OMNIA-SLIP0010-{}-{}-V1", purpose_index, index);
+        let derivation_info = format!("OMNIA-SLIP0010-{purpose_index}-{index}-V1");
 
         let hkdf = Hkdf::<Sha256>::new(Some(&purpose_index.to_be_bytes()), &secret_bytes);
         let mut derived_key = [0u8; 32];

--- a/omnia-crypto/src/threshold.rs
+++ b/omnia-crypto/src/threshold.rs
@@ -84,14 +84,11 @@ impl ThresholdConfig {
     pub fn new(total_participants: usize, threshold: usize) -> Self {
         assert!(
             threshold >= 2,
-            "Threshold must be at least 2, got {}",
-            threshold
+            "Threshold must be at least 2, got {threshold}"
         );
         assert!(
             threshold <= total_participants,
-            "Threshold {} exceeds total participants {}",
-            threshold,
-            total_participants
+            "Threshold {threshold} exceeds total participants {total_participants}"
         );
         Self {
             total_participants,

--- a/omnia-crypto/src/vrf.rs
+++ b/omnia-crypto/src/vrf.rs
@@ -166,7 +166,7 @@ pub fn vrf_verify(
     // Verify the signature against the input
     public_key
         .verify(input, &signature)
-        .map_err(|e| VrfError::VerificationFailed(format!("Signature verification: {}", e)))?;
+        .map_err(|e| VrfError::VerificationFailed(format!("Signature verification: {e}")))?;
 
     // Recompute the expected VRF output
     let mut preimage = Vec::new();
@@ -448,7 +448,7 @@ pub fn ecvrf_verify(
         );
     public_key
         .verify(&transcript, &signature)
-        .map_err(|e| VrfError::VerificationFailed(format!("Signature verification: {}", e)))?;
+        .map_err(|e| VrfError::VerificationFailed(format!("Signature verification: {e}")))?;
 
     // Step 5: Derive the VRF output from Gamma
     Ok(ecvrf_proof_to_hash(&proof.gamma))
@@ -805,18 +805,15 @@ mod tests {
         // Allow 500 bps (5%) tolerance for statistical variance
         assert!(
             freq_1_bps > 500 && freq_1_bps < 1500,
-            "Node 1 frequency {} bps not ~1000 bps (10%)",
-            freq_1_bps
+            "Node 1 frequency {freq_1_bps} bps not ~1000 bps (10%)"
         );
         assert!(
             freq_2_bps > 3500 && freq_2_bps < 4500,
-            "Node 2 frequency {} bps not ~4000 bps (40%)",
-            freq_2_bps
+            "Node 2 frequency {freq_2_bps} bps not ~4000 bps (40%)"
         );
         assert!(
             freq_3_bps > 4500 && freq_3_bps < 5500,
-            "Node 3 frequency {} bps not ~5000 bps (50%)",
-            freq_3_bps
+            "Node 3 frequency {freq_3_bps} bps not ~5000 bps (50%)"
         );
     }
 
@@ -964,18 +961,15 @@ mod tests {
 
         assert!(
             freq_1_bps > 500 && freq_1_bps < 1500,
-            "Node 1 V2 frequency {} bps not ~1000 bps (10%)",
-            freq_1_bps
+            "Node 1 V2 frequency {freq_1_bps} bps not ~1000 bps (10%)"
         );
         assert!(
             freq_2_bps > 3500 && freq_2_bps < 4500,
-            "Node 2 V2 frequency {} bps not ~4000 bps (40%)",
-            freq_2_bps
+            "Node 2 V2 frequency {freq_2_bps} bps not ~4000 bps (40%)"
         );
         assert!(
             freq_3_bps > 4500 && freq_3_bps < 5500,
-            "Node 3 V2 frequency {} bps not ~5000 bps (50%)",
-            freq_3_bps
+            "Node 3 V2 frequency {freq_3_bps} bps not ~5000 bps (50%)"
         );
     }
 

--- a/omnia-network/src/gossip.rs
+++ b/omnia-network/src/gossip.rs
@@ -697,8 +697,7 @@ pub fn deserialize_compressed<T: serde::de::DeserializeOwned>(
         }
         _ => {
             return Err(GossipError::InvalidMessageFormat(format!(
-                "unknown compression flag: 0x{:02x}",
-                flag
+                "unknown compression flag: 0x{flag:02x}"
             )));
         }
     };
@@ -782,8 +781,7 @@ mod tests {
         let err_msg = result.unwrap_err().to_string();
         assert!(
             err_msg.contains("unsigned"),
-            "Expected unsigned error, got: {}",
-            err_msg
+            "Expected unsigned error, got: {err_msg}"
         );
     }
 

--- a/omnia-network/src/network.rs
+++ b/omnia-network/src/network.rs
@@ -826,7 +826,7 @@ mod tests {
     fn test_network_config_custom_bootstrap_peers() {
         // Use a PeerId to generate a valid multiaddr for testing
         let peer_id = PeerId::random();
-        let addr: Multiaddr = format!("/ip4/1.2.3.4/udp/4001/quic-v1/p2p/{}", peer_id)
+        let addr: Multiaddr = format!("/ip4/1.2.3.4/udp/4001/quic-v1/p2p/{peer_id}")
             .parse()
             .expect("valid multiaddr");
         let config = NetworkConfig {
@@ -934,7 +934,7 @@ mod tests {
     fn test_extract_peer_id_from_multiaddr() {
         // Multiaddr with /p2p suffix — use a generated PeerId for a valid address
         let peer_id = PeerId::random();
-        let addr: Multiaddr = format!("/ip4/1.2.3.4/udp/4001/quic-v1/p2p/{}", peer_id)
+        let addr: Multiaddr = format!("/ip4/1.2.3.4/udp/4001/quic-v1/p2p/{peer_id}")
             .parse()
             .expect("valid multiaddr");
         let extracted = extract_peer_id_from_multiaddr(&addr);

--- a/omnia-primitives/src/event.rs
+++ b/omnia-primitives/src/event.rs
@@ -889,14 +889,14 @@ mod tests {
     #[test]
     fn test_circular_parent_reference_error_variant() {
         let err = EventValidationError::CircularParentReference;
-        assert_eq!(format!("{}", err), "Event parent references form a cycle");
+        assert_eq!(format!("{err}"), "Event parent references form a cycle");
     }
 
     /// Test that the new MissingParent error variant exists and is constructible.
     #[test]
     fn test_missing_parent_error_variant() {
         let err = EventValidationError::MissingParent;
-        assert_eq!(format!("{}", err), "Event references a non-existent parent");
+        assert_eq!(format!("{err}"), "Event references a non-existent parent");
     }
 
     /// Test that the new ZeroAmount error variant exists and is constructible.
@@ -904,7 +904,7 @@ mod tests {
     fn test_zero_amount_error_variant() {
         let err = EventValidationError::ZeroAmount;
         assert_eq!(
-            format!("{}", err),
+            format!("{err}"),
             "Event has obviously invalid data (zero amount)"
         );
     }
@@ -972,8 +972,7 @@ mod tests {
                 result,
                 Err(EventValidationError::CreatorPubkeyMismatch { .. })
             ),
-            "Expected CreatorPubkeyMismatch, got {:?}",
-            result
+            "Expected CreatorPubkeyMismatch, got {result:?}"
         );
     }
 
@@ -1029,8 +1028,7 @@ mod tests {
         let result = event.validate();
         assert!(
             result.is_ok(),
-            "Payload at exactly MAX_PAYLOAD_SIZE should accept, got {:?}",
-            result
+            "Payload at exactly MAX_PAYLOAD_SIZE should accept, got {result:?}"
         );
     }
 
@@ -1048,8 +1046,7 @@ mod tests {
         let result = event.validate();
         assert!(
             matches!(result, Err(EventValidationError::PayloadTooLarge { size, max }) if size == MAX_PAYLOAD_SIZE + 1 && max == MAX_PAYLOAD_SIZE),
-            "Expected PayloadTooLarge, got {:?}",
-            result
+            "Expected PayloadTooLarge, got {result:?}"
         );
     }
 
@@ -1060,7 +1057,7 @@ mod tests {
             claimed: "aa".to_string(),
             derived: "bb".to_string(),
         };
-        let msg = format!("{}", err);
+        let msg = format!("{err}");
         assert!(
             msg.contains("aa"),
             "Error message should contain claimed value"
@@ -1078,7 +1075,7 @@ mod tests {
             size: 2_000_000,
             max: MAX_PAYLOAD_SIZE,
         };
-        let msg = format!("{}", err);
+        let msg = format!("{err}");
         assert!(msg.contains("2000000"), "Error message should contain size");
         assert!(
             msg.contains(&MAX_PAYLOAD_SIZE.to_string()),

--- a/omnia-primitives/src/vector_clock.rs
+++ b/omnia-primitives/src/vector_clock.rs
@@ -390,7 +390,7 @@ mod tests {
         let n1 = nid(1);
         let mut vc = VectorClock::new();
         vc.set(n1, 5);
-        let s = format!("{}", vc);
+        let s = format!("{vc}");
         assert!(s.contains("01"));
         assert!(s.contains(":5"));
     }
@@ -521,9 +521,7 @@ mod tests {
         // The happened_before relationship must still hold after merge
         assert!(
             merged_a.happened_before(&merged_b),
-            "happened_before not preserved after merge: {:?} vs {:?}",
-            merged_a,
-            merged_b
+            "happened_before not preserved after merge: {merged_a:?} vs {merged_b:?}"
         );
     }
 

--- a/shards/src/computational/state.rs
+++ b/shards/src/computational/state.rs
@@ -66,8 +66,7 @@ impl ComputationalState {
             } => {
                 if self.tasks.contains_key(task_id) {
                     return Err(ShardError::StateConflict(format!(
-                        "Task already exists: {:?}",
-                        task_id
+                        "Task already exists: {task_id:?}"
                     )));
                 }
                 self.tasks.insert(

--- a/shards/src/computational/validator.rs
+++ b/shards/src/computational/validator.rs
@@ -17,8 +17,7 @@ impl ComputationalValidator {
             ComputationalOp::SubmitTask { task_id, .. } => {
                 if state.tasks.contains_key(task_id) {
                     return Err(ShardError::StateConflict(format!(
-                        "Task already exists: {:?}",
-                        task_id
+                        "Task already exists: {task_id:?}"
                     )));
                 }
                 Ok(())

--- a/shards/src/financial/validator.rs
+++ b/shards/src/financial/validator.rs
@@ -155,11 +155,10 @@ mod tests {
             Err(ShardError::ValidationFailed(msg)) => {
                 assert!(
                     msg.to_lowercase().contains("insufficient"),
-                    "Error should mention insufficient balance, got: {}",
-                    msg
+                    "Error should mention insufficient balance, got: {msg}"
                 );
             }
-            Err(other) => panic!("Expected ValidationFailed, got: {:?}", other),
+            Err(other) => panic!("Expected ValidationFailed, got: {other:?}"),
             Ok(()) => panic!("Second transfer should have failed"),
         }
 
@@ -194,11 +193,10 @@ mod tests {
             Err(ShardError::ValidationFailed(msg)) => {
                 assert!(
                     msg.to_lowercase().contains("insufficient"),
-                    "Error should mention insufficient balance, got: {}",
-                    msg
+                    "Error should mention insufficient balance, got: {msg}"
                 );
             }
-            Err(other) => panic!("Expected ValidationFailed, got: {:?}", other),
+            Err(other) => panic!("Expected ValidationFailed, got: {other:?}"),
             Ok(()) => panic!("Transfer should have failed"),
         }
 
@@ -241,8 +239,7 @@ mod tests {
         let result = state.apply(&mint_op, &event1);
         assert!(
             result.is_ok(),
-            "Replayed Mint should be handled gracefully (idempotent or rejected), got: {:?}",
-            result
+            "Replayed Mint should be handled gracefully (idempotent or rejected), got: {result:?}"
         );
 
         // Balance should be 100 (credited twice) — the state layer doesn't
@@ -274,11 +271,10 @@ mod tests {
                 assert!(
                     msg.to_lowercase().contains("zero")
                         || msg.to_lowercase().contains("greater than zero"),
-                    "Error should mention zero amount, got: {}",
-                    msg
+                    "Error should mention zero amount, got: {msg}"
                 );
             }
-            Err(other) => panic!("Expected InvalidOperation, got: {:?}", other),
+            Err(other) => panic!("Expected InvalidOperation, got: {other:?}"),
             Ok(()) => panic!("Zero-amount transfer should have been rejected"),
         }
     }
@@ -332,11 +328,10 @@ mod tests {
             Err(ShardError::ValidationFailed(msg)) => {
                 assert!(
                     msg.to_lowercase().contains("insufficient"),
-                    "Error should mention insufficient balance, got: {}",
-                    msg
+                    "Error should mention insufficient balance, got: {msg}"
                 );
             }
-            Err(other) => panic!("Expected ValidationFailed, got: {:?}", other),
+            Err(other) => panic!("Expected ValidationFailed, got: {other:?}"),
             Ok(()) => panic!("Burn should have been rejected"),
         }
 
@@ -432,11 +427,10 @@ mod tests {
             Err(ShardError::InvalidOperation(msg)) => {
                 assert!(
                     msg.to_lowercase().contains("greater than zero"),
-                    "Error should mention zero amount, got: {}",
-                    msg
+                    "Error should mention zero amount, got: {msg}"
                 );
             }
-            Err(other) => panic!("Expected InvalidOperation, got: {:?}", other),
+            Err(other) => panic!("Expected InvalidOperation, got: {other:?}"),
             Ok(()) => panic!("Zero-amount mint should have been rejected"),
         }
     }
@@ -458,11 +452,10 @@ mod tests {
             Err(ShardError::InvalidOperation(msg)) => {
                 assert!(
                     msg.to_lowercase().contains("greater than zero"),
-                    "Error should mention zero amount, got: {}",
-                    msg
+                    "Error should mention zero amount, got: {msg}"
                 );
             }
-            Err(other) => panic!("Expected InvalidOperation, got: {:?}", other),
+            Err(other) => panic!("Expected InvalidOperation, got: {other:?}"),
             Ok(()) => panic!("Zero-amount burn should have been rejected"),
         }
     }
@@ -492,11 +485,10 @@ mod tests {
             Err(ShardError::ValidationFailed(msg)) => {
                 assert!(
                     msg.to_lowercase().contains("not found"),
-                    "Error should mention account not found, got: {}",
-                    msg
+                    "Error should mention account not found, got: {msg}"
                 );
             }
-            Err(other) => panic!("Expected ValidationFailed, got: {:?}", other),
+            Err(other) => panic!("Expected ValidationFailed, got: {other:?}"),
             Ok(()) => panic!("Transfer from non-existent account should fail"),
         }
     }
@@ -535,11 +527,10 @@ mod tests {
             Err(ShardError::InvalidOperation(msg)) => {
                 assert!(
                     msg.contains("Financial"),
-                    "Error should mention Financial, got: {}",
-                    msg
+                    "Error should mention Financial, got: {msg}"
                 );
             }
-            Err(other) => panic!("Expected InvalidOperation, got: {:?}", other),
+            Err(other) => panic!("Expected InvalidOperation, got: {other:?}"),
             Ok(()) => panic!("Non-Financial ShardOp should have been rejected"),
         }
     }

--- a/shards/src/identity/state.rs
+++ b/shards/src/identity/state.rs
@@ -141,9 +141,10 @@ impl IdentityState {
                 Ok(())
             }
             IdentityOp::UpdateDid { did, updates } => {
-                let doc = self.dids.get_mut(did).ok_or_else(|| {
-                    ShardError::ValidationFailed(format!("DID not found: {}", did))
-                })?;
+                let doc = self
+                    .dids
+                    .get_mut(did)
+                    .ok_or_else(|| ShardError::ValidationFailed(format!("DID not found: {did}")))?;
 
                 for update in updates {
                     match update {
@@ -168,7 +169,7 @@ impl IdentityState {
             }
             IdentityOp::RecoverDid { did, shares } => {
                 let config = self.recovery_registry.get(did).ok_or_else(|| {
-                    ShardError::ValidationFailed(format!("No recovery config for DID: {}", did))
+                    ShardError::ValidationFailed(format!("No recovery config for DID: {did}"))
                 })?;
 
                 if shares.len() < config.threshold as usize {
@@ -179,7 +180,7 @@ impl IdentityState {
 
                 // Reconstruct the secret from the provided shares
                 let reconstructed = ShamirRecovery::reconstruct(shares).map_err(|e| {
-                    ShardError::ValidationFailed(format!("Recovery reconstruction failed: {}", e))
+                    ShardError::ValidationFailed(format!("Recovery reconstruction failed: {e}"))
                 })?;
 
                 // Derive a new Ed25519 public key from the reconstructed secret
@@ -195,8 +196,7 @@ impl IdentityState {
             IdentityOp::VerifyDid { did } => {
                 if !self.dids.contains_key(did) {
                     return Err(ShardError::ValidationFailed(format!(
-                        "DID not found: {}",
-                        did
+                        "DID not found: {did}"
                     )));
                 }
                 Ok(())
@@ -204,8 +204,7 @@ impl IdentityState {
             IdentityOp::AddAgent { did, agent } => {
                 if !self.dids.contains_key(did) {
                     return Err(ShardError::ValidationFailed(format!(
-                        "Owner DID not found: {}",
-                        did
+                        "Owner DID not found: {did}"
                     )));
                 }
                 if self.agent_registry.contains_key(&agent.did) {
@@ -224,8 +223,7 @@ impl IdentityState {
             } => {
                 if !self.dids.contains_key(did) {
                     return Err(ShardError::ValidationFailed(format!(
-                        "DID not found: {}",
-                        did
+                        "DID not found: {did}"
                     )));
                 }
                 let anchor = BiometricAnchor::enroll(template, algorithm);
@@ -234,7 +232,7 @@ impl IdentityState {
             }
             IdentityOp::VerifyBiometric { did, template } => {
                 let anchor = self.biometric_registry.get(did).ok_or_else(|| {
-                    ShardError::ValidationFailed(format!("No biometric enrolled for DID: {}", did))
+                    ShardError::ValidationFailed(format!("No biometric enrolled for DID: {did}"))
                 })?;
                 if !anchor.verify(template) {
                     return Err(ShardError::ValidationFailed(
@@ -245,7 +243,7 @@ impl IdentityState {
             }
             IdentityOp::RevokeAgent { agent_did } => {
                 let agent = self.agent_registry.get_mut(agent_did).ok_or_else(|| {
-                    ShardError::ValidationFailed(format!("Agent not found: {}", agent_did))
+                    ShardError::ValidationFailed(format!("Agent not found: {agent_did}"))
                 })?;
                 agent.revoke();
                 Ok(())
@@ -258,8 +256,7 @@ impl IdentityState {
             } => {
                 if !self.dids.contains_key(did) {
                     return Err(ShardError::ValidationFailed(format!(
-                        "DID not found: {}",
-                        did
+                        "DID not found: {did}"
                     )));
                 }
                 let shares = ShamirRecovery::split(secret, *threshold, *total_shares);
@@ -289,8 +286,7 @@ impl IdentityState {
     ) -> Result<(), ShardError> {
         if !self.dids.contains_key(did) {
             return Err(ShardError::ValidationFailed(format!(
-                "DID not found: {}",
-                did
+                "DID not found: {did}"
             )));
         }
         let anchor = BiometricAnchor::enroll(template, algorithm);
@@ -301,7 +297,7 @@ impl IdentityState {
     /// Verify a biometric template against the stored commitment.
     pub fn verify_biometric(&self, did: &str, fresh_template: &[u8]) -> Result<bool, ShardError> {
         let anchor = self.biometric_registry.get(did).ok_or_else(|| {
-            ShardError::ValidationFailed(format!("No biometric enrolled for DID: {}", did))
+            ShardError::ValidationFailed(format!("No biometric enrolled for DID: {did}"))
         })?;
         Ok(anchor.verify(fresh_template))
     }
@@ -316,8 +312,7 @@ impl IdentityState {
     ) -> Result<Vec<RecoveryShare>, ShardError> {
         if !self.dids.contains_key(did) {
             return Err(ShardError::ValidationFailed(format!(
-                "DID not found: {}",
-                did
+                "DID not found: {did}"
             )));
         }
         let shares = ShamirRecovery::split(secret, threshold, total);
@@ -334,7 +329,7 @@ impl IdentityState {
     /// Recover a DID secret using Shamir's Secret Sharing.
     pub fn recover_did(&self, did: &str, shares: &[RecoveryShare]) -> Result<Vec<u8>, ShardError> {
         let config = self.recovery_registry.get(did).ok_or_else(|| {
-            ShardError::ValidationFailed(format!("No recovery config for DID: {}", did))
+            ShardError::ValidationFailed(format!("No recovery config for DID: {did}"))
         })?;
         if shares.len() < config.threshold as usize {
             return Err(ShardError::ValidationFailed(format!(
@@ -344,7 +339,7 @@ impl IdentityState {
             )));
         }
         ShamirRecovery::reconstruct(shares).map_err(|e| {
-            ShardError::ValidationFailed(format!("Recovery reconstruction failed: {}", e))
+            ShardError::ValidationFailed(format!("Recovery reconstruction failed: {e}"))
         })
     }
 
@@ -363,7 +358,7 @@ impl IdentityState {
         let doc = self
             .dids
             .get_mut(did)
-            .ok_or_else(|| ShardError::ValidationFailed(format!("DID not found: {}", did)))?;
+            .ok_or_else(|| ShardError::ValidationFailed(format!("DID not found: {did}")))?;
 
         // Add the recovered key to authentication (rotation, not replacement)
         let key_array = *recovered_public_key;
@@ -448,7 +443,7 @@ impl IdentityState {
     /// - v2 (current): AES-256-GCM authenticated decryption
     pub fn decrypt_shares(&self, did: &str) -> Result<Vec<RecoveryShare>, ShardError> {
         let encrypted_shares = self.shares.get(did).ok_or_else(|| {
-            ShardError::ValidationFailed(format!("No encrypted shares for DID: {}", did))
+            ShardError::ValidationFailed(format!("No encrypted shares for DID: {did}"))
         })?;
 
         let mut decrypted = Vec::with_capacity(encrypted_shares.len());

--- a/shards/src/identity/validator.rs
+++ b/shards/src/identity/validator.rs
@@ -30,8 +30,7 @@ impl IdentityValidator {
             IdentityOp::UpdateDid { did, .. } => {
                 if !state.dids.contains_key(did) {
                     return Err(ShardError::ValidationFailed(format!(
-                        "DID not found: {}",
-                        did
+                        "DID not found: {did}"
                     )));
                 }
                 Ok(())
@@ -45,8 +44,7 @@ impl IdentityValidator {
                     }
                 } else {
                     return Err(ShardError::ValidationFailed(format!(
-                        "No recovery config for DID: {}",
-                        did
+                        "No recovery config for DID: {did}"
                     )));
                 }
                 Ok(())
@@ -54,8 +52,7 @@ impl IdentityValidator {
             IdentityOp::VerifyDid { did } => {
                 if !state.dids.contains_key(did) {
                     return Err(ShardError::ValidationFailed(format!(
-                        "DID not found: {}",
-                        did
+                        "DID not found: {did}"
                     )));
                 }
                 Ok(())
@@ -63,8 +60,7 @@ impl IdentityValidator {
             IdentityOp::AddAgent { did, agent } => {
                 if !state.dids.contains_key(did) {
                     return Err(ShardError::ValidationFailed(format!(
-                        "Owner DID not found: {}",
-                        did
+                        "Owner DID not found: {did}"
                     )));
                 }
                 if state.agent_registry.contains_key(&agent.did) {
@@ -78,8 +74,7 @@ impl IdentityValidator {
             IdentityOp::EnrollBiometric { did, .. } => {
                 if !state.dids.contains_key(did) {
                     return Err(ShardError::ValidationFailed(format!(
-                        "DID not found: {}",
-                        did
+                        "DID not found: {did}"
                     )));
                 }
                 Ok(())
@@ -87,8 +82,7 @@ impl IdentityValidator {
             IdentityOp::VerifyBiometric { did, .. } => {
                 if !state.biometric_registry.contains_key(did) {
                     return Err(ShardError::ValidationFailed(format!(
-                        "No biometric enrolled for DID: {}",
-                        did
+                        "No biometric enrolled for DID: {did}"
                     )));
                 }
                 Ok(())
@@ -96,8 +90,7 @@ impl IdentityValidator {
             IdentityOp::RevokeAgent { agent_did } => {
                 if !state.agent_registry.contains_key(agent_did) {
                     return Err(ShardError::ValidationFailed(format!(
-                        "Agent not found: {}",
-                        agent_did
+                        "Agent not found: {agent_did}"
                     )));
                 }
                 Ok(())
@@ -110,8 +103,7 @@ impl IdentityValidator {
             } => {
                 if !state.dids.contains_key(did) {
                     return Err(ShardError::ValidationFailed(format!(
-                        "DID not found: {}",
-                        did
+                        "DID not found: {did}"
                     )));
                 }
                 if *threshold < 2 {

--- a/shards/src/physical/state.rs
+++ b/shards/src/physical/state.rs
@@ -50,8 +50,7 @@ impl PhysicalState {
             } => {
                 if self.provenance.contains_key(item_id) {
                     return Err(ShardError::StateConflict(format!(
-                        "Item already anchored: {:?}",
-                        item_id
+                        "Item already anchored: {item_id:?}"
                     )));
                 }
                 self.provenance.insert(

--- a/shards/src/physical/validator.rs
+++ b/shards/src/physical/validator.rs
@@ -18,8 +18,7 @@ impl PhysicalValidator {
             PhysicalOp::AnchorItem { item_id, .. } => {
                 if state.provenance.contains_key(item_id) {
                     return Err(ShardError::StateConflict(format!(
-                        "Item already anchored: {:?}",
-                        item_id
+                        "Item already anchored: {item_id:?}"
                     )));
                 }
                 Ok(())

--- a/shards/src/router.rs
+++ b/shards/src/router.rs
@@ -154,7 +154,7 @@ impl ShardRouter {
         if let Some(shard) = self.shards.get_mut(&shard_id) {
             shard.process_event(event, op)
         } else {
-            Err(ShardError::UnknownShard(format!("{}", shard_id)))
+            Err(ShardError::UnknownShard(format!("{shard_id}")))
         }
     }
 
@@ -172,7 +172,7 @@ impl ShardRouter {
         if let Some(shard) = self.shards.get_mut(&target_id) {
             shard.process_event(event, inner_op)
         } else {
-            Err(ShardError::UnknownShard(format!("{}", target_id)))
+            Err(ShardError::UnknownShard(format!("{target_id}")))
         }
     }
 
@@ -214,7 +214,7 @@ impl ShardRouter {
         }
 
         let payload = ShardPayload::from_bytes(&event.payload)
-            .map_err(|e| ShardError::ValidationFailed(format!("Invalid payload: {}", e)))?;
+            .map_err(|e| ShardError::ValidationFailed(format!("Invalid payload: {e}")))?;
 
         // Replay protection — check nonce
         let creator = event.creator_pubkey;
@@ -243,7 +243,7 @@ impl ShardRouter {
                     error = %e,
                     "Fee deduction failed — insufficient quota"
                 );
-                ShardError::InsufficientFee(format!("Quota exceeded: {}", e))
+                ShardError::InsufficientFee(format!("Quota exceeded: {e}"))
             })?;
         }
 

--- a/shards/tests/fee_enforcement.rs
+++ b/shards/tests/fee_enforcement.rs
@@ -113,11 +113,10 @@ fn test_zero_quota_operations_fail() {
         ShardError::InsufficientFee(msg) => {
             assert!(
                 msg.contains("Quota exceeded"),
-                "Expected 'Quota exceeded' in error, got: {}",
-                msg
+                "Expected 'Quota exceeded' in error, got: {msg}"
             );
         }
-        other => panic!("Expected InsufficientFee, got: {:?}", other),
+        other => panic!("Expected InsufficientFee, got: {other:?}"),
     }
 }
 
@@ -181,7 +180,7 @@ fn test_partial_balance_some_succeed_then_fail() {
     );
     match result.unwrap_err() {
         ShardError::InsufficientFee(_) => {}
-        other => panic!("Expected InsufficientFee, got: {:?}", other),
+        other => panic!("Expected InsufficientFee, got: {other:?}"),
     }
 }
 
@@ -281,11 +280,10 @@ fn test_cross_shard_insufficient_balance() {
         ShardError::InsufficientFee(msg) => {
             assert!(
                 msg.contains("Quota exceeded"),
-                "Expected 'Quota exceeded', got: {}",
-                msg
+                "Expected 'Quota exceeded', got: {msg}"
             );
         }
-        other => panic!("Expected InsufficientFee, got: {:?}", other),
+        other => panic!("Expected InsufficientFee, got: {other:?}"),
     }
 }
 
@@ -351,9 +349,7 @@ fn test_identity_fee_is_lower_than_financial() {
 
     assert!(
         identity_fee < financial_fee,
-        "Identity fee ({}) should be less than financial fee ({})",
-        identity_fee,
-        financial_fee
+        "Identity fee ({identity_fee}) should be less than financial fee ({financial_fee})"
     );
 }
 
@@ -383,11 +379,10 @@ fn test_unregistered_did_fails_with_insufficient_fee() {
         ShardError::InsufficientFee(msg) => {
             assert!(
                 msg.contains("Quota exceeded"),
-                "Expected 'Quota exceeded', got: {}",
-                msg
+                "Expected 'Quota exceeded', got: {msg}"
             );
         }
-        other => panic!("Expected InsufficientFee, got: {:?}", other),
+        other => panic!("Expected InsufficientFee, got: {other:?}"),
     }
 }
 

--- a/shards/tests/financial_adversarial.rs
+++ b/shards/tests/financial_adversarial.rs
@@ -80,11 +80,10 @@ fn test_double_spend_attack() {
         ShardError::ValidationFailed(msg) => {
             assert!(
                 msg.contains("Insufficient balance"),
-                "expected 'Insufficient balance', got '{}'",
-                msg
+                "expected 'Insufficient balance', got '{msg}'"
             );
         }
-        other => panic!("expected ValidationFailed, got {:?}", other),
+        other => panic!("expected ValidationFailed, got {other:?}"),
     }
 
     // Verify balances unchanged after failed transfer
@@ -122,11 +121,10 @@ fn test_negative_balance_prevention() {
         ShardError::ValidationFailed(msg) => {
             assert!(
                 msg.contains("Insufficient balance"),
-                "expected 'Insufficient balance', got '{}'",
-                msg
+                "expected 'Insufficient balance', got '{msg}'"
             );
         }
-        other => panic!("expected ValidationFailed, got {:?}", other),
+        other => panic!("expected ValidationFailed, got {other:?}"),
     }
 
     // A's balance should be untouched
@@ -255,11 +253,10 @@ fn test_zero_amount_transfer_rejected() {
         ShardError::InvalidOperation(msg) => {
             assert!(
                 msg.contains("greater than zero"),
-                "expected 'greater than zero', got '{}'",
-                msg
+                "expected 'greater than zero', got '{msg}'"
             );
         }
-        other => panic!("expected InvalidOperation, got {:?}", other),
+        other => panic!("expected InvalidOperation, got {other:?}"),
     }
 }
 
@@ -281,11 +278,10 @@ fn test_zero_amount_mint_rejected() {
         ShardError::InvalidOperation(msg) => {
             assert!(
                 msg.contains("greater than zero"),
-                "expected 'greater than zero', got '{}'",
-                msg
+                "expected 'greater than zero', got '{msg}'"
             );
         }
-        other => panic!("expected InvalidOperation, got {:?}", other),
+        other => panic!("expected InvalidOperation, got {other:?}"),
     }
 }
 
@@ -311,11 +307,10 @@ fn test_zero_amount_burn_rejected() {
         ShardError::InvalidOperation(msg) => {
             assert!(
                 msg.contains("greater than zero"),
-                "expected 'greater than zero', got '{}'",
-                msg
+                "expected 'greater than zero', got '{msg}'"
             );
         }
-        other => panic!("expected InvalidOperation, got {:?}", other),
+        other => panic!("expected InvalidOperation, got {other:?}"),
     }
 }
 
@@ -352,11 +347,10 @@ fn test_burn_insufficient_balance() {
         ShardError::ValidationFailed(msg) => {
             assert!(
                 msg.contains("Insufficient balance"),
-                "expected 'Insufficient balance', got '{}'",
-                msg
+                "expected 'Insufficient balance', got '{msg}'"
             );
         }
-        other => panic!("expected ValidationFailed, got {:?}", other),
+        other => panic!("expected ValidationFailed, got {other:?}"),
     }
 
     // apply() should also catch it

--- a/substrate/src/genesis.rs
+++ b/substrate/src/genesis.rs
@@ -267,10 +267,10 @@ mod tests {
     fn test_validator(node_id: u64, stake: u64) -> ValidatorInfo {
         ValidatorInfo {
             node_id,
-            ed25519_public_key: format!("{:064x}", node_id),
-            dilithium_public_key: format!("{:0256x}", node_id),
+            ed25519_public_key: format!("{node_id:064x}"),
+            dilithium_public_key: format!("{node_id:0256x}"),
             initial_stake: stake,
-            network_address: format!("/ip4/127.0.0.{}/udp/4001/quic-v1", node_id),
+            network_address: format!("/ip4/127.0.0.{node_id}/udp/4001/quic-v1"),
         }
     }
 
@@ -320,7 +320,7 @@ mod tests {
         assert!(result.is_err());
         match result.unwrap_err() {
             GenesisError::InsufficientValidators(n) => assert_eq!(n, 2),
-            other => panic!("Expected InsufficientValidators, got: {:?}", other),
+            other => panic!("Expected InsufficientValidators, got: {other:?}"),
         }
     }
 
@@ -350,7 +350,7 @@ mod tests {
                     "error should mention the duplicate ID"
                 );
             }
-            other => panic!("Expected DuplicateNodeId, got: {:?}", other),
+            other => panic!("Expected DuplicateNodeId, got: {other:?}"),
         }
     }
 
@@ -426,7 +426,7 @@ mod tests {
         assert!(result.is_err());
         match result.unwrap_err() {
             GenesisError::ZeroStake(id) => assert_eq!(id, 2),
-            other => panic!("Expected ZeroStake, got: {:?}", other),
+            other => panic!("Expected ZeroStake, got: {other:?}"),
         }
     }
 }

--- a/substrate/src/snapshot.rs
+++ b/substrate/src/snapshot.rs
@@ -285,7 +285,7 @@ mod tests {
         if let Err(SnapshotError::IntegrityCheckFailed { .. }) = result {
             // expected
         } else {
-            panic!("expected IntegrityCheckFailed, got {:?}", result);
+            panic!("expected IntegrityCheckFailed, got {result:?}");
         }
     }
 

--- a/substrate/tests/gossip_libp2p.rs
+++ b/substrate/tests/gossip_libp2p.rs
@@ -62,7 +62,7 @@ impl TestNode {
                 data,
             })
             .await
-            .map_err(|e| format!("Failed to send publish command: {}", e))
+            .map_err(|e| format!("Failed to send publish command: {e}"))
     }
 
     /// Wait for a [`NetworkEvent::GossipReceived`] event containing the
@@ -208,9 +208,9 @@ async fn spawn_node(
     bootstrap_peers: Vec<(PeerId, Multiaddr)>,
 ) -> Result<TestNode, Box<dyn std::error::Error + Send + Sync>> {
     // Build the listen address for QUIC transport on localhost
-    let listen_addr: Multiaddr = format!("/ip4/127.0.0.1/udp/{}/quic-v1", port)
+    let listen_addr: Multiaddr = format!("/ip4/127.0.0.1/udp/{port}/quic-v1")
         .parse()
-        .map_err(|e| format!("Invalid listen address for port {}: {}", port, e))?;
+        .map_err(|e| format!("Invalid listen address for port {port}: {e}"))?;
 
     // Create OmniaNetwork — generates a fresh Ed25519 keypair internally
     let mut network = OmniaNetwork::new(listen_addr).await?;
@@ -221,7 +221,7 @@ async fn spawn_node(
     // the swarm starts polling and connections are established.
     network
         .subscribe("omnia_events")
-        .map_err(|e| format!("Subscribe failed: {:?}", e))?;
+        .map_err(|e| format!("Subscribe failed: {e:?}"))?;
 
     // Create command channel for external control of the network task
     let (cmd_tx, cmd_rx) = mpsc::channel(256);
@@ -239,7 +239,7 @@ async fn spawn_node(
     // the bootstrap peer may not be listening yet.
     for (pid, addr) in bootstrap_peers {
         if let Err(e) = network.dial(pid, addr) {
-            eprintln!("Warning: failed to dial bootstrap peer {}: {:?}", pid, e);
+            eprintln!("Warning: failed to dial bootstrap peer {pid}: {e:?}");
         }
     }
 
@@ -336,8 +336,7 @@ async fn event_propagation() -> Result<(), Box<dyn std::error::Error + Send + Sy
         .await;
     assert!(
         result_b.is_ok(),
-        "Node B should receive the event from A: {:?}",
-        result_b
+        "Node B should receive the event from A: {result_b:?}"
     );
 
     // Wait for C to receive the event (timeout 10s)
@@ -346,8 +345,7 @@ async fn event_propagation() -> Result<(), Box<dyn std::error::Error + Send + Sy
         .await;
     assert!(
         result_c.is_ok(),
-        "Node C should receive the event from A: {:?}",
-        result_c
+        "Node C should receive the event from A: {result_c:?}"
     );
 
     // Verify the event can be deserialized and its ID matches
@@ -409,8 +407,7 @@ async fn late_join_sync() -> Result<(), Box<dyn std::error::Error + Send + Sync>
         .await;
     assert!(
         result_b.is_ok(),
-        "Node B should receive the first event: {:?}",
-        result_b
+        "Node B should receive the first event: {result_b:?}"
     );
 
     // --- D joins the network ---
@@ -434,8 +431,7 @@ async fn late_join_sync() -> Result<(), Box<dyn std::error::Error + Send + Sync>
         .await;
     assert!(
         result_d.is_ok(),
-        "Node D (late joiner) should receive the event from A: {:?}",
-        result_d
+        "Node D (late joiner) should receive the event from A: {result_d:?}"
     );
 
     // Verify the event can be deserialized and matches
@@ -496,8 +492,7 @@ async fn multi_event_propagation() -> Result<(), Box<dyn std::error::Error + Sen
         .await;
     assert!(
         result1.is_ok(),
-        "Node B should receive event 1: {:?}",
-        result1
+        "Node B should receive event 1: {result1:?}"
     );
 
     let result2 = node_b
@@ -505,8 +500,7 @@ async fn multi_event_propagation() -> Result<(), Box<dyn std::error::Error + Sen
         .await;
     assert!(
         result2.is_ok(),
-        "Node B should receive event 2: {:?}",
-        result2
+        "Node B should receive event 2: {result2:?}"
     );
 
     let result3 = node_b
@@ -514,8 +508,7 @@ async fn multi_event_propagation() -> Result<(), Box<dyn std::error::Error + Sen
         .await;
     assert!(
         result3.is_ok(),
-        "Node B should receive event 3: {:?}",
-        result3
+        "Node B should receive event 3: {result3:?}"
     );
 
     // Verify all events deserialize correctly and have valid signatures

--- a/substrate/tests/gossip_simulation.rs
+++ b/substrate/tests/gossip_simulation.rs
@@ -110,11 +110,7 @@ async fn test_three_node_event_propagation() {
     for (i, node_arc) in network.nodes.iter().enumerate() {
         let node = node_arc.read().await;
         let graph = node.graph().await;
-        assert!(
-            graph.contains(&event_id),
-            "Node {} should have the event",
-            i
-        );
+        assert!(graph.contains(&event_id), "Node {i} should have the event");
     }
 }
 
@@ -315,20 +311,18 @@ fn test_crdt_100_percent_convergence() {
         alt2.merge(&c2);
         alt2.merge(&c1);
 
-        assert_eq!(merged.value(), expected, "Main merge failed for {}", desc);
-        assert_eq!(alt1.value(), expected, "Alt1 merge failed for {}", desc);
-        assert_eq!(alt2.value(), expected, "Alt2 merge failed for {}", desc);
+        assert_eq!(merged.value(), expected, "Main merge failed for {desc}");
+        assert_eq!(alt1.value(), expected, "Alt1 merge failed for {desc}");
+        assert_eq!(alt2.value(), expected, "Alt2 merge failed for {desc}");
         assert_eq!(
             merged.state_hash(),
             alt1.state_hash(),
-            "Hash mismatch for {}",
-            desc
+            "Hash mismatch for {desc}"
         );
         assert_eq!(
             alt1.state_hash(),
             alt2.state_hash(),
-            "Hash mismatch for {}",
-            desc
+            "Hash mismatch for {desc}"
         );
     }
 }
@@ -368,7 +362,7 @@ async fn test_network_event_processed_through_consensus() {
         let node = node_arc.read().await;
         let graph = node.graph().await;
         for id in &event_ids {
-            assert!(graph.contains(id), "Node {} missing event", i);
+            assert!(graph.contains(id), "Node {i} missing event");
         }
     }
 

--- a/substrate/tests/slashing_persistence.rs
+++ b/substrate/tests/slashing_persistence.rs
@@ -31,7 +31,7 @@ static DIR_COUNTER: AtomicU64 = AtomicU64::new(0);
 fn temp_dir(prefix: &str) -> PathBuf {
     let count = DIR_COUNTER.fetch_add(1, Ordering::Relaxed);
     let dir = tempfile::tempdir().expect("failed to create temp dir");
-    let path = dir.path().join(format!("{}-{}.redb", prefix, count));
+    let path = dir.path().join(format!("{prefix}-{count}.redb"));
     // Leak the TempDir so it is not cleaned up while the test uses it.
     // The OS will reclaim on process exit.
     std::mem::forget(dir);
@@ -113,7 +113,7 @@ fn test_corrupted_redb_data_starts_fresh() {
                     "Serialization error message should not be empty"
                 );
             }
-            other => panic!("Expected Serialization error, got: {:?}", other),
+            other => panic!("Expected Serialization error, got: {other:?}"),
         }
     }
 }


### PR DESCRIPTION
1. Fix ALL uninlined_format_args Clippy errors (128+ instances across 58 files)
   - Auto-fixed with cargo clippy --fix for inline format args
   - format!("{}", var) -> format!("{var}")
   - format!("{:?}", var) -> format!("{var:?}")
   - write!/writeln!/assert! macros also fixed

2. Fix needless_range_loop warnings in omnia-adapters/src/poseidon.rs
   - Added #[allow(clippy::needless_range_loop)] on matrix math functions
   - These loops use indices for both array access and error reporting

3. Fix deprecated omnia_substrate warnings in omnia-node
   - Added #![allow(deprecated)] to node/src/lib.rs (crate-level)
   - The node crate extensively uses Substrate runtime and types from
     the deprecated omnia-substrate crate

4. Fix cargo-udeps job: use nightly toolchain instead of 1.93.0 stable
   - cargo-udeps requires -Z binary-dep-depinfo which is nightly-only
   - Changed from toolchain 1.93.0 to nightly-2025-12-01

5. Fix unwrap_used in test code
- Added #[allow(clippy::unwrap_used)] to bench and test modules
   - node/src/pipeline.rs tests, benches/benches/hot_path_iai.rs

6. Remove unused import in node/src/http.rs (utoipa::OpenApi)

7. Remove continue-on-error from Cargo.lock verify step
   - Lockfile is now up-to-date, so this should be a hard gate

8. Run cargo fmt to fix formatting after clippy --fix changes