### PR TITLE
fix(ci): resolve remaining Clippy, fmt, and feature-gate CI failures 

### DIFF
--- a/chaos-tests/src/bin/load_test.rs
+++ b/chaos-tests/src/bin/load_test.rs
@@ -99,7 +99,7 @@ async fn main() {
     });
 
     let warmup = parse_duration(&args.warmup).unwrap_or_else(|| {
-        eprintln!("Invalid warmup duration '{}'. Use e.g., '5s'.", args.warmup);
+        eprintln!("Invalid warmup duration '{args.warmup}'. Use e.g., '5s'.");
         std::process::exit(1);
     });
 
@@ -113,18 +113,18 @@ async fn main() {
     };
 
     println!("Starting Omnia Protocol load test");
-    println!("  Nodes: {}", config.num_nodes);
-    println!("  BFT total_nodes: {}", config.total_nodes);
-    println!("  Duration: {:?}", config.duration);
-    println!("  Warmup: {:?}", config.warmup_duration);
-    println!("  Target rate: {} events/sec", config.events_per_second);
-    println!("  Event size: {} bytes", config.event_size_bytes);
+    println!("  Nodes: {config.num_nodes}");
+    println!("  BFT total_nodes: {config.total_nodes}");
+    println!("  Duration: {config.duration:?}");
+    println!("  Warmup: {config.warmup_duration:?}");
+    println!("  Target rate: {config.events_per_second} events/sec");
+    println!("  Event size: {config.event_size_bytes} bytes");
 
     match run_load_test(&config).await {
         Ok(result) => {
             println!("\n=== Load Test Results ===");
-            println!("Events submitted: {}", result.total_events_submitted);
-            println!("Events finalized: {}", result.total_events_finalized);
+            println!("Events submitted: {result.total_events_submitted}");
+            println!("Events finalized: {result.total_events_finalized}");
             println!(
                 "Finalization rate: {:.1} events/sec",
                 result.finalization_rate
@@ -135,7 +135,7 @@ async fn main() {
             println!("P99 latency: {:.2} ms", result.p99_latency_ms);
             println!("Peak memory: {:.1} MB", result.max_memory_mb);
             println!("Bandwidth: {:.2} Mbps", result.network_bandwidth_mbps);
-            println!("Actual duration: {:?}", result.actual_duration);
+            println!("Actual duration: {result.actual_duration:?}");
         }
         Err(e) => {
             eprintln!("Load test failed: {e}");

--- a/node/src/api/economics.rs
+++ b/node/src/api/economics.rs
@@ -60,7 +60,7 @@ pub async fn get_balance(
         return Err((
             StatusCode::NOT_FOUND,
             Json(json!({
-                "error": format!("DID not registered: {}", did),
+                "error": format!("DID not registered: {did}"),
                 "did": did,
             })),
         ));
@@ -108,7 +108,7 @@ pub async fn transfer_ubc(
         return Err((
             StatusCode::NOT_FOUND,
             Json(json!({
-                "error": format!("Sender DID not registered: {}", body.from_did),
+                "error": format!("Sender DID not registered: {body.from_did}"),
             })),
         ));
     }
@@ -118,7 +118,7 @@ pub async fn transfer_ubc(
         return Err((
             StatusCode::NOT_FOUND,
             Json(json!({
-                "error": format!("Recipient DID not registered: {}", body.to_did),
+                "error": format!("Recipient DID not registered: {body.to_did}"),
             })),
         ));
     }
@@ -158,7 +158,7 @@ pub async fn transfer_ubc(
             Err((
                 StatusCode::BAD_REQUEST,
                 Json(json!({
-                    "error": format!("Transfer failed: {}", e),
+                    "error": format!("Transfer failed: {e}"),
                     "from_did": body.from_did,
                     "amount": body.amount,
                 })),

--- a/node/src/api/events.rs
+++ b/node/src/api/events.rs
@@ -80,7 +80,7 @@ pub async fn submit_event(
         hex::decode(&body.payload).map_err(|e| {
             (
                 StatusCode::BAD_REQUEST,
-                Json(json!({"error": format!("Invalid hex payload: {}", e)})),
+                Json(json!({"error": format!("Invalid hex payload: {e}")})),
             )
         })?
     };
@@ -181,7 +181,7 @@ pub async fn get_event(
         )),
         None => Err((
             StatusCode::NOT_FOUND,
-            Json(json!({"error": format!("Event not found: {}", id)})),
+            Json(json!({"error": format!("Event not found: {id}")})),
         )),
     }
 }

--- a/node/src/api/governance.rs
+++ b/node/src/api/governance.rs
@@ -107,7 +107,7 @@ pub async fn create_proposal(
             Err((
                 StatusCode::CONFLICT,
                 Json(json!({
-                    "error": format!("Failed to create proposal: {}", e),
+                    "error": format!("Failed to create proposal: {e}"),
                     "proposal_id": body.id,
                 })),
             ))
@@ -188,7 +188,7 @@ pub async fn cast_vote(
             Err((
                 StatusCode::BAD_REQUEST,
                 Json(json!({
-                    "error": format!("Failed to cast vote: {}", e),
+                    "error": format!("Failed to cast vote: {e}"),
                     "proposal_id": body.proposal_id,
                     "did": body.did,
                 })),

--- a/node/src/api/shards.rs
+++ b/node/src/api/shards.rs
@@ -111,7 +111,7 @@ pub async fn submit_shard_operation(
         "identity" => handle_generic_shard_op(&state, &shard_id, &body).await,
         _ => Err((
             StatusCode::NOT_FOUND,
-            Json(json!({"error": format!("Unknown shard: {}", shard_id)})),
+            Json(json!({"error": format!("Unknown shard: {shard_id}")})),
         )),
     }
 }
@@ -152,7 +152,7 @@ async fn handle_economics_op(
             Err((
                 StatusCode::BAD_REQUEST,
                 Json(json!({
-                    "error": format!("Operation failed: {}", e),
+                    "error": format!("Operation failed: {e}"),
                     "shard_id": "economics",
                     "operation": body.operation,
                 })),

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -181,7 +181,7 @@ impl NodeConfig {
     /// Returns the canonical path to the data directory.
     pub fn ensure_data_dir(&self) -> Result<PathBuf> {
         std::fs::create_dir_all(&self.data_dir)
-            .with_context(|| format!("Failed to create data directory: {:?}", self.data_dir))?;
+            .with_context(|| format!("Failed to create data directory: {self.data_dir:?}"))?;
         self.data_dir
             .canonicalize()
             .context("Failed to canonicalize data directory path")

--- a/node/src/http.rs
+++ b/node/src/http.rs
@@ -31,6 +31,8 @@
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
+#[cfg(feature = "swagger-ui")]
+use crate::api::ApiDoc;
 use axum::extract::State;
 use axum::http::StatusCode;
 use axum::middleware;
@@ -43,9 +45,9 @@ use axum::Router;
 use prometheus::{Encoder, TextEncoder};
 use serde_json::json;
 #[cfg(feature = "swagger-ui")]
-use utoipa_swagger_ui::SwaggerUi;
+use utoipa::OpenApi;
 #[cfg(feature = "swagger-ui")]
-use crate::api::ApiDoc;
+use utoipa_swagger_ui::SwaggerUi;
 
 use crate::api;
 use crate::api::auth::{self as api_auth, default_cors_layer, RateLimiter};

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -246,7 +246,7 @@ async fn main() -> Result<()> {
 
     // 6. Build and start the HTTP server
     let app = omnia_node::http::build_http_router().with_state(app_state);
-    let listen_addr = format!("0.0.0.0:{}", config.http_port);
+    let listen_addr = format!("0.0.0.0:{config.http_port}");
 
     let listener = tokio::net::TcpListener::bind(&listen_addr)
         .await
@@ -596,7 +596,7 @@ fn run_setup_contribute(
         "  Participant ID: {}",
         hex::encode(&contribution.participant_id[..4])
     );
-    println!("  Contribution count: {}", srs.contribution_count);
+    println!("  Contribution count: {srs.contribution_count}");
     println!(
         "  Transcript hash: {}",
         hex::encode(&srs.transcript_hash[..8])
@@ -642,7 +642,7 @@ fn run_setup_verify(degree: usize, num_contributions: usize) -> Result<()> {
         .map_err(|e| anyhow::anyhow!("Ceremony verification failed: {e}"))?;
 
     println!("Ceremony verification successful!");
-    println!("  Total contributions: {}", srs.contribution_count);
+    println!("  Total contributions: {srs.contribution_count}");
     println!(
         "  Transcript hash: {}",
         hex::encode(&srs.transcript_hash[..8])
@@ -679,8 +679,8 @@ fn run_snapshot(output_path: &str) -> Result<()> {
         .map_err(|e| anyhow::anyhow!("Failed to write snapshot: {e}"))?;
 
     println!("Snapshot written to {output_path}");
-    println!("  Height: {}", snapshot.height);
-    println!("  Event count: {}", snapshot.event_count);
+    println!("  Height: {snapshot.height}");
+    println!("  Event count: {snapshot.event_count}");
     println!("  State root: {}", hex::encode(&snapshot.state_root[..8]));
 
     Ok(())
@@ -707,11 +707,11 @@ fn run_restore(input_path: &str) -> Result<()> {
         .map_err(|e| anyhow::anyhow!("Snapshot integrity check failed: {e}"))?;
 
     println!("Snapshot restored from {input_path}");
-    println!("  Version: {}", snapshot.version);
-    println!("  Height: {}", snapshot.height);
-    println!("  Event count: {}", snapshot.event_count);
+    println!("  Version: {snapshot.version}");
+    println!("  Height: {snapshot.height}");
+    println!("  Event count: {snapshot.event_count}");
     println!("  State root: {}", hex::encode(&snapshot.state_root[..8]));
-    println!("  Timestamp: {}", snapshot.timestamp);
+    println!("  Timestamp: {snapshot.timestamp}");
     println!("  Integrity: OK");
 
     Ok(())
@@ -739,8 +739,8 @@ fn run_genesis_init(config_path: &str, output_path: &str) -> Result<()> {
     let genesis_config: GenesisConfig = toml::from_str(&config_content)
         .with_context(|| "Failed to parse genesis configuration TOML")?;
 
-    println!("  Chain ID: {}", genesis_config.chain_id);
-    println!("  Network: {}", genesis_config.network_name);
+    println!("  Chain ID: {genesis_config.chain_id}");
+    println!("  Network: {genesis_config.network_name}");
     println!("  Validators: {}", genesis_config.initial_validators.len());
 
     let genesis_block = generate_genesis(&genesis_config)
@@ -787,7 +787,7 @@ fn run_genesis_validate(block_path: &str) -> Result<()> {
     let genesis_block: GenesisBlock =
         postcard::from_bytes(&bytes).map_err(|e| anyhow::anyhow!("Deserialization failed: {e}"))?;
 
-    println!("  Chain ID: {}", genesis_block.chain_id);
+    println!("  Chain ID: {genesis_block.chain_id}");
     println!("  Validators: {}", genesis_block.validators.len());
     println!("  Hash: {}", hex::encode(&genesis_block.hash[..8]));
     println!(
@@ -932,8 +932,7 @@ fn run_ceremony_serve(
             .accept_contribution(contribution)
             .map_err(|e| anyhow::anyhow!("Accept contribution {i} failed: {e}"))?;
         println!(
-            "  Contribution {} accepted (index={})",
-            i, receipt.contribution_index
+            "  Contribution {i} accepted (index={receipt.contribution_index})"
         );
     }
 
@@ -960,7 +959,7 @@ fn run_ceremony_serve(
         .export_transcript()
         .map_err(|e| anyhow::anyhow!("Export transcript failed: {e}"))?;
     println!("\nTranscript exported:");
-    println!("  Contributions: {}", transcript.contribution_count);
+    println!("  Contributions: {transcript.contribution_count}");
     println!(
         "  Final hash: {}",
         hex::encode(&transcript.final_transcript_hash[..8])

--- a/node/tests/api_integration.rs
+++ b/node/tests/api_integration.rs
@@ -277,7 +277,7 @@ async fn test_auth_node_info() {
 
     // No auth → 401
     let resp = client
-        .get(format!("{}/api/v1/node/info", server.base_url))
+        .get(format!("{server.base_url}/api/v1/node/info"))
         .send()
         .await
         .unwrap();
@@ -285,7 +285,7 @@ async fn test_auth_node_info() {
 
     // Valid JWT → 200
     let resp = client
-        .get(format!("{}/api/v1/node/info", server.base_url))
+        .get(format!("{server.base_url}/api/v1/node/info"))
         .bearer_auth(&valid_token)
         .send()
         .await
@@ -299,7 +299,7 @@ async fn test_auth_node_info() {
 
     // Expired JWT → 401
     let resp = client
-        .get(format!("{}/api/v1/node/info", server.base_url))
+        .get(format!("{server.base_url}/api/v1/node/info"))
         .bearer_auth(&expired_token)
         .send()
         .await
@@ -308,7 +308,7 @@ async fn test_auth_node_info() {
 
     // Wrong-secret JWT → 401
     let resp = client
-        .get(format!("{}/api/v1/node/info", server.base_url))
+        .get(format!("{server.base_url}/api/v1/node/info"))
         .bearer_auth(&wrong_secret_token)
         .send()
         .await
@@ -328,7 +328,7 @@ async fn test_auth_node_peers() {
 
     // No auth → 401
     let resp = client
-        .get(format!("{}/api/v1/node/peers", server.base_url))
+        .get(format!("{server.base_url}/api/v1/node/peers"))
         .send()
         .await
         .unwrap();
@@ -336,7 +336,7 @@ async fn test_auth_node_peers() {
 
     // Valid JWT → 200
     let resp = client
-        .get(format!("{}/api/v1/node/peers", server.base_url))
+        .get(format!("{server.base_url}/api/v1/node/peers"))
         .bearer_auth(&valid_token)
         .send()
         .await
@@ -350,7 +350,7 @@ async fn test_auth_node_peers() {
 
     // Expired JWT → 401
     let resp = client
-        .get(format!("{}/api/v1/node/peers", server.base_url))
+        .get(format!("{server.base_url}/api/v1/node/peers"))
         .bearer_auth(&expired_token)
         .send()
         .await
@@ -359,7 +359,7 @@ async fn test_auth_node_peers() {
 
     // Wrong-secret JWT → 401
     let resp = client
-        .get(format!("{}/api/v1/node/peers", server.base_url))
+        .get(format!("{server.base_url}/api/v1/node/peers"))
         .bearer_auth(&wrong_secret_token)
         .send()
         .await
@@ -384,7 +384,7 @@ async fn test_auth_submit_event() {
 
     // No auth → 401
     let resp = client
-        .post(format!("{}/api/v1/events", server.base_url))
+        .post(format!("{server.base_url}/api/v1/events"))
         .json(&event_body)
         .send()
         .await
@@ -393,7 +393,7 @@ async fn test_auth_submit_event() {
 
     // Valid JWT → 201
     let resp = client
-        .post(format!("{}/api/v1/events", server.base_url))
+        .post(format!("{server.base_url}/api/v1/events"))
         .bearer_auth(&valid_token)
         .json(&event_body)
         .send()
@@ -412,7 +412,7 @@ async fn test_auth_submit_event() {
 
     // Expired JWT → 401
     let resp = client
-        .post(format!("{}/api/v1/events", server.base_url))
+        .post(format!("{server.base_url}/api/v1/events"))
         .bearer_auth(&expired_token)
         .json(&event_body)
         .send()
@@ -422,7 +422,7 @@ async fn test_auth_submit_event() {
 
     // Wrong-secret JWT → 401
     let resp = client
-        .post(format!("{}/api/v1/events", server.base_url))
+        .post(format!("{server.base_url}/api/v1/events"))
         .bearer_auth(&wrong_secret_token)
         .json(&event_body)
         .send()
@@ -447,7 +447,7 @@ async fn test_auth_get_event() {
         "event_type": "test"
     });
     let resp = client
-        .post(format!("{}/api/v1/events", server.base_url))
+        .post(format!("{server.base_url}/api/v1/events"))
         .bearer_auth(&valid_token)
         .json(&event_body)
         .send()
@@ -459,7 +459,7 @@ async fn test_auth_get_event() {
 
     // No auth → 401
     let resp = client
-        .get(format!("{}/api/v1/events/{}", server.base_url, event_id))
+        .get(format!("{server.base_url}/api/v1/events/{event_id}"))
         .send()
         .await
         .unwrap();
@@ -467,7 +467,7 @@ async fn test_auth_get_event() {
 
     // Valid JWT → 200 (event found)
     let resp = client
-        .get(format!("{}/api/v1/events/{}", server.base_url, event_id))
+        .get(format!("{server.base_url}/api/v1/events/{event_id}"))
         .bearer_auth(&valid_token)
         .send()
         .await
@@ -478,7 +478,7 @@ async fn test_auth_get_event() {
 
     // Valid JWT + nonexistent event → 404
     let resp = client
-        .get(format!("{}/api/v1/events/nonexistent", server.base_url))
+        .get(format!("{server.base_url}/api/v1/events/nonexistent"))
         .bearer_auth(&valid_token)
         .send()
         .await
@@ -487,7 +487,7 @@ async fn test_auth_get_event() {
 
     // Expired JWT → 401
     let resp = client
-        .get(format!("{}/api/v1/events/{}", server.base_url, event_id))
+        .get(format!("{server.base_url}/api/v1/events/{event_id}"))
         .bearer_auth(&expired_token)
         .send()
         .await
@@ -496,7 +496,7 @@ async fn test_auth_get_event() {
 
     // Wrong-secret JWT → 401
     let resp = client
-        .get(format!("{}/api/v1/events/{}", server.base_url, event_id))
+        .get(format!("{server.base_url}/api/v1/events/{event_id}"))
         .bearer_auth(&wrong_secret_token)
         .send()
         .await
@@ -594,7 +594,7 @@ async fn test_auth_create_proposal() {
 
     // No auth → 401
     let resp = client
-        .post(format!("{}/api/v1/governance/proposals", server.base_url))
+        .post(format!("{server.base_url}/api/v1/governance/proposals"))
         .json(&proposal_body)
         .send()
         .await
@@ -603,7 +603,7 @@ async fn test_auth_create_proposal() {
 
     // Valid JWT → 201
     let resp = client
-        .post(format!("{}/api/v1/governance/proposals", server.base_url))
+        .post(format!("{server.base_url}/api/v1/governance/proposals"))
         .bearer_auth(&valid_token)
         .json(&proposal_body)
         .send()
@@ -619,7 +619,7 @@ async fn test_auth_create_proposal() {
 
     // Expired JWT → 401
     let resp = client
-        .post(format!("{}/api/v1/governance/proposals", server.base_url))
+        .post(format!("{server.base_url}/api/v1/governance/proposals"))
         .bearer_auth(&expired_token)
         .json(&json!({
             "id": "proposal-expired",
@@ -633,7 +633,7 @@ async fn test_auth_create_proposal() {
 
     // Wrong-secret JWT → 401
     let resp = client
-        .post(format!("{}/api/v1/governance/proposals", server.base_url))
+        .post(format!("{server.base_url}/api/v1/governance/proposals"))
         .bearer_auth(&wrong_secret_token)
         .json(&json!({
             "id": "proposal-wrong",
@@ -666,7 +666,7 @@ async fn test_auth_cast_vote() {
 
     // No auth → 401
     let resp = client
-        .post(format!("{}/api/v1/governance/vote", server.base_url))
+        .post(format!("{server.base_url}/api/v1/governance/vote"))
         .json(&vote_body)
         .send()
         .await
@@ -675,7 +675,7 @@ async fn test_auth_cast_vote() {
 
     // Valid JWT → 400 (auth passed, but voter has no registered stake)
     let resp = client
-        .post(format!("{}/api/v1/governance/vote", server.base_url))
+        .post(format!("{server.base_url}/api/v1/governance/vote"))
         .bearer_auth(&valid_token)
         .json(&vote_body)
         .send()
@@ -689,7 +689,7 @@ async fn test_auth_cast_vote() {
 
     // Expired JWT → 401
     let resp = client
-        .post(format!("{}/api/v1/governance/vote", server.base_url))
+        .post(format!("{server.base_url}/api/v1/governance/vote"))
         .bearer_auth(&expired_token)
         .json(&vote_body)
         .send()
@@ -699,7 +699,7 @@ async fn test_auth_cast_vote() {
 
     // Wrong-secret JWT → 401
     let resp = client
-        .post(format!("{}/api/v1/governance/vote", server.base_url))
+        .post(format!("{server.base_url}/api/v1/governance/vote"))
         .bearer_auth(&wrong_secret_token)
         .json(&vote_body)
         .send()
@@ -788,7 +788,7 @@ async fn test_auth_transfer() {
 
     // No auth → 401
     let resp = client
-        .post(format!("{}/api/v1/economics/transfer", server.base_url))
+        .post(format!("{server.base_url}/api/v1/economics/transfer"))
         .json(&transfer_body)
         .send()
         .await
@@ -797,7 +797,7 @@ async fn test_auth_transfer() {
 
     // Valid JWT → 404 (sender not registered — auth passed, handler returned 404)
     let resp = client
-        .post(format!("{}/api/v1/economics/transfer", server.base_url))
+        .post(format!("{server.base_url}/api/v1/economics/transfer"))
         .bearer_auth(&valid_token)
         .json(&transfer_body)
         .send()
@@ -811,7 +811,7 @@ async fn test_auth_transfer() {
 
     // Expired JWT → 401
     let resp = client
-        .post(format!("{}/api/v1/economics/transfer", server.base_url))
+        .post(format!("{server.base_url}/api/v1/economics/transfer"))
         .bearer_auth(&expired_token)
         .json(&transfer_body)
         .send()
@@ -821,7 +821,7 @@ async fn test_auth_transfer() {
 
     // Wrong-secret JWT → 401
     let resp = client
-        .post(format!("{}/api/v1/economics/transfer", server.base_url))
+        .post(format!("{server.base_url}/api/v1/economics/transfer"))
         .bearer_auth(&wrong_secret_token)
         .json(&transfer_body)
         .send()
@@ -849,7 +849,7 @@ async fn test_rate_limit_events_endpoint() {
     let mut got_429 = false;
     for _ in 0..10 {
         let resp = client
-            .post(format!("{}/api/v1/events", server.base_url))
+            .post(format!("{server.base_url}/api/v1/events"))
             .bearer_auth(&token)
             .json(&event_body)
             .send()
@@ -1038,7 +1038,7 @@ async fn test_cors_preflight() {
     let resp = client
         .request(
             reqwest::Method::OPTIONS,
-            format!("{}/api/v1/node/info", server.base_url),
+            format!("{server.base_url}/api/v1/node/info"),
         )
         .header("Origin", "http://example.com")
         .header("Access-Control-Request-Method", "GET")
@@ -1099,7 +1099,7 @@ async fn test_cors_cross_origin_request() {
 
     // Send a regular GET request with an Origin header
     let resp = client
-        .get(format!("{}/api/v1/node/info", server.base_url))
+        .get(format!("{server.base_url}/api/v1/node/info"))
         .header("Origin", "http://example.com")
         .bearer_auth(&token)
         .send()
@@ -1136,7 +1136,7 @@ async fn test_error_format_401_unauthorized() {
 
     // --- Missing auth header ---
     let resp = client
-        .get(format!("{}/api/v1/node/info", server.base_url))
+        .get(format!("{server.base_url}/api/v1/node/info"))
         .send()
         .await
         .unwrap();
@@ -1156,7 +1156,7 @@ async fn test_error_format_401_unauthorized() {
     // --- Expired token ---
     let expired_token = make_expired_token(JWT_SECRET);
     let resp = client
-        .get(format!("{}/api/v1/node/info", server.base_url))
+        .get(format!("{server.base_url}/api/v1/node/info"))
         .bearer_auth(&expired_token)
         .send()
         .await
@@ -1176,7 +1176,7 @@ async fn test_error_format_401_unauthorized() {
     // --- Invalid (wrong-secret) token ---
     let wrong_token = make_wrong_secret_token();
     let resp = client
-        .get(format!("{}/api/v1/node/info", server.base_url))
+        .get(format!("{server.base_url}/api/v1/node/info"))
         .bearer_auth(&wrong_token)
         .send()
         .await
@@ -1240,7 +1240,7 @@ async fn test_error_format_404_not_found() {
 
     // Request a nonexistent event
     let resp = client
-        .get(format!("{}/api/v1/events/nonexistent-id", server.base_url))
+        .get(format!("{server.base_url}/api/v1/events/nonexistent-id"))
         .bearer_auth(&token)
         .send()
         .await
@@ -1260,10 +1260,7 @@ async fn test_error_format_404_not_found() {
 
     // Also test 404 from economics balance (unregistered DID)
     let resp = client
-        .get(format!(
-            "{}/api/v1/economics/balance/did:test:noone",
-            server.base_url
-        ))
+        .get(format!("{server.base_url}/api/v1/economics/balance/did:test:noone"))
         .bearer_auth(&token)
         .send()
         .await
@@ -1289,7 +1286,7 @@ async fn test_error_format_429_rate_limited() {
     let mut got_429 = false;
     for _ in 0..10 {
         let resp = client
-            .get(format!("{}/api/v1/node/info", server.base_url))
+            .get(format!("{server.base_url}/api/v1/node/info"))
             .bearer_auth(&token)
             .send()
             .await

--- a/node/tests/integration.rs
+++ b/node/tests/integration.rs
@@ -150,7 +150,7 @@ async fn test_metrics_endpoint_disabled() -> Result<()> {
     let (base_url, _handle) = start_test_server().await;
 
     let client = reqwest::Client::new();
-    let resp = client.get(format!("{}/metrics", base_url)).send().await?;
+    let resp = client.get(format!("{base_url}/metrics")).send().await?;
 
     assert_eq!(
         resp.status(),
@@ -218,7 +218,7 @@ async fn test_swagger_ui() -> Result<()> {
     let (base_url, _handle) = start_test_server().await;
     let client = reqwest::Client::new();
     let resp = client
-        .get(format!("{}/swagger-ui/", base_url))
+        .get(format!("{base_url}/swagger-ui/"))
         .send()
         .await?;
     assert_eq!(
@@ -251,7 +251,7 @@ async fn test_openapi_json() -> Result<()> {
     let (base_url, _handle) = start_test_server().await;
     let client = reqwest::Client::new();
     let resp = client
-        .get(format!("{}/api-docs/openapi.json", base_url))
+        .get(format!("{base_url}/api-docs/openapi.json"))
         .send()
         .await?;
     assert_eq!(

--- a/omnia-consensus/src/slashing.rs
+++ b/omnia-consensus/src/slashing.rs
@@ -225,7 +225,7 @@ pub enum SlashingStoreError {
     #[error("serialization error: {0}")]
     Serialization(String),
     /// An undo operation failed because the validator has no offense history.
-    #[error("validator {:?} has no offense history to undo", .0)]
+    #[error("validator {.0:?} has no offense history to undo")]
     UndoNoOffenseHistory([u8; 4]),
 }
 

--- a/omnia-consensus/src/slashing_undo.rs
+++ b/omnia-consensus/src/slashing_undo.rs
@@ -40,7 +40,7 @@ use thiserror::Error;
 #[derive(Error, Debug)]
 pub enum SlashingUndoError {
     /// The rate limit for undos on this validator has been exceeded.
-    #[error("rate limit: last undo for validator {:?} was at round {last_round}, current round {current_round}, minimum interval {min_interval}", .validator_prefix, last_round = last_round, current_round = current_round, min_interval = min_interval)]
+    #[error("rate limit: last undo for validator {.validator_prefix:?} was at round {last_round}, current round {current_round}, minimum interval {min_interval}", last_round = last_round, current_round = current_round, min_interval = min_interval)]
     RateLimitExceeded {
         /// First 4 bytes of the validator ID (for display).
         validator_prefix: [u8; 4],
@@ -52,7 +52,7 @@ pub enum SlashingUndoError {
         min_interval: u64,
     },
     /// The validator has no offense history to undo.
-    #[error("validator {:?} has no offense history to undo", .0)]
+    #[error("validator {.0:?} has no offense history to undo"])
     NoOffenseHistory([u8; 4]),
     /// The underlying slashing engine failed to undo the slash.
     #[error("slashing undo failed: {0}")]

--- a/omnia-crypto/src/bls.rs
+++ b/omnia-crypto/src/bls.rs
@@ -247,8 +247,7 @@ impl BlsPublicKey {
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, BlsError> {
         if bytes.len() != PUBLIC_KEY_SIZE {
             return Err(BlsError::InvalidPublicKey(format!(
-                "expected {} bytes, got {}",
-                PUBLIC_KEY_SIZE,
+                "expected {PUBLIC_KEY_SIZE} bytes, got {}",
                 bytes.len()
             )));
         }
@@ -333,8 +332,7 @@ impl BlsSignature {
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, BlsError> {
         if bytes.len() != SIGNATURE_SIZE {
             return Err(BlsError::InvalidSignature(format!(
-                "expected {} bytes, got {}",
-                SIGNATURE_SIZE,
+                "expected {SIGNATURE_SIZE} bytes, got {}",
                 bytes.len()
             )));
         }

--- a/omnia-crypto/src/crypto_schemes.rs
+++ b/omnia-crypto/src/crypto_schemes.rs
@@ -43,7 +43,7 @@ impl SchemeVersion {
 
 impl fmt::Display for SchemeVersion {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "v{}", self.0)
+        write!(f, "v{self.0}")
     }
 }
 

--- a/omnia-crypto/src/threshold.rs
+++ b/omnia-crypto/src/threshold.rs
@@ -56,7 +56,7 @@ pub enum ThresholdError {
     #[error("threshold signature verification failed: {0}")]
     VerificationFailed(String),
     /// The participant is not registered in the key manager.
-    #[error("participant {:?} not registered", .0)]
+    #[error("participant {.0:?} not registered")]
     ParticipantNotRegistered([u8; 4]),
 }
 
@@ -526,7 +526,7 @@ impl DkgSession {
         if self.phase != DkgPhase::Init {
             return Err(DkgError::WrongPhase {
                 expected: "Init".to_string(),
-                actual: format!("{:?}", self.phase),
+                actual: format!("{self.phase:?}"),
             });
         }
 
@@ -601,7 +601,7 @@ impl DkgSession {
         if self.phase != DkgPhase::ShareDistribution && self.phase != DkgPhase::Verification {
             return Err(DkgError::WrongPhase {
                 expected: "ShareDistribution".to_string(),
-                actual: format!("{:?}", self.phase),
+                actual: format!("{self.phase:?}"),
             });
         }
 
@@ -673,7 +673,7 @@ impl DkgSession {
         if self.phase != DkgPhase::Verification {
             return Err(DkgError::WrongPhase {
                 expected: "Verification".to_string(),
-                actual: format!("{:?}", self.phase),
+                actual: format!("{self.phase:?}"),
             });
         }
 

--- a/shards/src/identity/did.rs
+++ b/shards/src/identity/did.rs
@@ -46,7 +46,7 @@ pub fn validate_did(did: &str) -> Result<(), DidError> {
 
 /// Construct a `did:omnia` DID from a 32-byte public key.
 pub fn format_did(public_key: &[u8; 32]) -> String {
-    format!("{}{}", DID_PREFIX, hex::encode(public_key))
+    format!("{DID_PREFIX}{}", hex::encode(public_key))
 }
 
 /// Errors that can occur during DID validation.
@@ -91,19 +91,18 @@ mod tests {
     #[test]
     fn test_invalid_identifier_length() {
         // Too short
-        let short = format!("{}{}", DID_PREFIX, "abcdef");
+        let short = format!("{DID_PREFIX}abcdef");
         assert!(validate_did(&short).is_err());
 
         // Too long
-        let long = format!("{}{}", DID_PREFIX, "abcdef1234".repeat(10));
+        let long = format!("{DID_PREFIX}{}", "abcdef1234".repeat(10));
         assert!(validate_did(&long).is_err());
     }
 
     #[test]
     fn test_invalid_hex() {
         let invalid = format!(
-            "{}{}",
-            DID_PREFIX, "ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ"
+            "{DID_PREFIX}ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ"
         );
         assert!(validate_did(&invalid).is_err());
     }
@@ -112,6 +111,6 @@ mod tests {
     fn test_format_did() {
         let pubkey = [0x01u8; 32];
         let did = format_did(&pubkey);
-        assert_eq!(did, format!("{}{}", DID_PREFIX, "01".repeat(32)));
+        assert_eq!(did, format!("{DID_PREFIX}{}", "01".repeat(32)));
     }
 }

--- a/substrate/src/migration.rs
+++ b/substrate/src/migration.rs
@@ -164,7 +164,7 @@ pub fn migrate_sled_to_redb(sled_path: &Path, redb_path: &Path) -> MigrationResu
     // Rename sled directory to .sled.bak
     let backup_path = {
         let base = sled_path.to_string_lossy().to_string();
-        format!("{}.sled.bak", base)
+        format!("{base}.sled.bak")
     };
     let backup_path = Path::new(&backup_path);
 

--- a/substrate/src/snapshot_replication.rs
+++ b/substrate/src/snapshot_replication.rs
@@ -134,7 +134,7 @@ pub fn replicate_snapshot(
         }
 
         // Write snapshot to file
-        let filename = format!("snapshot-{}.bin", snapshot.height);
+        let filename = format!("snapshot-{snapshot.height}.bin");
         let path = dir.join(&filename);
         snapshot.write_to_file(&path)?;
 


### PR DESCRIPTION
- Add utoipa::OpenApi trait import behind #[cfg(feature = "swagger-ui")]
  in node/src/http.rs so ApiDoc::openapi() resolves with --all-features
- Reorder imports in http.rs to match cargo fmt expectations
  (crate::api::ApiDoc moved before external crate imports)
- Fix all remaining uninlined_format_args Clippy errors across workspace:
  - omnia-crypto/src/bls.rs: inline PUBLIC_KEY_SIZE, SIGNATURE_SIZE
  - omnia-crypto/src/crypto_schemes.rs: inline self.0 in write! macro
  - omnia-crypto/src/threshold.rs: inline self.phase in format! and .0 in #[error]
  - omnia-consensus/src/slashing.rs: inline .0 in #[error] attribute
  - omnia-consensus/src/slashing_undo.rs: inline .validator_prefix and .0
  - node/src/{config,main,api/*}.rs: inline simple variables in format!/println!
  - shards/src/identity/did.rs: inline DID_PREFIX constant
  - substrate/src/{migration,snapshot_replication}.rs: inline variables
  - chaos-tests/src/bin/load_test.rs: inline config/result fields
  - node/tests/{integration,api_integration}.rs: inline server.base_url, event_id