### PR TITLE
fix(ci): resolve unused imports, missing ApiDoc import, and broken doc links

### DIFF
--- a/node/src/http.rs
+++ b/node/src/http.rs
@@ -44,6 +44,8 @@ use prometheus::{Encoder, TextEncoder};
 use serde_json::json;
 #[cfg(feature = "swagger-ui")]
 use utoipa_swagger_ui::SwaggerUi;
+#[cfg(feature = "swagger-ui")]
+use crate::api::ApiDoc;
 
 use crate::api;
 use crate::api::auth::{self as api_auth, default_cors_layer, RateLimiter};

--- a/omnia-adapters/src/settlement/ethereum/live.rs
+++ b/omnia-adapters/src/settlement/ethereum/live.rs
@@ -19,7 +19,7 @@ use crate::settlement::{FinalityProof, SettlementAdapter, SettlementError, TxHas
 // ---------------------------------------------------------------------------
 
 #[cfg(feature = "ethereum-live")]
-use alloy::primitives::{Address, B256, U256};
+use alloy::primitives::{Address, B256};
 #[cfg(feature = "ethereum-live")]
 use alloy::providers::{Provider, ProviderBuilder};
 #[cfg(feature = "ethereum-live")]

--- a/omnia-consensus/src/consensus.rs
+++ b/omnia-consensus/src/consensus.rs
@@ -30,6 +30,7 @@ use omnia_primitives::{Event, EventId};
 use omnia_primitives::{NodeId, VectorClock};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
+#[cfg(feature = "persistent-storage")]
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use thiserror::Error;

--- a/omnia-consensus/src/slashing.rs
+++ b/omnia-consensus/src/slashing.rs
@@ -1350,7 +1350,7 @@ impl SlashingEngine {
 
     /// Export the current slashing state as a [`SlashingState`] snapshot.
     ///
-    /// Used by genesis replay (see [`crate::genesis_replay`]) to capture
+    /// Used by genesis replay to capture
     /// the final slashing state after replaying the event history.
     pub fn to_state(&self) -> SlashingState {
         let state = self.state.read().unwrap_or_else(|e| {
@@ -1937,7 +1937,7 @@ impl crate::SlashingBackend for SlashingEngine {
 /// Type alias for the default slashing backend.
 ///
 /// This wraps the existing [`SlashingEngine`] as the canonical
-/// implementation of [`SlashingBackend`]. Consumers that do not
+/// implementation of [`crate::SlashingBackend`]. Consumers that do not
 /// need a custom slashing backend can use this type directly.
 pub type DefaultSlashingBackend = SlashingEngine;
 


### PR DESCRIPTION
- Gate std::sync::Arc import with #[cfg(feature = "persistent-storage")]
  in consensus.rs to fix unused-import error on non-persistent builds
- Add #[cfg(feature = "swagger-ui")] use crate::api::ApiDoc import
  in node/src/http.rs to fix undeclared type error with --all-features
- Remove unused U256 from alloy imports in ethereum/live.rs
- Fix broken intra-doc link crate::genesis_replay (module doesn't exist)
  in slashing.rs by removing the link
- Fix broken intra-doc link SlashingBackend in slashing.rs by using
  crate::SlashingBackend (trait is defined in lib.rs)