### PR TITLE
fix: allow release-please to use PAT for credentials

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,7 +21,12 @@ jobs:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Use RELEASE_PLEASE_TOKEN secret if available, otherwise fall back to GITHUB_TOKEN.
+          # The default GITHUB_TOKEN may lack permission to fetch merge commits
+          # and create release PRs depending on repository settings.
+          # To fix "Bad credentials" errors, create a PAT with repo scope and
+          # add it as the RELEASE_PLEASE_TOKEN repository secret.
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 

--- a/omnia-adapters/Cargo.toml
+++ b/omnia-adapters/Cargo.toml
@@ -8,6 +8,11 @@ license = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+# Declare cfg values emitted by build.rs so the compiler knows they are valid
+# and doesn't emit "unexpected cfg" warnings.
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(has_settlement_lib)", "cfg(rustc_version_compatible)"] }
+
 [dependencies]
 omnia-primitives = { path = "../omnia-primitives" }
 omnia-crypto = { path = "../omnia-crypto" }

--- a/omnia-adapters/build.rs
+++ b/omnia-adapters/build.rs
@@ -46,9 +46,7 @@ fn main() {
     // compile (for documentation and type-checking), but the `extern "C"`
     // block and `FfiSettlementAdapter` impl that reference the FFI
     // symbols require `has_settlement_lib` as well.
-    if std::path::Path::new("lib/libsettlement.a").exists()
-        || std::path::Path::new("lib/settlement.lib").exists()
-    {
+    if std::path::Path::new("lib/libsettlement.a").exists() || std::path::Path::new("lib/settlement.lib").exists() {
         println!("cargo:rustc-cfg=has_settlement_lib");
         println!("cargo:rustc-cfg=feature=\"settlement-ffi\"");
         println!("cargo:rustc-link-search=native=lib");

--- a/omnia-adapters/build.rs
+++ b/omnia-adapters/build.rs
@@ -34,8 +34,22 @@ fn main() {
         println!("cargo:rustc-env=OMNIA_RUSTC_VERSION={version}");
     }
 
-    // Enable FFI if pre-compiled library exists
-    if std::path::Path::new("lib/libsettlement.a").exists() {
+    // Enable FFI linking if pre-compiled library exists.
+    //
+    // We emit a custom cfg `has_settlement_lib` that the FFI code uses
+    // in addition to the `settlement-ffi` Cargo feature. This two-gate
+    // approach prevents linker errors when `--all-features` enables
+    // `settlement-ffi` but `libsettlement.a` is not present (e.g., on
+    // CI runners without the pre-compiled C library).
+    //
+    // The `settlement-ffi` feature alone allows the C ABI types to
+    // compile (for documentation and type-checking), but the `extern "C"`
+    // block and `FfiSettlementAdapter` impl that reference the FFI
+    // symbols require `has_settlement_lib` as well.
+    if std::path::Path::new("lib/libsettlement.a").exists()
+        || std::path::Path::new("lib/settlement.lib").exists()
+    {
+        println!("cargo:rustc-cfg=has_settlement_lib");
         println!("cargo:rustc-cfg=feature=\"settlement-ffi\"");
         println!("cargo:rustc-link-search=native=lib");
         println!("cargo:rustc-link-lib=static=settlement");
@@ -44,4 +58,5 @@ fn main() {
     // Ensure build script re-runs on changes
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=lib/libsettlement.a");
+    println!("cargo:rerun-if-changed=lib/settlement.lib");
 }

--- a/omnia-adapters/src/lib.rs
+++ b/omnia-adapters/src/lib.rs
@@ -92,8 +92,9 @@ pub use settlement::{
 #[cfg(feature = "ethereum-live")]
 pub use settlement::EthereumSettlementAdapter;
 
-// Conditionally re-export FFI adapter
-#[cfg(feature = "settlement-ffi")]
+// Conditionally re-export FFI adapter (requires both the feature flag
+// and the pre-compiled C library to be present at build time).
+#[cfg(all(feature = "settlement-ffi", has_settlement_lib))]
 pub use settlement::FfiSettlementAdapter;
 
 // ---------------------------------------------------------------------------

--- a/omnia-adapters/src/settlement/ffi.rs
+++ b/omnia-adapters/src/settlement/ffi.rs
@@ -7,9 +7,23 @@
 //!
 //! ## Build Requirements
 //!
-//! The FFI adapter requires a pre-compiled `libsettlement.a` (or `.so`)
-//! in the `lib/` directory. If the library is not found, the `settlement-ffi`
-//! feature is automatically disabled by `build.rs`.
+//! The FFI adapter requires a pre-compiled `libsettlement.a` (Linux/macOS)
+//! or `settlement.lib` (Windows) in the `lib/` directory. If the library
+//! is not found, the `has_settlement_lib` cfg is not emitted by `build.rs`,
+//! and the FFI linkage code is excluded — even if the `settlement-ffi`
+//! Cargo feature is enabled (e.g., via `--all-features`).
+//!
+//! ## Two-Gate Design
+//!
+//! The `settlement-ffi` Cargo feature and the `has_settlement_lib` build
+//! script cfg work together:
+//!
+//! - `settlement-ffi` alone: C ABI types compile, but no FFI linkage.
+//!   This allows `--all-features` to work without linker errors on
+//!   systems that lack the pre-compiled C library.
+//! - `settlement-ffi` + `has_settlement_lib`: Full FFI adapter with
+//!   extern declarations, struct, and trait impl. Requires the static
+//!   library to be present at link time.
 //!
 //! ## Safety
 //!
@@ -22,14 +36,19 @@
 // documented with a safety proof.
 #![allow(unsafe_code)]
 
-#[cfg(feature = "settlement-ffi")]
+#[cfg(all(feature = "settlement-ffi", has_settlement_lib))]
 use super::{FinalityProof, SettlementAdapter, SettlementError, TxHash};
-#[cfg(feature = "settlement-ffi")]
+#[cfg(all(feature = "settlement-ffi", has_settlement_lib))]
 use crate::merkle::MerkleProof;
 
 // ---------------------------------------------------------------------------
 // C ABI types
 // ---------------------------------------------------------------------------
+//
+// These types are always compiled when the `settlement-ffi` feature is on,
+// even without the pre-compiled library. This allows downstream code to
+// reference the C ABI types for type-checking and documentation without
+// requiring the actual FFI linkage.
 
 /// C-compatible transaction hash (32 bytes).
 #[repr(C)]
@@ -78,8 +97,13 @@ pub struct CSettlementResult {
 // ---------------------------------------------------------------------------
 // FFI function declarations
 // ---------------------------------------------------------------------------
+//
+// These extern "C" declarations reference symbols provided by the
+// pre-compiled C library. They are only compiled when the library
+// is actually present (has_settlement_lib), because otherwise the
+// linker would emit "unresolved external symbol" errors.
 
-#[cfg(feature = "settlement-ffi")]
+#[cfg(all(feature = "settlement-ffi", has_settlement_lib))]
 extern "C" {
     /// Submit a state root to the settlement layer via the C library.
     ///
@@ -143,7 +167,7 @@ extern "C" {
 ///
 /// All FFI calls are isolated in this module. The C library is
 /// responsible for thread safety and error handling.
-#[cfg(feature = "settlement-ffi")]
+#[cfg(all(feature = "settlement-ffi", has_settlement_lib))]
 pub struct FfiSettlementAdapter {
     /// Whether the FFI client has been initialized.
     initialized: bool,
@@ -151,11 +175,11 @@ pub struct FfiSettlementAdapter {
     rpc_url: String,
 }
 
-#[cfg(feature = "settlement-ffi")]
+#[cfg(all(feature = "settlement-ffi", has_settlement_lib))]
 impl FfiSettlementAdapter {
     /// Create a new FFI settlement adapter.
     ///
-    /// The adapter is not connected until [`init`](Self::init) is called.
+    /// The adapter is not connected until `init` is called.
     /// Operations called before initialization will return an error.
     pub fn new(rpc_url: &str) -> Self {
         Self {
@@ -195,7 +219,7 @@ impl FfiSettlementAdapter {
     }
 }
 
-#[cfg(feature = "settlement-ffi")]
+#[cfg(all(feature = "settlement-ffi", has_settlement_lib))]
 #[async_trait::async_trait]
 impl SettlementAdapter for FfiSettlementAdapter {
     async fn submit_root(&self, root: [u8; 32]) -> Result<TxHash, SettlementError> {
@@ -267,7 +291,7 @@ impl SettlementAdapter for FfiSettlementAdapter {
     }
 }
 
-#[cfg(all(test, feature = "settlement-ffi"))]
+#[cfg(all(test, feature = "settlement-ffi", has_settlement_lib))]
 mod tests {
     use super::*;
 

--- a/omnia-adapters/src/settlement/mod.rs
+++ b/omnia-adapters/src/settlement/mod.rs
@@ -49,8 +49,9 @@ pub use solana::SolanaAdapter;
 // Re-export new hybrid architecture types
 pub use mock::MockSettlementAdapter;
 
-// Conditionally re-export FFI adapter
-#[cfg(feature = "settlement-ffi")]
+// Conditionally re-export FFI adapter (requires both the feature flag
+// and the pre-compiled C library to be present at build time).
+#[cfg(all(feature = "settlement-ffi", has_settlement_lib))]
 pub use ffi::FfiSettlementAdapter;
 
 // Conditionally re-export live Ethereum adapter


### PR DESCRIPTION
The default GITHUB_TOKEN may lack permission to fetch merge commits
and create release PRs depending on repository settings. This adds
fallback support for a RELEASE_PLEASE_TOKEN secret (PAT with repo
scope) which resolves 'Bad credentials' errors.

To fix: create a PAT with 'repo' scope and add it as the
RELEASE_PLEASE_TOKEN repository secret in GitHub Settings > Secrets.