### PR TITLE
fix(security): comprehensive security, performance, and correctness audit fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4853,7 +4853,6 @@ name = "omnia-network"
 version = "0.1.56"
 dependencies = [
  "blake3",
- "chrono",
  "futures",
  "hex",
  "libp2p",
@@ -4909,6 +4908,7 @@ dependencies = [
  "utoipa",
  "utoipa-swagger-ui",
  "uuid",
+ "zeroize",
 ]
 
 [[package]]
@@ -4917,7 +4917,6 @@ version = "0.1.56"
 dependencies = [
  "bincode",
  "blake3",
- "chrono",
  "ed25519-dalek",
  "hex",
  "postcard",
@@ -4927,7 +4926,6 @@ dependencies = [
  "sha2",
  "subtle",
  "thiserror 2.0.18",
- "uuid",
 ]
 
 [[package]]

--- a/agent-ctx/fix-event-result-callers-rust-agent.md
+++ b/agent-ctx/fix-event-result-callers-rust-agent.md
@@ -1,0 +1,36 @@
+# Task: Fix Event::new() and Event::genesis() Result Return Type Callers
+
+## Summary
+Fixed all callers across the omnia-protocol workspace where `Event::new()` and `Event::genesis()` now return `Result<Event, EventValidationError>` instead of `Event` directly.
+
+## Root Cause
+`Event::new()` and `Event::genesis()` in `omnia-primitives/src/event.rs` changed their return types from `Event` to `Result<Event, EventValidationError>`. All callers that treated the return as a plain `Event` needed to handle the `Result`.
+
+## Files Modified
+
+### Fuzz Targets
+1. **`fuzz/fuzz_targets/causal_graph_insert.rs`** - Added `.unwrap()` to `Event::genesis()` (line 15) and `Event::new()` (line 20)
+2. **`fuzz/fuzz_targets/event_validate.rs`** - Added `.unwrap()` to `Event::genesis()` (line 14) and `Event::new()` (line 19)
+3. **`fuzz/fuzz_targets/shard_route.rs`** - Added `.unwrap()` to `Event::genesis()` (line 15)
+
+### Chaos Tests Library
+4. **`chaos-tests/src/lib.rs`** - Used `.expect("genesis event creation should not fail")` for genesis (line 251) and `.map_err(|e| anyhow::anyhow!("Event creation failed: {e}"))?` for submit_event (lines 467-472) to respect `#![deny(clippy::unwrap_used)]`
+5. **`chaos-tests/src/stability_test.rs`** - Used `.expect("genesis event creation should not fail")` for warmup (line 325) and `.expect("event creation should not fail")` for submit_round (lines 370-375)
+6. **`chaos-tests/src/safety_monitoring.rs`** - Used `.expect("genesis event creation should not fail")` for warmup (line 341) and `.expect("event creation should not fail")` for submit_and_propagate (lines 391-396)
+7. **`chaos-tests/src/gossip_chaos.rs`** - Used `.expect("genesis event creation")` (lines 241, 642) and `.expect("event creation")` (line 456)
+8. **`chaos-tests/src/load_test.rs`** - Used `.expect("event creation should not fail")` for the if/else expression (lines 207-219)
+9. **`chaos-tests/src/full_chaos_suite.rs`** - Used `.expect("event creation should not fail")` for both equivocating events (lines 394-402, 406-414)
+
+### Chaos Tests Integration Tests
+10. **`chaos-tests/tests/integration_test.rs`** - Used `.expect("genesis event creation")` (lines 33, 357, 712) and `.expect("event creation")` (line 411)
+11. **`chaos-tests/tests/byzantine.rs`** - Used `.unwrap()` (lines 35-43, 48-56, 124, 129) since the file has `#![allow(clippy::unwrap_used)]`
+
+## Strategy Used
+- **Fuzz code**: Used `.unwrap()` since failures in fuzz targets are acceptable
+- **Test code without clippy deny**: Used `.unwrap()` where `#![allow(clippy::unwrap_used)]` is in effect
+- **Test code with clippy deny**: Used `.expect("descriptive message")`
+- **Production code returning Result**: Used `?` with `.map_err()` for error conversion
+- **Production code not returning Result**: Used `.expect("descriptive message")`
+
+## Verification
+`cargo check --workspace` passes cleanly with no errors.

--- a/benches/benches/baseline_bench.rs
+++ b/benches/benches/baseline_bench.rs
@@ -32,7 +32,7 @@ fn create_signed_event(
     payload: Vec<u8>,
 ) -> Event {
     let keypair = generate_keypair();
-    let mut event = Event::new(creator, seq, vc, self_parent, other_parent, payload);
+    let mut event = Event::new(creator, seq, vc, self_parent, other_parent, payload).expect("event creation");
     event.sign_with_keypair(&keypair);
     event
 }
@@ -81,7 +81,7 @@ fn tx_throughput_bench(c: &mut Criterion) {
                 let mut graph = CausalGraph::new();
 
                 // Genesis event
-                let mut genesis = Event::genesis(creator, vec![]);
+                let mut genesis = Event::genesis(creator, vec![]).expect("genesis creation");
                 genesis.sign_with_keypair(&keypair);
                 let genesis_id = genesis.id;
                 graph.insert(genesis).expect("genesis insert");
@@ -98,7 +98,7 @@ fn tx_throughput_bench(c: &mut Criterion) {
                     let mut vc = VectorClock::new();
                     vc.set(creator, seq + 1);
 
-                    let mut event = Event::new(creator, seq, vc, Some(last_id), None, vec![seq as u8; 64]);
+                    let mut event = Event::new(creator, seq, vc, Some(last_id), None, vec![seq as u8; 64]).expect("event creation");
                     event.sign_with_keypair(&keypair);
 
                     let event_id = event.id;
@@ -158,7 +158,7 @@ fn finality_latency_bench(c: &mut Criterion) {
                 let mut graph = CausalGraph::new();
 
                 let keypair = generate_keypair();
-                let mut genesis = Event::genesis(creator, vec![]);
+                let mut genesis = Event::genesis(creator, vec![]).expect("genesis creation");
                 genesis.sign_with_keypair(&keypair);
                 let genesis_id = genesis.id;
                 graph.insert(genesis).expect("genesis insert");
@@ -171,7 +171,7 @@ fn finality_latency_bench(c: &mut Criterion) {
 
                 let mut vc = VectorClock::new();
                 vc.set(creator, seq + 1);
-                let mut event = Event::new(creator, seq, vc, Some(last_id), None, vec![1u8; 64]);
+                let mut event = Event::new(creator, seq, vc, Some(last_id), None, vec![1u8; 64]).expect("event creation");
                 event.sign_with_keypair(&keypair);
 
                 let event_id = event.id;
@@ -276,7 +276,7 @@ fn gossip_latency_bench(c: &mut Criterion) {
                 // "Local" graph with a genesis event
                 let keypair = generate_keypair();
                 let mut local_graph = CausalGraph::new();
-                let mut genesis = Event::genesis(creator, vec![]);
+                let mut genesis = Event::genesis(creator, vec![]).expect("genesis creation");
                 genesis.sign_with_keypair(&keypair);
                 let genesis_id = genesis.id;
                 local_graph.insert(genesis).expect("genesis insert");
@@ -292,7 +292,7 @@ fn gossip_latency_bench(c: &mut Criterion) {
                 // Create a new event on the "local" node
                 let mut vc = VectorClock::new();
                 vc.set(creator, seq + 1);
-                let mut event = Event::new(creator, seq, vc, Some(last_id), None, vec![1u8; 128]);
+                let mut event = Event::new(creator, seq, vc, Some(last_id), None, vec![1u8; 128]).expect("event creation");
                 event.sign_with_keypair(&keypair);
 
                 // Simulate serialization + deserialization (postcard wire format)
@@ -345,7 +345,7 @@ fn dag_insert_bench(c: &mut Criterion) {
                         for _ in 0..pre_fill {
                             let mut vc = VectorClock::new();
                             vc.set(creator, seq + 1);
-                            let mut event = Event::new(creator, seq, vc, last_id, None, vec![seq as u8; 32]);
+                            let mut event = Event::new(creator, seq, vc, last_id, None, vec![seq as u8; 32]).expect("event creation");
                             event.sign_with_keypair(&keypair);
                             last_id = Some(event.id);
                             graph.insert(event).expect("pre-fill insert");
@@ -359,7 +359,7 @@ fn dag_insert_bench(c: &mut Criterion) {
 
                         let mut vc = VectorClock::new();
                         vc.set(creator, seq + 1);
-                        let mut event = Event::new(creator, seq, vc, last_id, None, vec![seq as u8; 32]);
+                        let mut event = Event::new(creator, seq, vc, last_id, None, vec![seq as u8; 32]).expect("event creation");
                         event.sign_with_keypair(&keypair);
                         let _ = graph.insert(event);
 

--- a/benches/benches/baseline_bench.rs
+++ b/benches/benches/baseline_bench.rs
@@ -98,7 +98,8 @@ fn tx_throughput_bench(c: &mut Criterion) {
                     let mut vc = VectorClock::new();
                     vc.set(creator, seq + 1);
 
-                    let mut event = Event::new(creator, seq, vc, Some(last_id), None, vec![seq as u8; 64]).expect("event creation");
+                    let mut event =
+                        Event::new(creator, seq, vc, Some(last_id), None, vec![seq as u8; 64]).expect("event creation");
                     event.sign_with_keypair(&keypair);
 
                     let event_id = event.id;
@@ -171,7 +172,8 @@ fn finality_latency_bench(c: &mut Criterion) {
 
                 let mut vc = VectorClock::new();
                 vc.set(creator, seq + 1);
-                let mut event = Event::new(creator, seq, vc, Some(last_id), None, vec![1u8; 64]).expect("event creation");
+                let mut event =
+                    Event::new(creator, seq, vc, Some(last_id), None, vec![1u8; 64]).expect("event creation");
                 event.sign_with_keypair(&keypair);
 
                 let event_id = event.id;
@@ -292,7 +294,8 @@ fn gossip_latency_bench(c: &mut Criterion) {
                 // Create a new event on the "local" node
                 let mut vc = VectorClock::new();
                 vc.set(creator, seq + 1);
-                let mut event = Event::new(creator, seq, vc, Some(last_id), None, vec![1u8; 128]).expect("event creation");
+                let mut event =
+                    Event::new(creator, seq, vc, Some(last_id), None, vec![1u8; 128]).expect("event creation");
                 event.sign_with_keypair(&keypair);
 
                 // Simulate serialization + deserialization (postcard wire format)
@@ -345,7 +348,8 @@ fn dag_insert_bench(c: &mut Criterion) {
                         for _ in 0..pre_fill {
                             let mut vc = VectorClock::new();
                             vc.set(creator, seq + 1);
-                            let mut event = Event::new(creator, seq, vc, last_id, None, vec![seq as u8; 32]).expect("event creation");
+                            let mut event = Event::new(creator, seq, vc, last_id, None, vec![seq as u8; 32])
+                                .expect("event creation");
                             event.sign_with_keypair(&keypair);
                             last_id = Some(event.id);
                             graph.insert(event).expect("pre-fill insert");
@@ -359,7 +363,8 @@ fn dag_insert_bench(c: &mut Criterion) {
 
                         let mut vc = VectorClock::new();
                         vc.set(creator, seq + 1);
-                        let mut event = Event::new(creator, seq, vc, last_id, None, vec![seq as u8; 32]).expect("event creation");
+                        let mut event =
+                            Event::new(creator, seq, vc, last_id, None, vec![seq as u8; 32]).expect("event creation");
                         event.sign_with_keypair(&keypair);
                         let _ = graph.insert(event);
 

--- a/benches/benches/hot_path_iai.rs
+++ b/benches/benches/hot_path_iai.rs
@@ -16,7 +16,7 @@ use omnia_primitives::{Event, NodeId, VectorClock};
 fn create_signed_event(creator: NodeId, seq: u64, parent: Option<[u8; 32]>) -> Event {
     let keypair = generate_keypair();
     let vc = VectorClock::with_node(creator, seq + 1);
-    let mut event = Event::new(creator, seq, vc, parent, None, vec![1, 2, 3]);
+    let mut event = Event::new(creator, seq, vc, parent, None, vec![1, 2, 3]).expect("event creation");
     event.sign_with_keypair(&keypair);
     event
 }

--- a/benches/benches/throughput.rs
+++ b/benches/benches/throughput.rs
@@ -56,7 +56,8 @@ fn benchmark_graph_insertion(c: &mut Criterion) {
         let mut seq: u64 = 1;
         b.iter(|| {
             let vc = VectorClock::with_node(creator, seq + 1);
-            let mut event = Event::new(creator, seq, vc, Some(genesis.id), None, vec![seq as u8]).expect("event creation");
+            let mut event =
+                Event::new(creator, seq, vc, Some(genesis.id), None, vec![seq as u8]).expect("event creation");
             event.sign_with_keypair(&keypair);
             let _ = graph.insert(event);
             seq += 1;

--- a/benches/benches/throughput.rs
+++ b/benches/benches/throughput.rs
@@ -30,7 +30,7 @@ fn benchmark_event_creation(c: &mut Criterion) {
 
     group.bench_function("create_and_sign", |b| {
         b.iter(|| {
-            let mut event = Event::new(creator, 0, vc.clone(), None, None, vec![1, 2, 3]);
+            let mut event = Event::new(creator, 0, vc.clone(), None, None, vec![1, 2, 3]).expect("event creation");
             event.sign_with_keypair(&keypair);
             black_box(event);
         });
@@ -48,7 +48,7 @@ fn benchmark_graph_insertion(c: &mut Criterion) {
     let creator: NodeId = [0u8; 32];
 
     // Pre-create genesis
-    let mut genesis = Event::genesis(creator, vec![]);
+    let mut genesis = Event::genesis(creator, vec![]).expect("genesis creation");
     genesis.sign_with_keypair(&keypair);
     graph.insert(genesis.clone()).expect("genesis insert should succeed");
 
@@ -56,7 +56,7 @@ fn benchmark_graph_insertion(c: &mut Criterion) {
         let mut seq: u64 = 1;
         b.iter(|| {
             let vc = VectorClock::with_node(creator, seq + 1);
-            let mut event = Event::new(creator, seq, vc, Some(genesis.id), None, vec![seq as u8]);
+            let mut event = Event::new(creator, seq, vc, Some(genesis.id), None, vec![seq as u8]).expect("event creation");
             event.sign_with_keypair(&keypair);
             let _ = graph.insert(event);
             seq += 1;
@@ -112,9 +112,9 @@ fn bench_slashing_operations(c: &mut Criterion) {
         let keypair = generate_keypair();
         let creator: NodeId = [0u8; 32];
         let vc = VectorClock::with_node(creator, 1);
-        let mut event_a = Event::new(creator, 0, vc.clone(), None, None, vec![1, 2, 3]);
+        let mut event_a = Event::new(creator, 0, vc.clone(), None, None, vec![1, 2, 3]).expect("event creation");
         event_a.sign_with_keypair(&keypair);
-        let mut event_b = Event::new(creator, 0, vc.clone(), None, None, vec![4, 5, 6]);
+        let mut event_b = Event::new(creator, 0, vc.clone(), None, None, vec![4, 5, 6]).expect("event creation");
         event_b.sign_with_keypair(&keypair);
 
         b.iter(|| {

--- a/binding/src/anchor.rs
+++ b/binding/src/anchor.rs
@@ -87,11 +87,10 @@ impl PhysicalAnchor {
             Ok(b) => b,
             Err(_) => return false,
         };
-        if !self.quantum_commitment.verify(
-            public_key,
-            &provenance_bytes,
-            CommitmentPhase::ClassicalOnly,
-        ) {
+        if !self
+            .quantum_commitment
+            .verify(public_key, &provenance_bytes, CommitmentPhase::ClassicalOnly)
+        {
             return false;
         }
 

--- a/binding/src/anchor.rs
+++ b/binding/src/anchor.rs
@@ -83,9 +83,13 @@ impl PhysicalAnchor {
         }
 
         // 2. Verify quantum commitment
+        let provenance_bytes = match self.provenance_log.to_bytes() {
+            Ok(b) => b,
+            Err(_) => return false,
+        };
         if !self.quantum_commitment.verify(
             public_key,
-            &self.provenance_log.to_bytes(),
+            &provenance_bytes,
             CommitmentPhase::ClassicalOnly,
         ) {
             return false;
@@ -169,7 +173,7 @@ mod tests {
         );
 
         // Create commitment over the provenance log bytes (as verify() expects)
-        let commitment = test_commitment_signed(&provenance.to_bytes(), &kp);
+        let commitment = test_commitment_signed(&provenance.to_bytes().unwrap(), &kp);
 
         let anchor = PhysicalAnchor::new(rf, commitment, provenance);
 
@@ -192,7 +196,7 @@ mod tests {
             test_commitment_with_vc(b"creation", &kp, &vc),
             [0xCDu8; 32],
         );
-        let commitment = test_commitment_signed(&provenance.to_bytes(), &kp);
+        let commitment = test_commitment_signed(&provenance.to_bytes().unwrap(), &kp);
 
         let anchor = PhysicalAnchor::new(rf, commitment, provenance);
 
@@ -214,7 +218,7 @@ mod tests {
             test_commitment_with_vc(b"creation", &kp, &vc),
             [0xCDu8; 32],
         );
-        let commitment = test_commitment_signed(&provenance.to_bytes(), &kp);
+        let commitment = test_commitment_signed(&provenance.to_bytes().unwrap(), &kp);
 
         let anchor = PhysicalAnchor::new(rf, commitment, provenance);
         assert!(anchor.verify_chain_only());
@@ -241,7 +245,7 @@ mod tests {
             test_commitment_signed(b"transfer1", &kp),
         );
 
-        let commitment = test_commitment_signed(&provenance.to_bytes(), &kp);
+        let commitment = test_commitment_signed(&provenance.to_bytes().unwrap(), &kp);
         let anchor = PhysicalAnchor::new(rf, commitment, provenance);
         assert_eq!(anchor.current_holder(), "did:omnia:bob");
     }

--- a/binding/src/key_rotation.rs
+++ b/binding/src/key_rotation.rs
@@ -5,6 +5,7 @@
 //! and new keys are valid during a transition period.
 
 use crate::quantum_commit::{CommitmentPhase, PqPublicKey};
+use ed25519_dalek::Verifier;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -22,6 +23,9 @@ pub enum KeyRotationError {
     /// Authorization signature is missing.
     #[error("authorization signature required")]
     AuthorizationSignatureRequired,
+    /// Authorization signature is invalid.
+    #[error("invalid authorization signature")]
+    InvalidAuthorizationSignature,
 }
 
 /// A key rotation request that supports PQC transitions.
@@ -47,6 +51,8 @@ pub struct PqcKeyRotationManager {
     current_phase: CommitmentPhase,
     /// Pending rotations.
     pending: Vec<PqcKeyRotationRequest>,
+    /// Current Ed25519 public key used for verifying rotation authorization.
+    current_ed25519_public: Option<[u8; 32]>,
 }
 
 impl PqcKeyRotationManager {
@@ -55,7 +61,13 @@ impl PqcKeyRotationManager {
         Self {
             current_phase,
             pending: Vec::new(),
+            current_ed25519_public: None,
         }
+    }
+
+    /// Set the current Ed25519 public key for verifying rotation authorization signatures.
+    pub fn set_current_ed25519_public(&mut self, public_key: [u8; 32]) {
+        self.current_ed25519_public = Some(public_key);
     }
 
     /// Submit a key rotation request.
@@ -69,6 +81,18 @@ impl PqcKeyRotationManager {
 
         if request.authorization_sig.is_empty() {
             return Err(KeyRotationError::AuthorizationSignatureRequired);
+        }
+
+        // Verify the authorization signature against the current Ed25519 key
+        if let Some(ref pubkey_bytes) = self.current_ed25519_public {
+            let verifying_key = ed25519_dalek::VerifyingKey::from_bytes(pubkey_bytes)
+                .map_err(|_| KeyRotationError::InvalidAuthorizationSignature)?;
+            let signature = ed25519_dalek::Signature::try_from(request.authorization_sig.as_slice())
+                .map_err(|_| KeyRotationError::InvalidAuthorizationSignature)?;
+            // The message being signed is the rotation request details
+            let message = format!("{}:{}", request.new_phase as u8, request.effective_at);
+            verifying_key.verify(message.as_bytes(), &signature)
+                .map_err(|_| KeyRotationError::InvalidAuthorizationSignature)?;
         }
 
         self.pending.push(request);

--- a/binding/src/key_rotation.rs
+++ b/binding/src/key_rotation.rs
@@ -91,7 +91,8 @@ impl PqcKeyRotationManager {
                 .map_err(|_| KeyRotationError::InvalidAuthorizationSignature)?;
             // The message being signed is the rotation request details
             let message = format!("{}:{}", request.new_phase as u8, request.effective_at);
-            verifying_key.verify(message.as_bytes(), &signature)
+            verifying_key
+                .verify(message.as_bytes(), &signature)
                 .map_err(|_| KeyRotationError::InvalidAuthorizationSignature)?;
         }
 

--- a/binding/src/keystore_bridge.rs
+++ b/binding/src/keystore_bridge.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::key_rotation::{KeyRotationError, PqcKeyRotationManager, PqcKeyRotationRequest};
+use crate::provenance::ProvenanceError;
 use crate::quantum_commit::{CommitmentPhase, PqPublicKey};
 
 /// Errors that can occur during keystore bridge operations.
@@ -35,6 +36,9 @@ pub enum BridgeError {
     /// Cryptographic operation failed.
     #[error("crypto error: {0}")]
     Crypto(String),
+    /// Provenance error.
+    #[error("provenance error: {0}")]
+    Provenance(#[from] ProvenanceError),
 }
 
 /// Persistent rotation state serialized as JSON.
@@ -58,6 +62,9 @@ pub struct RotationState {
     /// returns the correct post-rotation keypair even after a restart.
     /// The keystore on disk still holds the original keypair; this field
     /// supplements it until a full keystore rotation is performed.
+    ///
+    /// WARNING: Ed25519 secret key is stored in plaintext JSON.
+    /// This must be encrypted before production use.
     #[serde(default)]
     pub rotated_ed25519_secret: Option<String>,
 }
@@ -130,7 +137,7 @@ impl KeyStoreBridge {
         };
 
         let rotation_state_path = data_dir.join("rotation_state.json");
-        let (rotation_state, rotation_manager) = if rotation_state_path.exists() {
+        let (rotation_state, mut rotation_manager) = if rotation_state_path.exists() {
             let state_bytes = std::fs::read(&rotation_state_path)?;
             let state: RotationState =
                 serde_json::from_slice(&state_bytes).map_err(|e| BridgeError::Serialization(e.to_string()))?;
@@ -149,6 +156,10 @@ impl KeyStoreBridge {
             let manager = PqcKeyRotationManager::new(CommitmentPhase::ClassicalOnly);
             (state, manager)
         };
+
+        // Set the current Ed25519 public key on the rotation manager
+        // so it can verify authorization signatures for rotation requests.
+        rotation_manager.set_current_ed25519_public(keystore.public_key().to_bytes());
 
         // Restore rotated Ed25519 keypair from persisted state (if any).
         let rotated_keypair = rotation_state
@@ -230,9 +241,19 @@ impl KeyStoreBridge {
         // post-rotation key even after a restart.  Both the in-memory field and
         // the serializable hex representation in `rotation_state` are updated
         // so that `persist_rotation_state()` writes them to disk.
-        let ed25519_secret_hex = hex::encode(ed25519_keypair.to_bytes());
         self.rotated_keypair = Some(ed25519_keypair);
-        self.rotation_state.rotated_ed25519_secret = Some(ed25519_secret_hex);
+        #[cfg(debug_assertions)]
+        {
+            let ed25519_secret_hex = hex::encode(self.rotated_keypair.as_ref().expect("just set").to_bytes());
+            self.rotation_state.rotated_ed25519_secret = Some(ed25519_secret_hex);
+        }
+        #[cfg(not(debug_assertions))]
+        {
+            // In release builds, do not persist the secret key in plaintext.
+            // Use the keystore's key rotation mechanism instead.
+            self.rotation_state.rotated_ed25519_secret = None;
+            tracing::warn!("Ed25519 secret key not persisted to disk in release build — use keystore rotation");
+        }
 
         let new_pubkey = PqPublicKey {
             ed25519: self
@@ -388,6 +409,13 @@ mod tests {
     use super::*;
     use tempfile::TempDir;
 
+    /// Helper: sign a rotation authorization message with the current signing key.
+    fn sign_rotation_auth(bridge: &KeyStoreBridge, new_phase: CommitmentPhase, current_round: u64) -> Vec<u8> {
+        let keypair = bridge.current_signing_key().expect("signing key");
+        let message = format!("{}:{}", new_phase as u8, current_round);
+        keypair.sign(message.as_bytes()).to_bytes().to_vec()
+    }
+
     #[test]
     fn test_load_creates_new_bridge() {
         let dir = TempDir::new().expect("temp dir");
@@ -402,7 +430,7 @@ mod tests {
         // Create and rotate
         {
             let mut bridge = KeyStoreBridge::load(dir.path(), "test-pass").expect("bridge load");
-            let sig = vec![1u8; 64]; // Mock signature
+            let sig = sign_rotation_auth(&bridge, CommitmentPhase::Hybrid, 100);
             bridge.rotate(&sig, CommitmentPhase::Hybrid, 100).expect("rotate");
         }
 
@@ -417,13 +445,14 @@ mod tests {
         let mut bridge = KeyStoreBridge::load(dir.path(), "test-pass").expect("bridge load");
 
         // First rotate to Hybrid
-        let sig = vec![1u8; 64];
+        let sig = sign_rotation_auth(&bridge, CommitmentPhase::Hybrid, 100);
         bridge
             .rotate(&sig, CommitmentPhase::Hybrid, 100)
             .expect("rotate to hybrid");
 
-        // Try to downgrade to ClassicalOnly
-        let result = bridge.rotate(&sig, CommitmentPhase::ClassicalOnly, 200);
+        // Try to downgrade to ClassicalOnly (signature doesn't matter — fails at downgrade check)
+        let bad_sig = vec![1u8; 64];
+        let result = bridge.rotate(&bad_sig, CommitmentPhase::ClassicalOnly, 200);
         assert!(result.is_err(), "Downgrade should be prevented");
     }
 
@@ -488,7 +517,7 @@ mod tests {
                 .verifying_key()
                 .to_bytes();
 
-            let sig = vec![1u8; 64];
+            let sig = sign_rotation_auth(&bridge, CommitmentPhase::Hybrid, 100);
             bridge.rotate(&sig, CommitmentPhase::Hybrid, 100).expect("rotate");
 
             // After rotation, current_signing_key() must return the NEW key
@@ -525,7 +554,7 @@ mod tests {
         let mut bridge = KeyStoreBridge::load(dir.path(), "test-pass").expect("bridge load");
 
         // Rotate to Hybrid
-        let sig = vec![1u8; 64];
+        let sig = sign_rotation_auth(&bridge, CommitmentPhase::Hybrid, 100);
         bridge
             .rotate(&sig, CommitmentPhase::Hybrid, 100)
             .expect("rotate to hybrid");

--- a/binding/src/provenance.rs
+++ b/binding/src/provenance.rs
@@ -110,6 +110,23 @@ impl ProvenanceEvent {
     }
 }
 
+/// Errors that can occur during provenance log operations.
+#[derive(Debug, thiserror::Error)]
+pub enum ProvenanceError {
+    /// The provenance log has no events (invalid state).
+    #[error("provenance log has no events")]
+    EmptyLog,
+    /// Deserialization failed.
+    #[error("deserialization error: {0}")]
+    DeserializationError(String),
+    /// Serialization failed.
+    #[error("serialization error: {0}")]
+    SerializationError(String),
+    /// Invalid log structure.
+    #[error("invalid log: {0}")]
+    InvalidLog(String),
+}
+
 /// An append-only provenance log for a single physical item.
 ///
 /// The log records the complete chain of custody for an item, from
@@ -366,8 +383,12 @@ impl ProvenanceLog {
     }
 
     /// Get the creation event (first event in the log).
-    pub fn creation_event(&self) -> &ProvenanceEvent {
-        &self.events[0]
+    ///
+    /// Returns an error if the log is empty (should never happen after
+    /// construction via `new()`, but can occur after deserialization of
+    /// corrupt data).
+    pub fn creation_event(&self) -> Result<&ProvenanceEvent, ProvenanceError> {
+        self.events.first().ok_or(ProvenanceError::EmptyLog)
     }
 
     /// Check if the item has been destroyed.
@@ -382,25 +403,37 @@ impl ProvenanceLog {
     ///
     /// The output is prefixed with a version byte to support future
     /// state-format migrations.
-    pub fn to_bytes(&self) -> Vec<u8> {
+    pub fn to_bytes(&self) -> Result<Vec<u8>, ProvenanceError> {
         let mut bytes = vec![Self::PROVENANCE_LOG_VERSION];
-        bytes.extend(postcard::to_allocvec(self).expect("ProvenanceLog serialization cannot fail"));
-        bytes
+        let serialized = postcard::to_allocvec(self)
+            .map_err(|e| ProvenanceError::SerializationError(e.to_string()))?;
+        bytes.extend(serialized);
+        Ok(bytes)
     }
 
     /// Deserialize a provenance log from bytes.
     ///
     /// Reads and validates the version byte before deserializing the
     /// payload. Returns an error if the version is unsupported.
-    pub fn from_bytes(bytes: &[u8]) -> Result<Self, postcard::Error> {
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, ProvenanceError> {
         if bytes.is_empty() {
-            return Err(postcard::Error::DeserializeUnexpectedEnd);
+            return Err(ProvenanceError::DeserializationError("empty input".into()));
         }
         let version = bytes[0];
         if version != Self::PROVENANCE_LOG_VERSION {
-            return Err(postcard::Error::DeserializeUnexpectedEnd);
+            return Err(ProvenanceError::DeserializationError(format!(
+                "unsupported version: {}",
+                version
+            )));
         }
-        postcard::from_bytes(&bytes[1..])
+        let log: Self = postcard::from_bytes(&bytes[1..])
+            .map_err(|e| ProvenanceError::DeserializationError(e.to_string()))?;
+        if log.events.is_empty() {
+            return Err(ProvenanceError::InvalidLog(
+                "provenance log must have at least one event".into(),
+            ));
+        }
+        Ok(log)
     }
 }
 
@@ -542,7 +575,7 @@ mod tests {
             test_commitment(b"transfer1"),
         );
 
-        let bytes = log.to_bytes();
+        let bytes = log.to_bytes().unwrap();
         let restored = ProvenanceLog::from_bytes(&bytes).unwrap();
 
         assert_eq!(log.item_id, restored.item_id);

--- a/binding/src/provenance.rs
+++ b/binding/src/provenance.rs
@@ -405,8 +405,7 @@ impl ProvenanceLog {
     /// state-format migrations.
     pub fn to_bytes(&self) -> Result<Vec<u8>, ProvenanceError> {
         let mut bytes = vec![Self::PROVENANCE_LOG_VERSION];
-        let serialized = postcard::to_allocvec(self)
-            .map_err(|e| ProvenanceError::SerializationError(e.to_string()))?;
+        let serialized = postcard::to_allocvec(self).map_err(|e| ProvenanceError::SerializationError(e.to_string()))?;
         bytes.extend(serialized);
         Ok(bytes)
     }
@@ -426,8 +425,8 @@ impl ProvenanceLog {
                 version
             )));
         }
-        let log: Self = postcard::from_bytes(&bytes[1..])
-            .map_err(|e| ProvenanceError::DeserializationError(e.to_string()))?;
+        let log: Self =
+            postcard::from_bytes(&bytes[1..]).map_err(|e| ProvenanceError::DeserializationError(e.to_string()))?;
         if log.events.is_empty() {
             return Err(ProvenanceError::InvalidLog(
                 "provenance log must have at least one event".into(),

--- a/binding/src/rf_fingerprint.rs
+++ b/binding/src/rf_fingerprint.rs
@@ -39,10 +39,12 @@ pub struct RfFingerprint {
     pub measured_at: VectorClock,
     /// Device's claimed identity (must match DID).
     pub device_did: String,
-    /// Measurement confidence (0.0 - 1.0). Higher means stricter matching
-    /// threshold. A confidence of 0.95 means the Hamming similarity must
+    /// Confidence threshold in parts per million (PPM).
+    /// 800_000 = 80% similarity required.
+    /// Higher means stricter matching threshold.
+    /// A confidence_ppm of 950_000 means the Hamming similarity must
     /// exceed 95% for the fingerprint to be considered a match.
-    pub confidence: f64,
+    pub confidence_ppm: u64,
 }
 
 impl RfFingerprint {
@@ -53,13 +55,13 @@ impl RfFingerprint {
     /// * `spectral_hash` — 32-byte hash of the device's RF spectral features
     /// * `measured_at` — Vector clock at measurement time
     /// * `device_did` — DID string of the device being fingerprinted
-    /// * `confidence` — Matching threshold (0.0–1.0); typical values: 0.90–0.99
-    pub fn new(spectral_hash: [u8; 32], measured_at: VectorClock, device_did: String, confidence: f64) -> Self {
+    /// * `confidence_ppm` — Matching threshold in PPM (0–1_000_000); typical values: 900_000–990_000
+    pub fn new(spectral_hash: [u8; 32], measured_at: VectorClock, device_did: String, confidence_ppm: u64) -> Self {
         Self {
             spectral_hash,
             measured_at,
             device_did,
-            confidence: confidence.clamp(0.0, 1.0),
+            confidence_ppm: confidence_ppm.min(1_000_000), // Cap at 100%
         }
     }
 
@@ -67,9 +69,9 @@ impl RfFingerprint {
     /// fingerprint.
     ///
     /// Uses Hamming distance between the stored `spectral_hash` and the
-    /// `current_measurement`. The similarity is computed as
-    /// `1.0 - (hamming_distance / 256.0)`, and the match is accepted if
-    /// similarity exceeds the stored `confidence` threshold.
+    /// `current_measurement`. The similarity is computed using integer
+    /// PPM arithmetic: `(256 - distance) * 1_000_000 / 256`, and the match
+    /// is accepted if similarity exceeds the stored `confidence_ppm` threshold.
     ///
     /// # Arguments
     ///
@@ -80,8 +82,9 @@ impl RfFingerprint {
     /// `true` if the similarity exceeds the confidence threshold.
     pub fn verify(&self, current_measurement: &[u8; 32]) -> bool {
         let distance = hamming_distance(&self.spectral_hash, current_measurement);
-        let similarity = 1.0 - (distance as f64 / 256.0);
-        similarity > self.confidence
+        // Integer PPM-based similarity: (256 - distance) * 1_000_000 / 256
+        let similarity_ppm = (256u64 - distance as u64) * 1_000_000 / 256;
+        similarity_ppm > self.confidence_ppm
     }
 
     /// Create a dummy/stub RF fingerprint for testing.
@@ -94,7 +97,7 @@ impl RfFingerprint {
             spectral_hash: hash_bytes,
             measured_at: VectorClock::new(),
             device_did: device_did.to_string(),
-            confidence: 0.95,
+            confidence_ppm: 950_000, // 95% in PPM
         }
     }
 }
@@ -128,7 +131,7 @@ mod tests {
         let hash_a = [0x00_u8; 32];
         let hash_b = [0xFF_u8; 32];
         let fp = RfFingerprint::stub("did:omnia:device1", hash_a);
-        // Hamming distance = 256, similarity = 0.0, which is NOT > 0.95
+        // Hamming distance = 256, similarity_ppm = 0, which is NOT > 950_000
         assert!(!fp.verify(&hash_b));
     }
 
@@ -136,7 +139,7 @@ mod tests {
     fn test_slightly_different_fingerprints_match() {
         let hash_a = [0xAB_u8; 32];
         let mut hash_b = [0xAB_u8; 32];
-        // Flip 1 bit — similarity = 1.0 - 1/256 ≈ 0.996 > 0.95
+        // Flip 1 bit — similarity_ppm = 255 * 1_000_000 / 256 = 996_093 > 950_000
         hash_b[0] ^= 0x01;
         let fp = RfFingerprint::stub("did:omnia:device1", hash_a);
         assert!(fp.verify(&hash_b));
@@ -161,9 +164,9 @@ mod tests {
             [0u8; 32],
             VectorClock::new(),
             "did:omnia:test".to_string(),
-            1.5, // Should be clamped to 1.0
+            1_500_000, // Should be clamped to 1_000_000
         );
-        // With confidence 1.0 (clamped from 1.5), similarity must be > 1.0
+        // With confidence_ppm 1_000_000 (clamped from 1_500_000), similarity must be > 1_000_000
         // which is impossible, so even identical hashes won't match
         assert!(!fp.verify(&[0u8; 32]));
     }

--- a/binding/tests/provenance_chain.rs
+++ b/binding/tests/provenance_chain.rs
@@ -175,7 +175,7 @@ fn test_physical_anchor_verification() {
     );
 
     // Create commitment over the provenance log bytes (as verify() expects)
-    let commitment = make_commitment(&provenance.to_bytes(), &kp);
+    let commitment = make_commitment(&provenance.to_bytes().unwrap(), &kp);
 
     let anchor = PhysicalAnchor::new(make_rf("did:omnia:creator", rf_hash), commitment, provenance);
 
@@ -209,7 +209,7 @@ fn test_provenance_serialization_roundtrip() {
         make_commitment(b"transfer", &kp),
     );
 
-    let bytes = log.to_bytes();
+    let bytes = log.to_bytes().unwrap();
     let restored = ProvenanceLog::from_bytes(&bytes).unwrap();
 
     assert_eq!(log.item_id, restored.item_id);

--- a/chaos-tests/src/full_chaos_suite.rs
+++ b/chaos-tests/src/full_chaos_suite.rs
@@ -398,7 +398,8 @@ fn run_byzantine_equivocation(config: &ChaosSuiteConfig) -> ChaosScenarioResult 
         self_parent,
         other_parent,
         vec![0xEE, 0x01],
-    );
+    )
+    .expect("event creation should not fail");
     event_a.sign_with_keypair(&byzantine_keypair);
 
     // Create event B: same (creator, sequence), different payload = [0xEQ, 0x02]
@@ -409,7 +410,8 @@ fn run_byzantine_equivocation(config: &ChaosSuiteConfig) -> ChaosScenarioResult 
         self_parent,
         other_parent,
         vec![0xEE, 0x02],
-    );
+    )
+    .expect("event creation should not fail");
     event_b.sign_with_keypair(&byzantine_keypair);
 
     // Verify that the two events have different IDs (because payloads differ)

--- a/chaos-tests/src/gossip_chaos.rs
+++ b/chaos-tests/src/gossip_chaos.rs
@@ -238,7 +238,7 @@ fn test_compact_encoding_roundtrip_preserves_data() {
     let mut encoder = CompactEncoder::new(1024, 16);
     let keypair = omnia_crypto::generate_keypair();
 
-    let mut event = Event::genesis(node(1), vec![1, 2, 3, 4, 5]);
+    let mut event = Event::genesis(node(1), vec![1, 2, 3, 4, 5]).expect("genesis event creation");
     event.sign_with_keypair(&keypair);
 
     let peer_id = node(2);
@@ -453,7 +453,7 @@ fn test_compact_encoding_large_vector_clock() {
         vc.set(node(i), (i as u64) * 100 + 50);
     }
 
-    let mut event = Event::new(node(1), 0, vc, None, None, vec![1, 2, 3]);
+    let mut event = Event::new(node(1), 0, vc, None, None, vec![1, 2, 3]).expect("event creation");
     event.sign_with_keypair(&keypair);
 
     let peer_id = node(2);
@@ -639,7 +639,7 @@ fn test_compact_encoder_frontier_updates() {
     let keypair = omnia_crypto::generate_keypair();
 
     // Create event from node 1
-    let mut event = Event::genesis(node(1), vec![1, 2, 3]);
+    let mut event = Event::genesis(node(1), vec![1, 2, 3]).expect("genesis event creation");
     event.sign_with_keypair(&keypair);
 
     let peer_id = node(2);

--- a/chaos-tests/src/lib.rs
+++ b/chaos-tests/src/lib.rs
@@ -248,7 +248,8 @@ impl ChaosNetwork {
         // at the same time.
         let mut genesis_events: Vec<(usize, Event)> = Vec::with_capacity(n);
         for i in 0..n {
-            let mut event = Event::genesis(node_ids[i], vec![(i + 1) as u8]);
+            let mut event = Event::genesis(node_ids[i], vec![(i + 1) as u8])
+                .expect("genesis event creation should not fail");
             event.sign_with_keypair(&keypairs[i]);
 
             // Insert into the node's own graph (graph only needs &mut graph)
@@ -467,7 +468,8 @@ impl ChaosNetwork {
                 Event::genesis(node.node_id, payload)
             } else {
                 Event::new(node.node_id, sequence, vc, self_parent, other_parent, payload)
-            };
+            }
+            .map_err(|e| anyhow::anyhow!("Event creation failed: {e}"))?;
             event.sign_with_keypair(&node.keypair);
 
             event_id = event.id;

--- a/chaos-tests/src/lib.rs
+++ b/chaos-tests/src/lib.rs
@@ -248,8 +248,8 @@ impl ChaosNetwork {
         // at the same time.
         let mut genesis_events: Vec<(usize, Event)> = Vec::with_capacity(n);
         for i in 0..n {
-            let mut event = Event::genesis(node_ids[i], vec![(i + 1) as u8])
-                .expect("genesis event creation should not fail");
+            let mut event =
+                Event::genesis(node_ids[i], vec![(i + 1) as u8]).expect("genesis event creation should not fail");
             event.sign_with_keypair(&keypairs[i]);
 
             // Insert into the node's own graph (graph only needs &mut graph)

--- a/chaos-tests/src/load_test.rs
+++ b/chaos-tests/src/load_test.rs
@@ -215,7 +215,8 @@ pub async fn run_load_test(config: &LoadTestConfig) -> Result<LoadTestResult, Lo
                 None, // no other-parent in single-node mode
                 payload,
             )
-        };
+        }
+        .expect("event creation should not fail");
 
         let event_id = event.id;
 

--- a/chaos-tests/src/safety_monitoring.rs
+++ b/chaos-tests/src/safety_monitoring.rs
@@ -338,7 +338,8 @@ impl SafetyMonitor {
         // Create genesis events using each node's identity keypair
         let mut genesis_events: Vec<(usize, Event)> = Vec::with_capacity(self.nodes.len());
         for (i, node) in self.nodes.iter_mut().enumerate() {
-            let mut genesis = Event::genesis(node.node_id, vec![(i + 1) as u8]);
+            let mut genesis = Event::genesis(node.node_id, vec![(i + 1) as u8])
+                .expect("genesis event creation should not fail");
             // Use the node's own identity keypair for signing (not a random one)
             genesis.sign_with_keypair(&node.keypair);
 
@@ -391,7 +392,8 @@ impl SafetyMonitor {
             Event::genesis(source_node_id, payload)
         } else {
             Event::new(source_node_id, sequence, vc, self_parent, other_parent, payload)
-        };
+        }
+        .expect("event creation should not fail");
 
         // Use the node's own identity keypair for signing (not a random one)
         let keypair = self.nodes[source_idx].keypair.clone();

--- a/chaos-tests/src/safety_monitoring.rs
+++ b/chaos-tests/src/safety_monitoring.rs
@@ -338,8 +338,8 @@ impl SafetyMonitor {
         // Create genesis events using each node's identity keypair
         let mut genesis_events: Vec<(usize, Event)> = Vec::with_capacity(self.nodes.len());
         for (i, node) in self.nodes.iter_mut().enumerate() {
-            let mut genesis = Event::genesis(node.node_id, vec![(i + 1) as u8])
-                .expect("genesis event creation should not fail");
+            let mut genesis =
+                Event::genesis(node.node_id, vec![(i + 1) as u8]).expect("genesis event creation should not fail");
             // Use the node's own identity keypair for signing (not a random one)
             genesis.sign_with_keypair(&node.keypair);
 

--- a/chaos-tests/src/stability_test.rs
+++ b/chaos-tests/src/stability_test.rs
@@ -322,7 +322,8 @@ impl StabilityTestRunner {
         let mut genesis_events: Vec<(usize, Event)> = Vec::with_capacity(self.nodes.len());
 
         for i in 0..self.nodes.len() {
-            let mut genesis = Event::genesis(self.nodes[i].node_id, vec![(i + 1) as u8]);
+            let mut genesis = Event::genesis(self.nodes[i].node_id, vec![(i + 1) as u8])
+                .expect("genesis event creation should not fail");
             genesis.sign_with_keypair(&self.keypairs[i]);
 
             if let Err(e) = self.nodes[i].graph.insert(genesis.clone()) {
@@ -370,7 +371,8 @@ impl StabilityTestRunner {
                 Event::genesis(source_node_id, payload)
             } else {
                 Event::new(source_node_id, sequence, vc, self_parent, other_parent, payload)
-            };
+            }
+            .expect("event creation should not fail");
 
             event.sign_with_keypair(&self.keypairs[i]);
 

--- a/chaos-tests/tests/byzantine.rs
+++ b/chaos-tests/tests/byzantine.rs
@@ -39,7 +39,8 @@ fn test_equivocation_detection() {
         node0_self_parent,
         None,
         vec![0xAA], // Payload A
-    );
+    )
+    .unwrap();
     event_a.sign_with_keypair(&node0_keypair);
 
     let mut vc2 = node0_vc.clone();
@@ -51,7 +52,8 @@ fn test_equivocation_detection() {
         node0_self_parent,
         None,
         vec![0xBB], // Payload B (different from A)
-    );
+    )
+    .unwrap();
     event_b.sign_with_keypair(&node0_keypair);
 
     // Verify these are indeed equivocating events
@@ -119,12 +121,12 @@ fn test_equivocation_detected_by_multiple_observers() {
     // Create equivocating events
     let mut vc1 = node0_vc.clone();
     vc1.set(node0_id, node0_sequence.saturating_add(1));
-    let mut event_a = Event::new(node0_id, node0_sequence, vc1, node0_self_parent, None, vec![1]);
+    let mut event_a = Event::new(node0_id, node0_sequence, vc1, node0_self_parent, None, vec![1]).unwrap();
     event_a.sign_with_keypair(&node0_keypair);
 
     let mut vc2 = node0_vc.clone();
     vc2.set(node0_id, node0_sequence.saturating_add(1));
-    let mut event_b = Event::new(node0_id, node0_sequence, vc2, node0_self_parent, None, vec![2]);
+    let mut event_b = Event::new(node0_id, node0_sequence, vc2, node0_self_parent, None, vec![2]).unwrap();
     event_b.sign_with_keypair(&node0_keypair);
 
     assert!(SlashingEngine::check_equivocation(&event_a, &event_b));

--- a/chaos-tests/tests/integration_test.rs
+++ b/chaos-tests/tests/integration_test.rs
@@ -155,7 +155,6 @@ fn test_pool_pruning_with_sharded_state_tracking() {
 /// deserialize, validate, and process through consensus.
 #[test]
 fn test_batch_gossip_propagation_pipeline() {
-    use omnia_consensus::batch::MAX_BATCH_SIZE;
     use omnia_network::{
         deserialize_batch_message, serialize_batch_message, validate_batch_message, GossipBatchMessage,
     };
@@ -686,7 +685,6 @@ fn test_optimized_stack_identical_consensus_outcomes() {
 /// 8. Track in ShardedConsensusState
 #[test]
 fn test_full_optimized_pipeline_end_to_end() {
-    use omnia_consensus::batch::MAX_BATCH_SIZE;
     use omnia_network::{
         deserialize_batch_message, serialize_batch_message, validate_batch_message, GossipBatchMessage,
     };
@@ -695,7 +693,7 @@ fn test_full_optimized_pipeline_end_to_end() {
     let mut pool = PruningAwarePool::new(512, 100_000);
     let mut bloom = GossipBloomFilter::new(10_000, 0.01);
     let mut priority_queue = PriorityGossipQueue::with_defaults();
-    let mut encoder = CompactEncoder::new(2048, 16);
+    let encoder = CompactEncoder::new(2048, 16);
     let config = BatchConfig {
         flush_size: 5,
         ..Default::default()
@@ -704,7 +702,7 @@ fn test_full_optimized_pipeline_end_to_end() {
     let mut ingestor = BatchIngestor::new(config, creator);
 
     let peer_id = node(2);
-    let mut peer_frontier = VectorClock::new();
+    let _peer_frontier = VectorClock::new();
 
     // Create and process 10 events
     for i in 0..10u8 {
@@ -776,7 +774,7 @@ fn test_full_optimized_pipeline_end_to_end() {
 
     // All events should be in bloom filter
     let stats = sharded.stats();
-    for i in 0..10u8 {
+    for _ in 0..10u8 {
         // We can't iterate the sharded state, but we verified individual inserts
     }
     assert!(stats.total_tracked == 10);

--- a/chaos-tests/tests/integration_test.rs
+++ b/chaos-tests/tests/integration_test.rs
@@ -30,7 +30,7 @@ fn node(id: u8) -> NodeId {
 /// Helper: create a signed event for testing.
 fn signed_event(creator: NodeId, payload: Vec<u8>) -> Event {
     let keypair = generate_keypair();
-    let mut event = Event::genesis(creator, payload);
+    let mut event = Event::genesis(creator, payload).expect("genesis event creation");
     event.sign_with_keypair(&keypair);
     event
 }
@@ -354,7 +354,7 @@ fn test_bloom_filter_with_compact_encoded_events() {
     let mut event_ids: Vec<EventId> = Vec::new();
     for i in 0..50u8 {
         let keypair = generate_keypair();
-        let mut event = Event::genesis(node(i), vec![i]);
+        let mut event = Event::genesis(node(i), vec![i]).expect("genesis event creation");
         event.sign_with_keypair(&keypair);
 
         // Insert into bloom filter
@@ -408,7 +408,7 @@ fn test_compact_encoding_with_multi_node_events() {
     vc.set(node(2), 3); // Same as peer
     vc.set(node(3), 10);
 
-    let mut event = Event::new(node(1), 8, vc, None, None, vec![1, 2, 3]);
+    let mut event = Event::new(node(1), 8, vc, None, None, vec![1, 2, 3]).expect("event creation");
     event.sign_with_keypair(&keypair);
 
     // Encode for the peer
@@ -709,7 +709,7 @@ fn test_full_optimized_pipeline_end_to_end() {
     // Create and process 10 events
     for i in 0..10u8 {
         let keypair = generate_keypair();
-        let mut event = Event::genesis(node(i + 1), vec![i; 32]);
+        let mut event = Event::genesis(node(i + 1), vec![i; 32]).expect("genesis event creation");
         event.sign_with_keypair(&keypair);
         let event_id = event.id;
 

--- a/economics/src/economics_shard.rs
+++ b/economics/src/economics_shard.rs
@@ -10,7 +10,7 @@
 //! However, it does maintain its own `QuotaSystem` and `GovernanceState`
 //! for managing UBC allowances and voting.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use serde::{Deserialize, Serialize};
 
@@ -84,6 +84,8 @@ pub struct EconomicsState {
     pub governance: GovernanceState,
     /// Verified useful-work proofs keyed by result hash.
     pub verified_work: HashMap<[u8; 32], UsefulWorkProof>,
+    /// Admin keys authorized to submit work during the pre-ZK phase.
+    pub admin_keys: HashSet<[u8; 32]>,
 }
 
 impl EconomicsState {
@@ -99,6 +101,7 @@ impl EconomicsState {
             quota: QuotaSystem::default_system(),
             governance: GovernanceState::new(DecayRate::ten_percent()),
             verified_work: HashMap::new(),
+            admin_keys: HashSet::new(),
         }
     }
 
@@ -108,11 +111,34 @@ impl EconomicsState {
             quota: QuotaSystem::new(default_quota, epoch_duration_ms),
             governance: GovernanceState::new(decay_rate),
             verified_work: HashMap::new(),
+            admin_keys: HashSet::new(),
         }
     }
 
+    /// Check if a key is an admin key authorized to submit work.
+    fn is_admin(&self, key: &[u8; 32]) -> bool {
+        self.admin_keys.contains(key)
+    }
+
+    /// Add an admin key authorized to submit work during the pre-ZK phase.
+    pub fn add_admin_key(&mut self, key: [u8; 32]) {
+        self.admin_keys.insert(key);
+    }
+
     /// Apply an economics operation, mutating state.
-    pub fn apply(&mut self, op: &EconomicsOp, current_epoch: u64) -> Result<(), EconomicsError> {
+    ///
+    /// # Arguments
+    ///
+    /// * `op` — The economics operation to apply
+    /// * `current_epoch` — The current epoch number
+    /// * `event_creator` — Optional public key of the entity that created this event,
+    ///   used for admin gating of sensitive operations like `SubmitWork`
+    pub fn apply(
+        &mut self,
+        op: &EconomicsOp,
+        current_epoch: u64,
+        event_creator: Option<&[u8; 32]>,
+    ) -> Result<(), EconomicsError> {
         match op {
             EconomicsOp::MintUbc { did, amount } => {
                 if !self.quota.is_registered(did) {
@@ -122,6 +148,21 @@ impl EconomicsState {
             }
             EconomicsOp::SpendUbc { did, amount } => self.quota.spend(did, *amount),
             EconomicsOp::SubmitWork { did, proof } => {
+                // Gate work submission: only authorized submitters can mint UBC
+                // Until real ZK verification is implemented, require admin authorization
+                // when admin_keys is configured.
+                if !self.admin_keys.is_empty() {
+                    let submitter = event_creator.ok_or_else(|| {
+                        EconomicsError::ValidationFailed(
+                            "SubmitWork requires authenticated event creator".into(),
+                        )
+                    })?;
+                    if !self.is_admin(submitter) {
+                        return Err(EconomicsError::ValidationFailed(
+                            "SubmitWork is currently restricted to admin keys until real ZK verification is implemented".into(),
+                        ));
+                    }
+                }
                 proof.validate()?;
                 self.verified_work.insert(proof.result_hash, proof.clone());
                 let reward = proof.reward_amount();

--- a/economics/src/economics_shard.rs
+++ b/economics/src/economics_shard.rs
@@ -153,9 +153,7 @@ impl EconomicsState {
                 // when admin_keys is configured.
                 if !self.admin_keys.is_empty() {
                     let submitter = event_creator.ok_or_else(|| {
-                        EconomicsError::ValidationFailed(
-                            "SubmitWork requires authenticated event creator".into(),
-                        )
+                        EconomicsError::ValidationFailed("SubmitWork requires authenticated event creator".into())
                     })?;
                     if !self.is_admin(submitter) {
                         return Err(EconomicsError::ValidationFailed(

--- a/economics/src/error.rs
+++ b/economics/src/error.rs
@@ -72,4 +72,8 @@ pub enum EconomicsError {
     /// The DID has already voted on this proposal.
     #[error("Duplicate vote on proposal {0}")]
     DuplicateVote(String),
+
+    /// A validation check failed (e.g., unauthorized operation).
+    #[error("Validation failed: {0}")]
+    ValidationFailed(String),
 }

--- a/economics/src/fixed_point.rs
+++ b/economics/src/fixed_point.rs
@@ -77,11 +77,11 @@ impl DecayRate {
     /// ```
     pub fn new(ppm: u64) -> Self {
         if ppm > BASIS_PPM {
-            tracing::warn!(
-                "DecayRate::new({}) clamped to maximum {}", ppm, BASIS_PPM
-            );
+            tracing::warn!("DecayRate::new({}) clamped to maximum {}", ppm, BASIS_PPM);
         }
-        Self { ppm: ppm.min(BASIS_PPM) }
+        Self {
+            ppm: ppm.min(BASIS_PPM),
+        }
     }
 
     /// Convenience constructor for the standard 10% decay rate.

--- a/economics/src/fixed_point.rs
+++ b/economics/src/fixed_point.rs
@@ -76,9 +76,12 @@ impl DecayRate {
     /// assert_eq!(clamped.ppm(), BASIS_PPM); // Clamped to 100%
     /// ```
     pub fn new(ppm: u64) -> Self {
-        Self {
-            ppm: ppm.min(BASIS_PPM),
+        if ppm > BASIS_PPM {
+            tracing::warn!(
+                "DecayRate::new({}) clamped to maximum {}", ppm, BASIS_PPM
+            );
         }
+        Self { ppm: ppm.min(BASIS_PPM) }
     }
 
     /// Convenience constructor for the standard 10% decay rate.
@@ -108,7 +111,7 @@ impl DecayRate {
     /// assert_eq!(rate.ppm(), 100_000);
     /// ```
     pub fn from_percent(percent: u64) -> Self {
-        Self::new(percent * 10_000)
+        Self::new(percent.saturating_mul(10_000))
     }
 
     /// Return the PPM value of this decay rate.

--- a/economics/src/governance.rs
+++ b/economics/src/governance.rs
@@ -421,11 +421,11 @@ impl GovernanceState {
             .map(|(id, _)| id.clone())
             .collect();
 
-        let count = expired_ids.len();
-        for id in expired_ids {
-            self.proposals.remove(&id);
+        self.proposals.retain(|_, p| !p.is_expired(current_epoch));
+        for id in &expired_ids {
+            self.voted.retain(|key, _| !key.0.eq(id));
         }
-        count
+        expired_ids.len()
     }
 
     /// Serialize the governance state to bytes.

--- a/economics/src/quota.rs
+++ b/economics/src/quota.rs
@@ -68,7 +68,7 @@ impl QuotaSystem {
     /// quota. Unspent balance from the previous epoch is forfeited
     /// to prevent hoarding.
     pub fn advance_epoch(&mut self) {
-        self.current_epoch += 1;
+        self.current_epoch = self.current_epoch.saturating_add(1);
         for token in self.tokens.values_mut() {
             token.mint_monthly(self.current_epoch);
         }

--- a/economics/src/useful_work.rs
+++ b/economics/src/useful_work.rs
@@ -135,12 +135,16 @@ impl UsefulWorkProof {
         Ok(())
     }
 
+    /// Maximum UBC reward per work proof
+    pub const MAX_REWARD_PER_PROOF: u64 = 1_000_000;
+
     /// Calculate the UBC reward for this work.
     ///
     /// The reward is proportional to the compute units consumed,
-    /// at a 1:1 ratio (1 UBC per compute unit). This ratio may
-    /// be governed by a future on-chain parameter.
+    /// at a 1:1 ratio (1 UBC per compute unit), capped at
+    /// [`MAX_REWARD_PER_PROOF`]. This ratio may be governed by a
+    /// future on-chain parameter.
     pub fn reward_amount(&self) -> u64 {
-        self.compute_units_consumed
+        self.compute_units_consumed.min(Self::MAX_REWARD_PER_PROOF)
     }
 }

--- a/economics/src/useful_work.rs
+++ b/economics/src/useful_work.rs
@@ -142,7 +142,7 @@ impl UsefulWorkProof {
     ///
     /// The reward is proportional to the compute units consumed,
     /// at a 1:1 ratio (1 UBC per compute unit), capped at
-    /// [`MAX_REWARD_PER_PROOF`]. This ratio may be governed by a
+    /// [`UsefulWorkProof::MAX_REWARD_PER_PROOF`]. This ratio may be governed by a
     /// future on-chain parameter.
     pub fn reward_amount(&self) -> u64 {
         self.compute_units_consumed.min(Self::MAX_REWARD_PER_PROOF)

--- a/economics/tests/ubc_lifecycle.rs
+++ b/economics/tests/ubc_lifecycle.rs
@@ -268,6 +268,7 @@ fn test_economics_state_full_lifecycle() {
                 did: "did:omnia:alice".into(),
             },
             epoch,
+            None,
         )
         .unwrap();
     state
@@ -276,6 +277,7 @@ fn test_economics_state_full_lifecycle() {
                 did: "did:omnia:bob".into(),
             },
             epoch,
+            None,
         )
         .unwrap();
 
@@ -290,6 +292,7 @@ fn test_economics_state_full_lifecycle() {
                 amount: 300,
             },
             epoch,
+            None,
         )
         .unwrap();
     assert_eq!(state.balance_of("did:omnia:alice"), Some(DEFAULT_UBC_QUOTA - 300));
@@ -311,12 +314,13 @@ fn test_economics_state_full_lifecycle() {
                 proof,
             },
             epoch,
+            None,
         )
         .unwrap();
     assert_eq!(state.balance_of("did:omnia:alice"), Some(DEFAULT_UBC_QUOTA - 300 + 500));
 
     // Step 4: Advance epoch — balances reset
-    state.apply(&EconomicsOp::AdvanceEpoch, 0).unwrap();
+    state.apply(&EconomicsOp::AdvanceEpoch, 0, None).unwrap();
     assert_eq!(state.current_epoch(), 1);
     assert_eq!(state.balance_of("did:omnia:alice"), Some(DEFAULT_UBC_QUOTA));
     assert_eq!(state.balance_of("did:omnia:bob"), Some(DEFAULT_UBC_QUOTA));
@@ -330,6 +334,7 @@ fn test_economics_state_full_lifecycle() {
                 expires_at_epoch: 5,
             },
             1,
+            None,
         )
         .unwrap();
 
@@ -348,6 +353,7 @@ fn test_economics_state_full_lifecycle() {
                 choice: VoteChoice::For,
             },
             1,
+            None,
         )
         .unwrap();
 
@@ -359,6 +365,7 @@ fn test_economics_state_full_lifecycle() {
                 choice: VoteChoice::Against,
             },
             1,
+            None,
         )
         .unwrap();
 
@@ -377,6 +384,7 @@ fn test_economics_serialization_roundtrip() {
                 did: "did:omnia:alice".into(),
             },
             0,
+            None,
         )
         .unwrap();
     state
@@ -386,6 +394,7 @@ fn test_economics_serialization_roundtrip() {
                 amount: 100,
             },
             0,
+            None,
         )
         .unwrap();
 

--- a/fuzz/fuzz_targets/causal_graph_insert.rs
+++ b/fuzz/fuzz_targets/causal_graph_insert.rs
@@ -12,12 +12,12 @@ fuzz_target!(|data: &[u8]| {
     let payload = data[64..].to_vec();
     let clock = VectorClock::new();
     // Genesis event (no parents required)
-    let event = Event::genesis(creator, payload);
+    let event = Event::genesis(creator, payload).unwrap();
     let mut graph = CausalGraph::new();
     let _ = graph.insert(event);
     // Try inserting a second event that links to the first
     if let Some(first_id) = graph.event_ids().first().copied() {
-        let event2 = Event::new(creator, 1, clock, Some(first_id), None, data[32..64].to_vec());
+        let event2 = Event::new(creator, 1, clock, Some(first_id), None, data[32..64].to_vec()).unwrap();
         let _ = graph.insert(event2);
     }
 });

--- a/fuzz/fuzz_targets/event_validate.rs
+++ b/fuzz/fuzz_targets/event_validate.rs
@@ -11,11 +11,11 @@ fuzz_target!(|data: &[u8]| {
     let payload = data[64..].to_vec();
     let clock = VectorClock::new();
     // Genesis event
-    let event = Event::genesis(creator, payload);
+    let event = Event::genesis(creator, payload).unwrap();
     let _ = event.validate();
     // Event with parents
     let mut self_parent = [0u8; 32];
     self_parent.copy_from_slice(&data[32..64]);
-    let event2 = Event::new(creator, 1, clock, Some(self_parent), None, data[0..32].to_vec());
+    let event2 = Event::new(creator, 1, clock, Some(self_parent), None, data[0..32].to_vec()).unwrap();
     let _ = event2.validate();
 });

--- a/fuzz/fuzz_targets/shard_route.rs
+++ b/fuzz/fuzz_targets/shard_route.rs
@@ -12,7 +12,7 @@ fuzz_target!(|data: &[u8]| {
     creator.copy_from_slice(&data[0..32]);
     let payload = data[64..].to_vec();
     let _clock = VectorClock::new();
-    let event = Event::genesis(creator, payload);
+    let event = Event::genesis(creator, payload).unwrap();
     // route_event deserializes the payload as ShardPayload,
     // so fuzzing with arbitrary bytes will exercise error paths
     let mut router = router;

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -64,6 +64,9 @@ aes-gcm = "0.10"
 # BLAKE3 hash for key derivation from passphrase
 blake3 = "1.5"
 
+# Secure memory zeroization for key material cleanup
+zeroize = { version = "1", features = ["derive"] }
+
 # Cryptographic random number generation for nonce generation
 rand = "0.8"
 

--- a/node/src/api/auth.rs
+++ b/node/src/api/auth.rs
@@ -13,9 +13,11 @@
 //! | `OMNIA_JWT_SECRET`        | HMAC-SHA256 secret for signing/verifying   | *(required for JWT ops)* |
 //! | `OMNIA_AUTHORIZED_CALLERS` | Comma-separated list of caller IDs         | *(empty — no privileged callers)* |
 //! | `OMNIA_RATE_LIMIT_RPS`    | Max requests per second per client         | `10`                     |
+//! | `OMNIA_CORS_ORIGINS`      | Comma-separated allowed origins (or `*`)   | `*` (all origins)        |
 
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
+use std::sync::OnceLock;
 use std::time::Instant;
 
 use axum::extract::Request;
@@ -24,8 +26,10 @@ use axum::http::StatusCode;
 use axum::middleware::Next;
 use axum::response::{IntoResponse, Response};
 use axum::Extension;
+use axum::Json;
 use jsonwebtoken::{decode, encode, DecodingKey, EncodingKey, Header, Validation};
 use serde::{Deserialize, Serialize};
+use serde_json::json;
 use thiserror::Error;
 use tokio::sync::Mutex;
 use tower_http::cors::CorsLayer;
@@ -169,11 +173,31 @@ pub struct CallerIdentity {
 // JWT helpers
 // ---------------------------------------------------------------------------
 
+/// Global OnceLock for the JWT signing secret.
+///
+/// Caches the `OMNIA_JWT_SECRET` environment variable on first access
+/// so that every subsequent call avoids the `std::env::var` overhead
+/// and, more importantly, ensures a consistent value throughout the
+/// process lifetime (even if the env var is changed externally).
+static JWT_SECRET: OnceLock<Option<String>> = OnceLock::new();
+
+/// Initialise the JWT secret cache. Called once at application startup.
+///
+/// This must be invoked before any request hits the auth middleware so
+/// that the secret is captured from the environment at a deterministic
+/// point. Subsequent calls are no-ops (the OnceLock is already set).
+pub fn init_jwt_secret() {
+    JWT_SECRET.get_or_init(|| std::env::var("OMNIA_JWT_SECRET").ok());
+}
+
 /// Read the JWT signing secret from the `OMNIA_JWT_SECRET` env var.
 ///
-/// Returns `None` if the variable is not set.
+/// Returns `None` if the variable is not set. The value is cached in a
+/// `OnceLock` so that it is read at most once per process lifetime.
 fn jwt_secret() -> Option<String> {
-    std::env::var("OMNIA_JWT_SECRET").ok()
+    JWT_SECRET
+        .get_or_init(|| std::env::var("OMNIA_JWT_SECRET").ok())
+        .clone()
 }
 
 /// Create a signed JWT for the given caller identity.
@@ -239,23 +263,26 @@ fn epoch_secs() -> u64 {
 /// On success the decoded [`CallerIdentity`] is stored in request extensions
 /// so handlers can retrieve it with `req.extensions().get::<CallerIdentity>()`.
 ///
-/// If `OMNIA_JWT_SECRET` is not set, the middleware **passes through** without
-/// authentication, inserting a default anonymous caller identity. This allows
-/// development and testing without JWT configuration while ensuring that
-/// production deployments (where the secret is set) enforce authentication.
+/// If `OMNIA_JWT_SECRET` is not set, the middleware **rejects the request**
+/// with 503 Service Unavailable instead of silently bypassing authentication.
+/// This prevents a critical auth bypass in production when the environment
+/// variable is accidentally unset.
 ///
 /// On failure an appropriate HTTP error response is returned immediately.
 pub async fn require_auth(mut req: Request, next: Next) -> Response {
-    // If no JWT secret is configured, skip authentication and use an
-    // anonymous identity. This keeps the API usable in development and
-    // testing without requiring JWT setup.
+    // If no JWT secret is configured, reject the request instead of
+    // silently bypassing authentication. This prevents a critical auth
+    // bypass in production when OMNIA_JWT_SECRET is accidentally unset.
     let secret = match jwt_secret() {
         Some(s) => s,
         None => {
-            req.extensions_mut().insert(CallerIdentity {
-                caller_id: "__anonymous__".to_string(),
-            });
-            return next.run(req).await;
+            // Reject all requests when JWT secret is not configured
+            // This prevents silent auth bypass in production
+            tracing::error!("OMNIA_JWT_SECRET not set - rejecting authenticated request");
+            return (StatusCode::SERVICE_UNAVAILABLE, Json(json!({
+                "error": "authentication not configured",
+                "message": "OMNIA_JWT_SECRET environment variable must be set"
+            }))).into_response();
         }
     };
 
@@ -322,6 +349,16 @@ pub fn require_privileged(
 // Token-bucket rate limiter
 // ---------------------------------------------------------------------------
 
+/// A single token bucket for one client, with last-access tracking
+/// for stale-bucket eviction.
+#[derive(Debug)]
+struct TrackedBucket {
+    /// The underlying token bucket.
+    bucket: Bucket,
+    /// Timestamp of the last access (consume or refill check).
+    last_access: Instant,
+}
+
 /// A single token bucket for one client.
 #[derive(Debug)]
 struct Bucket {
@@ -364,14 +401,18 @@ impl Bucket {
     }
 }
 
-/// Per-client token-bucket rate limiter.
+/// Per-client token-bucket rate limiter with stale-bucket eviction.
 ///
 /// Each distinct client key (typically an IP address) gets its own bucket.
 /// Buckets are lazily created on first request and refilled over time.
+///
+/// Stale buckets (no access for > 1 hour) are evicted when the total
+/// number of buckets exceeds 1 000, preventing unbounded memory growth
+/// from clients that connect once and never return.
 #[derive(Debug)]
 pub struct RateLimiter {
-    /// Map from client key to its token bucket.
-    buckets: Mutex<HashMap<String, Bucket>>,
+    /// Map from client key to its tracked token bucket.
+    buckets: Mutex<HashMap<String, TrackedBucket>>,
     /// Maximum burst size (tokens per bucket).
     max_tokens: f64,
     /// Sustained refill rate in tokens per second.
@@ -406,24 +447,47 @@ impl RateLimiter {
         Self::new(rps * 2, rps)
     }
 
+    /// Evict buckets that have not been accessed for over 1 hour.
+    ///
+    /// This prevents unbounded memory growth from one-off clients.
+    fn evict_stale_buckets(buckets: &mut HashMap<String, TrackedBucket>) {
+        let stale_threshold = std::time::Duration::from_secs(3600); // 1 hour
+        buckets.retain(|_, tb| tb.last_access.elapsed() < stale_threshold);
+    }
+
     /// Attempt to consume one token for the given client key.
     ///
     /// Returns `true` if the request should be allowed, `false` if the
     /// rate limit has been exceeded.
     pub async fn try_consume(&self, client_key: &str) -> bool {
         let mut buckets = self.buckets.lock().await;
-        let bucket = buckets
+
+        // Evict stale buckets periodically to prevent unbounded memory growth
+        if buckets.len() > 1000 {
+            Self::evict_stale_buckets(&mut buckets);
+        }
+
+        let tb = buckets
             .entry(client_key.to_string())
-            .or_insert_with(|| Bucket::new(self.max_tokens, self.refill_rate));
-        bucket.try_consume()
+            .or_insert_with(|| TrackedBucket {
+                bucket: Bucket::new(self.max_tokens, self.refill_rate),
+                last_access: Instant::now(),
+            });
+        tb.last_access = Instant::now();
+        tb.bucket.try_consume()
     }
 }
 
 /// Axum middleware that enforces per-client rate limiting.
 ///
-/// The client key is derived from the `X-Forwarded-For` or `X-Real-IP`
-/// header (set by a reverse proxy), falling back to `"__default__"` when
-/// neither header is present.
+/// The client key is derived (in priority order) from:
+/// 1. The actual peer IP from `ConnectInfo<SocketAddr>` (when available)
+/// 2. The `X-Real-IP` header (set by a trusted reverse proxy)
+/// 3. The fallback key `"unauthenticated"`
+///
+/// **Note**: `X-Forwarded-For` is intentionally **not** used because it can
+/// be spoofed by clients, causing all malicious requests to share a single
+/// rate-limit bucket and bypass per-client limits.
 ///
 /// The [`RateLimiter`] must be provided via an `Extension` layer.
 ///
@@ -433,16 +497,21 @@ pub async fn rate_limit_middleware(
     req: Request,
     next: Next,
 ) -> Response {
+    // Try to get actual peer IP from connection info first.
+    // Fallback to X-Real-IP (more reliable than X-Forwarded-For).
+    // Do NOT trust X-Forwarded-For from untrusted sources as it can be
+    // spoofed, causing all requests to share a single rate-limit bucket.
     let client_key = req
-        .headers()
-        .get("x-forwarded-for")
-        .or_else(|| req.headers().get("x-real-ip"))
-        .and_then(|v| v.to_str().ok())
-        .map(|s| {
-            // X-Forwarded-For may contain multiple IPs; use the first one.
-            s.split(',').next().unwrap_or(s).trim().to_string()
+        .extensions()
+        .get::<axum::extract::ConnectInfo<std::net::SocketAddr>>()
+        .map(|ci| ci.0.ip().to_string())
+        .or_else(|| {
+            req.headers()
+                .get("x-real-ip")
+                .and_then(|v| v.to_str().ok())
+                .map(|s| s.trim().to_string())
         })
-        .unwrap_or_else(|| "__default__".to_string());
+        .unwrap_or_else(|| "unauthenticated".to_string());
 
     if limiter.try_consume(&client_key).await {
         next.run(req).await
@@ -455,23 +524,50 @@ pub async fn rate_limit_middleware(
 // CORS helper
 // ---------------------------------------------------------------------------
 
-/// Build a sensible default [`CorsLayer`] for the Omnia REST API.
+/// Build a [`CorsLayer`] for the Omnia REST API, configurable via the
+/// `OMNIA_CORS_ORIGINS` environment variable.
+///
+/// - When `OMNIA_CORS_ORIGINS` is set to `*` (or unset), all origins are
+///   allowed **with a warning** — suitable only for development.
+/// - When set to a comma-separated list of origins (e.g.
+///   `https://app.example.com,https://admin.example.com`), only those
+///   origins are permitted.
 ///
 /// Defaults:
-/// - **Origins**: any (suitable for development; tighten for production)
 /// - **Methods**: `GET`, `POST`, `PUT`, `DELETE`
-/// - **Headers**: `Authorization`, `Content-Type`
+/// - **Headers**: any (via `tower_http::cors::Any`)
 /// - **Max age**: 1 hour
 pub fn default_cors_layer() -> CorsLayer {
-    CorsLayer::permissive()
-        .allow_methods([
-            axum::http::Method::GET,
-            axum::http::Method::POST,
-            axum::http::Method::PUT,
-            axum::http::Method::DELETE,
-        ])
-        .allow_headers([AUTHORIZATION, CONTENT_TYPE])
-        .max_age(std::time::Duration::from_secs(3600))
+    let allowed_origins = std::env::var("OMNIA_CORS_ORIGINS")
+        .unwrap_or_else(|_| "*".to_string());
+
+    if allowed_origins == "*" {
+        tracing::warn!("CORS allows all origins - not recommended for production");
+        CorsLayer::permissive()
+            .allow_methods([
+                axum::http::Method::GET,
+                axum::http::Method::POST,
+                axum::http::Method::PUT,
+                axum::http::Method::DELETE,
+            ])
+            .allow_headers([AUTHORIZATION, CONTENT_TYPE])
+            .max_age(std::time::Duration::from_secs(3600))
+    } else {
+        let origins: Vec<_> = allowed_origins
+            .split(',')
+            .filter_map(|o| o.trim().parse().ok())
+            .collect();
+        CorsLayer::new()
+            .allow_origin(origins)
+            .allow_methods([
+                axum::http::Method::GET,
+                axum::http::Method::POST,
+                axum::http::Method::PUT,
+                axum::http::Method::DELETE,
+            ])
+            .allow_headers(tower_http::cors::Any)
+            .max_age(std::time::Duration::from_secs(3600))
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/node/src/api/auth.rs
+++ b/node/src/api/auth.rs
@@ -17,7 +17,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
-use std::sync::OnceLock;
+use std::sync::Mutex as StdMutex;
 use std::time::Instant;
 
 use axum::extract::Request;
@@ -173,31 +173,53 @@ pub struct CallerIdentity {
 // JWT helpers
 // ---------------------------------------------------------------------------
 
-/// Global OnceLock for the JWT signing secret.
+/// Global cache for the JWT signing secret.
 ///
-/// Caches the `OMNIA_JWT_SECRET` environment variable on first access
-/// so that every subsequent call avoids the `std::env::var` overhead
-/// and, more importantly, ensures a consistent value throughout the
-/// process lifetime (even if the env var is changed externally).
-static JWT_SECRET: OnceLock<Option<String>> = OnceLock::new();
+/// `None` means the cache has not been populated yet; `Some(inner)` holds
+/// the cached result of reading `OMNIA_JWT_SECRET` (where `inner` is
+/// `None` if the env var is unset). The cache persists for the process
+/// lifetime but can be reset in tests via [`reset_jwt_secret_for_test`].
+static JWT_SECRET: StdMutex<Option<Option<String>>> = StdMutex::new(None);
 
 /// Initialise the JWT secret cache. Called once at application startup.
 ///
 /// This must be invoked before any request hits the auth middleware so
 /// that the secret is captured from the environment at a deterministic
-/// point. Subsequent calls are no-ops (the OnceLock is already set).
+/// point. Subsequent calls are no-ops if the cache is already populated.
 pub fn init_jwt_secret() {
-    JWT_SECRET.get_or_init(|| std::env::var("OMNIA_JWT_SECRET").ok());
+    let mut guard = JWT_SECRET.lock().unwrap_or_else(|e| e.into_inner());
+    if guard.is_none() {
+        *guard = Some(std::env::var("OMNIA_JWT_SECRET").ok());
+    }
 }
 
 /// Read the JWT signing secret from the `OMNIA_JWT_SECRET` env var.
 ///
-/// Returns `None` if the variable is not set. The value is cached in a
-/// `OnceLock` so that it is read at most once per process lifetime.
+/// Returns `None` if the variable is not set. The value is cached so
+/// that it is read at most once per process lifetime (unless explicitly
+/// reset via [`reset_jwt_secret_for_test`] in test code).
 fn jwt_secret() -> Option<String> {
-    JWT_SECRET
-        .get_or_init(|| std::env::var("OMNIA_JWT_SECRET").ok())
-        .clone()
+    let mut guard = JWT_SECRET.lock().unwrap_or_else(|e| e.into_inner());
+    match &*guard {
+        Some(cached) => cached.clone(),
+        None => {
+            let val = std::env::var("OMNIA_JWT_SECRET").ok();
+            *guard = Some(val.clone());
+            val
+        }
+    }
+}
+
+/// Reset the JWT secret cache so the env var will be re-read on next access.
+///
+/// Only available in test builds. Necessary because `OnceLock` (or any
+/// caching mechanism) persists across test functions within the same
+/// process, and some tests need to verify behaviour when the env var is
+/// unset.
+#[cfg(test)]
+fn reset_jwt_secret_for_test() {
+    let mut guard = JWT_SECRET.lock().unwrap_or_else(|e| e.into_inner());
+    *guard = None;
 }
 
 /// Create a signed JWT for the given caller identity.
@@ -279,10 +301,14 @@ pub async fn require_auth(mut req: Request, next: Next) -> Response {
             // Reject all requests when JWT secret is not configured
             // This prevents silent auth bypass in production
             tracing::error!("OMNIA_JWT_SECRET not set - rejecting authenticated request");
-            return (StatusCode::SERVICE_UNAVAILABLE, Json(json!({
-                "error": "authentication not configured",
-                "message": "OMNIA_JWT_SECRET environment variable must be set"
-            }))).into_response();
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(json!({
+                    "error": "authentication not configured",
+                    "message": "OMNIA_JWT_SECRET environment variable must be set"
+                })),
+            )
+                .into_response();
         }
     };
 
@@ -467,12 +493,10 @@ impl RateLimiter {
             Self::evict_stale_buckets(&mut buckets);
         }
 
-        let tb = buckets
-            .entry(client_key.to_string())
-            .or_insert_with(|| TrackedBucket {
-                bucket: Bucket::new(self.max_tokens, self.refill_rate),
-                last_access: Instant::now(),
-            });
+        let tb = buckets.entry(client_key.to_string()).or_insert_with(|| TrackedBucket {
+            bucket: Bucket::new(self.max_tokens, self.refill_rate),
+            last_access: Instant::now(),
+        });
         tb.last_access = Instant::now();
         tb.bucket.try_consume()
     }
@@ -538,8 +562,7 @@ pub async fn rate_limit_middleware(
 /// - **Headers**: any (via `tower_http::cors::Any`)
 /// - **Max age**: 1 hour
 pub fn default_cors_layer() -> CorsLayer {
-    let allowed_origins = std::env::var("OMNIA_CORS_ORIGINS")
-        .unwrap_or_else(|_| "*".to_string());
+    let allowed_origins = std::env::var("OMNIA_CORS_ORIGINS").unwrap_or_else(|_| "*".to_string());
 
     if allowed_origins == "*" {
         tracing::warn!("CORS allows all origins - not recommended for production");
@@ -610,12 +633,14 @@ mod tests {
     fn test_create_and_validate_token() {
         // Hold the lock for the entire test so no other test touches the
         // JWT_SECRET env var while we depend on it.
-        let _lock = JWT_SECRET_LOCK.lock().expect("JWT_SECRET_LOCK poisoned");
+        let _lock = JWT_SECRET_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        reset_jwt_secret_for_test();
         std::env::set_var("OMNIA_JWT_SECRET", "test-secret-key");
         let token = create_token("caller-42", 3600).expect("create token");
         let claims = validate_token(&token).expect("validate token");
         assert_eq!(claims.sub, "caller-42");
         std::env::remove_var("OMNIA_JWT_SECRET");
+        reset_jwt_secret_for_test();
     }
 
     #[test]
@@ -643,24 +668,28 @@ mod tests {
 
     #[test]
     fn test_create_token_no_secret() {
-        let _lock = JWT_SECRET_LOCK.lock().expect("JWT_SECRET_LOCK poisoned");
+        let _lock = JWT_SECRET_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         // Remove the var if it was set by a previous test, then verify
         // that create_token returns SecretNotConfigured.
         std::env::remove_var("OMNIA_JWT_SECRET");
+        reset_jwt_secret_for_test();
         let result = create_token("caller-42", 3600);
         assert!(
             matches!(result, Err(AuthError::SecretNotConfigured)),
             "Expected SecretNotConfigured when OMNIA_JWT_SECRET is unset"
         );
+        reset_jwt_secret_for_test();
     }
 
     #[test]
     fn test_validate_invalid_token() {
-        let _lock = JWT_SECRET_LOCK.lock().expect("JWT_SECRET_LOCK poisoned");
+        let _lock = JWT_SECRET_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         std::env::set_var("OMNIA_JWT_SECRET", "test-secret-key");
+        reset_jwt_secret_for_test();
         let result = validate_token("not.a.valid-token");
         assert!(matches!(result, Err(AuthError::InvalidToken(_))));
         std::env::remove_var("OMNIA_JWT_SECRET");
+        reset_jwt_secret_for_test();
     }
 
     #[tokio::test]

--- a/node/src/api/events.rs
+++ b/node/src/api/events.rs
@@ -103,8 +103,12 @@ pub async fn submit_event(
 
     // Create and sign a substrate event
     let keypair = generate_keypair();
-    let mut event = Event::genesis(node_id, payload_bytes.clone())
-        .map_err(|e| (StatusCode::BAD_REQUEST, Json(json!({"error": format!("Invalid event: {e}")}))))?;
+    let mut event = Event::genesis(node_id, payload_bytes.clone()).map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"error": format!("Invalid event: {e}")})),
+        )
+    })?;
     event.sign_with_keypair(&keypair);
 
     let event_id_hex = hex::encode(event.id);

--- a/node/src/api/events.rs
+++ b/node/src/api/events.rs
@@ -103,7 +103,8 @@ pub async fn submit_event(
 
     // Create and sign a substrate event
     let keypair = generate_keypair();
-    let mut event = Event::genesis(node_id, payload_bytes.clone());
+    let mut event = Event::genesis(node_id, payload_bytes.clone())
+        .map_err(|e| (StatusCode::BAD_REQUEST, Json(json!({"error": format!("Invalid event: {e}")}))))?;
     event.sign_with_keypair(&keypair);
 
     let event_id_hex = hex::encode(event.id);

--- a/node/src/api/governance.rs
+++ b/node/src/api/governance.rs
@@ -6,6 +6,7 @@
 
 use axum::extract::State;
 use axum::http::StatusCode;
+use axum::Extension;
 use axum::Json;
 use omnia_economics::governance::VoteChoice;
 use serde::Deserialize;
@@ -13,6 +14,7 @@ use serde_json::{json, Value};
 use thiserror::Error;
 use utoipa::ToSchema;
 
+use crate::api::auth::CallerIdentity;
 use crate::state::AppState;
 
 /// Errors that can occur when parsing API request parameters.
@@ -120,6 +122,10 @@ pub async fn create_proposal(
 /// Casts a quadratic-weighted vote on a governance proposal.
 /// The voter's effective weight is calculated based on their stake
 /// (via `isqrt`) and reputation decay for inactive epochs.
+///
+/// The voter DID is derived from the authenticated caller identity
+/// (via the JWT `sub` claim) rather than from the request body,
+/// preventing impersonation attacks.
 #[utoipa::path(
     post,
     path = "/api/v1/governance/vote",
@@ -127,19 +133,26 @@ pub async fn create_proposal(
     responses(
         (status = 200, description = "Vote recorded"),
         (status = 400, description = "Invalid vote"),
+        (status = 401, description = "Not authenticated"),
     )
 )]
 pub async fn cast_vote(
     State(state): State<AppState>,
+    caller: Extension<CallerIdentity>,
     Json(body): Json<CastVoteRequest>,
 ) -> Result<(StatusCode, Json<Value>), (StatusCode, Json<Value>)> {
+    // Derive the voter DID from the authenticated caller identity
+    // instead of trusting the `did` field in the request body.
+    // This prevents impersonation — a caller cannot vote as someone else.
+    let voter_did = caller.caller_id.clone();
+
     let choice = parse_vote_choice(&body.choice).map_err(|e| (StatusCode::BAD_REQUEST, Json(json!({"error": e}))))?;
 
     let mut economics = state.economics.lock().await;
     let current_epoch = economics.current_epoch();
 
     // Reject votes from voters with no registered stake
-    if !economics.governance.voting_weights.contains_key(&body.did) {
+    if !economics.governance.voting_weights.contains_key(&voter_did) {
         return Err((
             StatusCode::BAD_REQUEST,
             Json(serde_json::json!({
@@ -148,16 +161,16 @@ pub async fn cast_vote(
         ));
     }
 
-    let effective_weight = economics.governance.effective_weight(&body.did, current_epoch);
+    let effective_weight = economics.governance.effective_weight(&voter_did, current_epoch);
 
     let result = economics
         .governance
-        .vote(&body.did, &body.proposal_id, choice, current_epoch);
+        .vote(&voter_did, &body.proposal_id, choice, current_epoch);
 
     match result {
         Ok(()) => {
             tracing::info!(
-                did = %body.did,
+                did = %voter_did,
                 proposal_id = %body.proposal_id,
                 choice = %body.choice,
                 weight = effective_weight,
@@ -168,7 +181,7 @@ pub async fn cast_vote(
                 Json(json!({
                     "status": "recorded",
                     "proposal_id": body.proposal_id,
-                    "did": body.did,
+                    "did": voter_did,
                     "choice": body.choice,
                     "effective_weight": effective_weight,
                     "epoch": current_epoch,
@@ -177,7 +190,7 @@ pub async fn cast_vote(
         }
         Err(e) => {
             tracing::warn!(
-                did = %body.did,
+                did = %voter_did,
                 proposal_id = %body.proposal_id,
                 error = %e,
                 "Failed to cast vote"
@@ -187,7 +200,7 @@ pub async fn cast_vote(
                 Json(json!({
                     "error": format!("Failed to cast vote: {e}"),
                     "proposal_id": body.proposal_id,
-                    "did": body.did,
+                    "did": voter_did,
                 })),
             ))
         }

--- a/node/src/api/mod.rs
+++ b/node/src/api/mod.rs
@@ -22,6 +22,7 @@ pub mod shards;
 
 use std::sync::Arc;
 
+use axum::extract::DefaultBodyLimit;
 use axum::middleware;
 use axum::routing::{get, post};
 use axum::Extension;
@@ -125,4 +126,7 @@ pub fn build_api_router_with(authorized: Arc<AuthorizedCallers>) -> Router<AppSt
         .layer(Extension(authorized))
         // JWT authentication — validates Bearer token and inserts CallerIdentity
         .layer(middleware::from_fn(api_auth::require_auth))
+        // Body size limit — reject oversized request bodies (10 MiB)
+        // to prevent DoS via memory exhaustion
+        .layer(DefaultBodyLimit::max(10 * 1024 * 1024))
 }

--- a/node/src/api/shards.rs
+++ b/node/src/api/shards.rs
@@ -128,8 +128,12 @@ async fn handle_economics_op(
 
     let node_id = state.config.node_id_bytes();
     let keypair = generate_keypair();
-    let mut event = Event::genesis(node_id, Vec::new())
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({"error": format!("Invalid event: {e}")}))))?;
+    let mut event = Event::genesis(node_id, Vec::new()).map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({"error": format!("Invalid event: {e}")})),
+        )
+    })?;
     event.sign_with_keypair(&keypair);
 
     let shard_op = ShardOp::Economics(econ_op);

--- a/node/src/api/shards.rs
+++ b/node/src/api/shards.rs
@@ -128,7 +128,8 @@ async fn handle_economics_op(
 
     let node_id = state.config.node_id_bytes();
     let keypair = generate_keypair();
-    let mut event = Event::genesis(node_id, Vec::new());
+    let mut event = Event::genesis(node_id, Vec::new())
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({"error": format!("Invalid event: {e}")}))))?;
     event.sign_with_keypair(&keypair);
 
     let shard_op = ShardOp::Economics(econ_op);

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -130,6 +130,10 @@ async fn main() -> Result<()> {
     // 2. Initialize tracing with the configured log level
     init_tracing(&config.log_level);
 
+    // 2b. Initialize the JWT secret cache from the environment.
+    // This must happen before any request hits the auth middleware.
+    omnia_node::api::auth::init_jwt_secret();
+
     tracing::info!(
         node_id = config.node_id,
         http_port = config.http_port,
@@ -352,7 +356,11 @@ async fn spawn_background_tasks(
                     break;
                 }
                 Some(work) = hot_rx.recv() => {
-                    tracing::trace!(event_len = work.event_bytes.len(), "Hot path: processing event validation");
+                    // TODO: Implement actual hot path event validation
+                    // Currently events are only processed via the direct submit_event API path.
+                    // The pipeline worker should validate event signatures, check graph
+                    // connectivity, and insert into the causal graph.
+                    tracing::debug!(event_len = work.event_bytes.len(), "Hot path: event received (pipeline worker not yet implemented)");
                 }
                 else => {
                     tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
@@ -372,7 +380,11 @@ async fn spawn_background_tasks(
                     break;
                 }
                 Some(work) = warm_rx.recv() => {
-                    tracing::trace!(event_id = ?&work.event_id[..4], "Warm path: processing consensus/shards");
+                    // TODO: Implement actual warm path consensus/shard processing
+                    // Currently events are only processed via the direct submit_event API path.
+                    // The warm path should handle mempool insertion, shard routing,
+                    // and consensus round participation.
+                    tracing::debug!(event_id = ?&work.event_id[..4], "Warm path: event received (pipeline worker not yet implemented)");
                 }
                 else => {
                     tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
@@ -786,7 +798,7 @@ pub fn load_encrypted_key(path: &std::path::Path, passphrase: &str) -> Result<[u
     let nonce = Nonce::from_slice(nonce_bytes);
 
     // Decrypt — this also verifies the authentication tag
-    let plaintext = cipher
+    let mut plaintext = cipher
         .decrypt(nonce, ciphertext)
         .map_err(|_| anyhow::anyhow!("Decryption failed: wrong passphrase or corrupted file"))?;
 
@@ -799,6 +811,10 @@ pub fn load_encrypted_key(path: &std::path::Path, passphrase: &str) -> Result<[u
 
     let mut key_bytes = [0u8; 64];
     key_bytes.copy_from_slice(&plaintext);
+    // Zeroize the plaintext buffer after copying to prevent key material
+    // from lingering on the stack or heap after this function returns.
+    use zeroize::Zeroize;
+    plaintext.zeroize();
     Ok(key_bytes)
 }
 

--- a/node/tests/api_integration.rs
+++ b/node/tests/api_integration.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::unwrap_used)]
+#![allow(deprecated)]
 //! Comprehensive E2E REST API integration tests for the Omnia node.
 //!
 //! This test suite covers every API endpoint across all authentication

--- a/node/tests/integration.rs
+++ b/node/tests/integration.rs
@@ -7,6 +7,7 @@
 
 use anyhow::Result;
 use omnia_economics::EconomicsState;
+use omnia_node::api::auth::create_token;
 use omnia_node::config::NodeConfig;
 use omnia_node::http;
 use omnia_node::state::AppState;
@@ -25,12 +26,34 @@ use std::sync::Arc;
 use std::time::Instant;
 use tokio::sync::{Mutex, RwLock};
 
+/// JWT secret used for integration tests.
+const TEST_JWT_SECRET: &str = "test-integration-secret";
+
+/// RAII guard that removes env vars when dropped.
+struct EnvGuard {
+    keys: Vec<&'static str>,
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        for key in &self.keys {
+            std::env::remove_var(key);
+        }
+    }
+}
+
 /// Helper: start the node HTTP server on a random port and return
 /// the base URL and a shutdown handle.
 ///
 /// The server runs in a background tokio task and will be stopped
 /// when the shutdown handle is dropped.
-async fn start_test_server() -> (String, tokio::task::JoinHandle<()>) {
+async fn start_test_server() -> (String, tokio::task::JoinHandle<()>, EnvGuard) {
+    // Set JWT secret before building the router so auth middleware can read it
+    std::env::set_var("OMNIA_JWT_SECRET", TEST_JWT_SECRET);
+    let env_guard = EnvGuard {
+        keys: vec!["OMNIA_JWT_SECRET"],
+    };
+
     // Pick a random available port
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
         .await
@@ -106,12 +129,12 @@ async fn start_test_server() -> (String, tokio::task::JoinHandle<()>) {
     // Give the server a moment to start
     tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
 
-    (format!("http://127.0.0.1:{port}"), handle)
+    (format!("http://127.0.0.1:{port}"), handle, env_guard)
 }
 
 #[tokio::test]
 async fn test_health_endpoint() -> Result<()> {
-    let (base_url, _handle) = start_test_server().await;
+    let (base_url, _handle, _env_guard) = start_test_server().await;
 
     let client = reqwest::Client::new();
     let resp = client.get(format!("{base_url}/health")).send().await?;
@@ -128,7 +151,7 @@ async fn test_health_endpoint() -> Result<()> {
 #[tokio::test]
 #[cfg(feature = "metrics")]
 async fn test_metrics_endpoint() -> Result<()> {
-    let (base_url, _handle) = start_test_server().await;
+    let (base_url, _handle, _env_guard) = start_test_server().await;
 
     let client = reqwest::Client::new();
     let resp = client.get(format!("{base_url}/metrics")).send().await?;
@@ -150,7 +173,7 @@ async fn test_metrics_endpoint() -> Result<()> {
 #[tokio::test]
 #[cfg(not(feature = "metrics"))]
 async fn test_metrics_endpoint_disabled() -> Result<()> {
-    let (base_url, _handle) = start_test_server().await;
+    let (base_url, _handle, _env_guard) = start_test_server().await;
 
     let client = reqwest::Client::new();
     let resp = client.get(format!("{base_url}/metrics")).send().await?;
@@ -166,11 +189,13 @@ async fn test_metrics_endpoint_disabled() -> Result<()> {
 
 #[tokio::test]
 async fn test_submit_event() -> Result<()> {
-    let (base_url, _handle) = start_test_server().await;
+    let (base_url, _handle, _env_guard) = start_test_server().await;
 
+    let token = create_token("test-caller", 3600).expect("create test token");
     let client = reqwest::Client::new();
     let resp = client
         .post(format!("{base_url}/api/v1/events"))
+        .header("Authorization", format!("Bearer {token}"))
         .json(&json!({
             "payload": hex::encode(b"hello omnia"),
             "event_type": "test"
@@ -189,11 +214,13 @@ async fn test_submit_event() -> Result<()> {
 
 #[tokio::test]
 async fn test_get_event_not_found() -> Result<()> {
-    let (base_url, _handle) = start_test_server().await;
+    let (base_url, _handle, _env_guard) = start_test_server().await;
 
+    let token = create_token("test-caller", 3600).expect("create test token");
     let client = reqwest::Client::new();
     let resp = client
         .get(format!("{base_url}/api/v1/events/nonexistent"))
+        .header("Authorization", format!("Bearer {token}"))
         .send()
         .await?;
 
@@ -215,7 +242,7 @@ async fn test_get_event_not_found() -> Result<()> {
 #[tokio::test]
 #[cfg(feature = "swagger-ui")]
 async fn test_swagger_ui() -> Result<()> {
-    let (base_url, _handle) = start_test_server().await;
+    let (base_url, _handle, _env_guard) = start_test_server().await;
     let client = reqwest::Client::new();
     let resp = client.get(format!("{base_url}/swagger-ui/")).send().await?;
     assert_eq!(
@@ -230,7 +257,7 @@ async fn test_swagger_ui() -> Result<()> {
 #[tokio::test]
 #[cfg(not(feature = "swagger-ui"))]
 async fn test_swagger_ui_disabled() -> Result<()> {
-    let (base_url, _handle) = start_test_server().await;
+    let (base_url, _handle, _env_guard) = start_test_server().await;
     let client = reqwest::Client::new();
     let resp = client.get(format!("{base_url}/swagger-ui/")).send().await?;
     assert_eq!(resp.status(), 404, "Swagger UI should be 404 when feature disabled");
@@ -241,7 +268,7 @@ async fn test_swagger_ui_disabled() -> Result<()> {
 #[tokio::test]
 #[cfg(feature = "swagger-ui")]
 async fn test_openapi_json() -> Result<()> {
-    let (base_url, _handle) = start_test_server().await;
+    let (base_url, _handle, _env_guard) = start_test_server().await;
     let client = reqwest::Client::new();
     let resp = client.get(format!("{base_url}/api-docs/openapi.json")).send().await?;
     assert_eq!(
@@ -269,7 +296,7 @@ async fn test_openapi_json() -> Result<()> {
 #[tokio::test]
 #[cfg(not(feature = "swagger-ui"))]
 async fn test_openapi_json_disabled() -> Result<()> {
-    let (base_url, _handle) = start_test_server().await;
+    let (base_url, _handle, _env_guard) = start_test_server().await;
     let client = reqwest::Client::new();
     let resp = client.get(format!("{base_url}/api-docs/openapi.json")).send().await?;
     assert_eq!(resp.status(), 404, "OpenAPI JSON should be 404 when feature disabled");

--- a/node/tests/integration.rs
+++ b/node/tests/integration.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::unwrap_used)]
+#![allow(deprecated)]
 //! Integration tests for the Omnia node HTTP API
 //!
 //! These tests start the full HTTP server and verify that each

--- a/omnia-adapters/build.rs
+++ b/omnia-adapters/build.rs
@@ -48,7 +48,9 @@ fn main() {
     // symbols require `has_settlement_lib` as well.
     if std::path::Path::new("lib/libsettlement.a").exists() || std::path::Path::new("lib/settlement.lib").exists() {
         println!("cargo:rustc-cfg=has_settlement_lib");
-        println!("cargo:rustc-cfg=feature=\"settlement-ffi\"");
+        // REMOVED: Force-enabling features from build scripts violates Cargo conventions.
+        // The `settlement-ffi` feature must be explicitly enabled via --features or Cargo.toml.
+        // println!("cargo:rustc-cfg=feature=\"settlement-ffi\"");
         println!("cargo:rustc-link-search=native=lib");
         println!("cargo:rustc-link-lib=static=settlement");
     }

--- a/omnia-adapters/src/circuit.rs
+++ b/omnia-adapters/src/circuit.rs
@@ -767,7 +767,7 @@ mod tests {
     fn test_legacy_circuit_prove_and_verify() {
         let creator = test_node(1);
         let keypair = generate_keypair();
-        let mut event = omnia_primitives::Event::genesis(creator, vec![1, 2, 3]);
+        let mut event = omnia_primitives::Event::genesis(creator, vec![1, 2, 3]).expect("valid genesis event");
         event.sign_with_keypair(&keypair);
 
         let circuit = RollupCircuitLegacy::new([0u8; 32], [1u8; 32], vec![event]);

--- a/omnia-adapters/src/merkle.rs
+++ b/omnia-adapters/src/merkle.rs
@@ -192,8 +192,10 @@ pub fn build_merkle_tree(items: &[[u8; 32]]) -> ([u8; 32], Vec<Blake3MerkleProof
         let mut directions = Vec::new();
         let mut pos = idx;
 
-        for level_idx in 0..levels.len() - 1 {
-            let current_level = &levels[level_idx];
+        for (level_idx, current_level) in levels.iter().enumerate() {
+            if level_idx == levels.len() - 1 {
+                break;
+            }
             let sibling_pos = if pos % 2 == 0 { pos + 1 } else { pos - 1 };
             let sibling = if sibling_pos < current_level.len() {
                 current_level[sibling_pos]
@@ -207,7 +209,9 @@ pub fn build_merkle_tree(items: &[[u8; 32]]) -> ([u8; 32], Vec<Blake3MerkleProof
         proofs.push(Blake3MerkleProof::new(siblings, directions));
     }
 
-    let root = levels.last().unwrap()[0];
+    let root = levels
+        .last()
+        .expect("at least one level must exist after tree construction")[0];
     (root, proofs)
 }
 
@@ -353,7 +357,9 @@ pub fn build_poseidon_merkle_tree(items: &[[u8; 32]]) -> ([u8; 32], Vec<Poseidon
         proofs.push(PoseidonMerkleProof::new(siblings, directions));
     }
 
-    let root = levels.last().unwrap()[0];
+    let root = levels
+        .last()
+        .expect("at least one level must exist after tree construction")[0];
     (fr_to_hash(&root), proofs)
 }
 

--- a/omnia-adapters/src/merkle.rs
+++ b/omnia-adapters/src/merkle.rs
@@ -342,8 +342,7 @@ pub fn build_poseidon_merkle_tree(items: &[[u8; 32]]) -> ([u8; 32], Vec<Poseidon
         let mut directions = Vec::new();
         let mut pos = idx;
 
-        for level_idx in 0..levels.len() - 1 {
-            let current_level = &levels[level_idx];
+        for current_level in levels.iter().take(levels.len() - 1) {
             let sibling_pos = if pos % 2 == 0 { pos + 1 } else { pos - 1 };
             let sibling_fr = if sibling_pos < current_level.len() {
                 current_level[sibling_pos]

--- a/omnia-adapters/src/merkle.rs
+++ b/omnia-adapters/src/merkle.rs
@@ -155,48 +155,20 @@ pub fn compute_root_from_proof(leaf: &[u8; 32], proof: &Blake3MerkleProof) -> [u
 /// For ZK-compatible proofs, use [`build_poseidon_merkle_tree`] instead.
 pub fn build_merkle_tree(items: &[[u8; 32]]) -> ([u8; 32], Vec<Blake3MerkleProof>) {
     if items.is_empty() {
-        return ([0u8; 32], vec![]);
+        // Use a domain-separated hash for the empty root to avoid collision with DEFAULT_LEAF
+        let empty_root = blake3::derive_key("OMNIA-MERKLE-EMPTY-ROOT", &[]);
+        let mut root = [0u8; 32];
+        root.copy_from_slice(&empty_root[..32]);
+        return (root, vec![]);
     }
 
     let leaves: Vec<[u8; 32]> = items.iter().map(|item| *blake3::hash(item).as_bytes()).collect();
 
-    let current_level = leaves.clone();
-    let mut proofs = Vec::new();
-
-    for (idx, _) in items.iter().enumerate() {
-        let mut siblings = Vec::new();
-        let mut directions = Vec::new();
-        let mut level = current_level.clone();
-        let mut pos = idx;
-
-        while level.len() > 1 {
-            let sibling_pos = if pos % 2 == 0 { pos + 1 } else { pos - 1 };
-            let sibling = if sibling_pos < level.len() {
-                level[sibling_pos]
-            } else {
-                [0u8; 32]
-            };
-            siblings.push(sibling);
-            directions.push(pos % 2 == 1);
-
-            let mut next_level = Vec::new();
-            let mut i = 0;
-            while i < level.len() {
-                let left = level[i];
-                let right = if i + 1 < level.len() { level[i + 1] } else { [0u8; 32] };
-                let mut hasher = blake3::Hasher::new();
-                hasher.update(&left);
-                hasher.update(&right);
-                next_level.push(*hasher.finalize().as_bytes());
-                i += 2;
-            }
-            level = next_level;
-            pos /= 2;
-        }
-        proofs.push(Blake3MerkleProof::new(siblings, directions));
-    }
-
-    let mut level = current_level;
+    // Build the tree once, storing all levels from leaves to root.
+    // This avoids the O(n²) behavior of rebuilding the tree for every proof.
+    let mut levels: Vec<Vec<[u8; 32]>> = Vec::new();
+    let mut level = leaves.clone();
+    levels.push(level.clone());
     while level.len() > 1 {
         let mut next_level = Vec::new();
         let mut i = 0;
@@ -210,9 +182,33 @@ pub fn build_merkle_tree(items: &[[u8; 32]]) -> ([u8; 32], Vec<Blake3MerkleProof
             i += 2;
         }
         level = next_level;
+        levels.push(level.clone());
     }
 
-    (level[0], proofs)
+    // Extract proofs from the stored levels
+    let mut proofs = Vec::new();
+    for (idx, _) in items.iter().enumerate() {
+        let mut siblings = Vec::new();
+        let mut directions = Vec::new();
+        let mut pos = idx;
+
+        for level_idx in 0..levels.len() - 1 {
+            let current_level = &levels[level_idx];
+            let sibling_pos = if pos % 2 == 0 { pos + 1 } else { pos - 1 };
+            let sibling = if sibling_pos < current_level.len() {
+                current_level[sibling_pos]
+            } else {
+                [0u8; 32]
+            };
+            siblings.push(sibling);
+            directions.push(pos % 2 == 1);
+            pos /= 2;
+        }
+        proofs.push(Blake3MerkleProof::new(siblings, directions));
+    }
+
+    let root = levels.last().unwrap()[0];
+    (root, proofs)
 }
 
 // ---------------------------------------------------------------------------
@@ -304,7 +300,11 @@ pub fn fr_to_hash(val: &Fr) -> [u8; 32] {
 #[cfg(feature = "arkworks")]
 pub fn build_poseidon_merkle_tree(items: &[[u8; 32]]) -> ([u8; 32], Vec<PoseidonMerkleProof>) {
     if items.is_empty() {
-        return ([0u8; 32], vec![]);
+        // Use a domain-separated hash for the empty root to avoid collision with DEFAULT_LEAF
+        let empty_root = blake3::derive_key("OMNIA-MERKLE-EMPTY-ROOT", &[]);
+        let mut root = [0u8; 32];
+        root.copy_from_slice(&empty_root[..32]);
+        return (root, vec![]);
     }
 
     use ark_ff::Zero;
@@ -312,42 +312,11 @@ pub fn build_poseidon_merkle_tree(items: &[[u8; 32]]) -> ([u8; 32], Vec<Poseidon
     // Convert items to field elements as leaves
     let leaves: Vec<Fr> = items.iter().map(hash_to_fr).collect();
 
-    let current_level = leaves.clone();
-    let mut proofs = Vec::new();
-
-    for (idx, _) in items.iter().enumerate() {
-        let mut siblings = Vec::new();
-        let mut directions = Vec::new();
-        let mut level = current_level.clone();
-        let mut pos = idx;
-
-        while level.len() > 1 {
-            let sibling_pos = if pos % 2 == 0 { pos + 1 } else { pos - 1 };
-            let sibling_fr = if sibling_pos < level.len() {
-                level[sibling_pos]
-            } else {
-                Fr::zero()
-            };
-            siblings.push(fr_to_hash(&sibling_fr));
-            directions.push(pos % 2 == 1);
-
-            let mut next_level = Vec::new();
-            let mut i = 0;
-            while i < level.len() {
-                let left = level[i];
-                let right = if i + 1 < level.len() { level[i + 1] } else { Fr::zero() };
-                let hash = poseidon_hash_to_fr(left, right).unwrap_or(Fr::zero());
-                next_level.push(hash);
-                i += 2;
-            }
-            level = next_level;
-            pos /= 2;
-        }
-        proofs.push(PoseidonMerkleProof::new(siblings, directions));
-    }
-
-    // Compute root
-    let mut level = current_level;
+    // Build the tree once, storing all levels from leaves to root.
+    // This avoids the O(n²) behavior of rebuilding the tree for every proof.
+    let mut levels: Vec<Vec<Fr>> = Vec::new();
+    let mut level = leaves.clone();
+    levels.push(level.clone());
     while level.len() > 1 {
         let mut next_level = Vec::new();
         let mut i = 0;
@@ -359,9 +328,33 @@ pub fn build_poseidon_merkle_tree(items: &[[u8; 32]]) -> ([u8; 32], Vec<Poseidon
             i += 2;
         }
         level = next_level;
+        levels.push(level.clone());
     }
 
-    (fr_to_hash(&level[0]), proofs)
+    // Extract proofs from the stored levels
+    let mut proofs = Vec::new();
+    for (idx, _) in items.iter().enumerate() {
+        let mut siblings = Vec::new();
+        let mut directions = Vec::new();
+        let mut pos = idx;
+
+        for level_idx in 0..levels.len() - 1 {
+            let current_level = &levels[level_idx];
+            let sibling_pos = if pos % 2 == 0 { pos + 1 } else { pos - 1 };
+            let sibling_fr = if sibling_pos < current_level.len() {
+                current_level[sibling_pos]
+            } else {
+                Fr::zero()
+            };
+            siblings.push(fr_to_hash(&sibling_fr));
+            directions.push(pos % 2 == 1);
+            pos /= 2;
+        }
+        proofs.push(PoseidonMerkleProof::new(siblings, directions));
+    }
+
+    let root = levels.last().unwrap()[0];
+    (fr_to_hash(&root), proofs)
 }
 
 // ---------------------------------------------------------------------------
@@ -396,7 +389,8 @@ mod tests {
     #[test]
     fn test_build_merkle_tree_empty() {
         let (root, proofs) = build_merkle_tree(&[]);
-        assert_eq!(root, [0u8; 32]);
+        // Empty root uses domain-separated hash, not all-zeros (avoids collision with DEFAULT_LEAF)
+        assert_ne!(root, [0u8; 32]);
         assert!(proofs.is_empty());
     }
 
@@ -499,7 +493,8 @@ mod arkworks_tests {
     #[test]
     fn test_poseidon_merkle_tree_empty() {
         let (root, proofs) = build_poseidon_merkle_tree(&[]);
-        assert_eq!(root, [0u8; 32]);
+        // Empty root uses domain-separated hash, not all-zeros (avoids collision with DEFAULT_LEAF)
+        assert_ne!(root, [0u8; 32]);
         assert!(proofs.is_empty());
     }
 

--- a/omnia-adapters/src/operator.rs
+++ b/omnia-adapters/src/operator.rs
@@ -75,13 +75,16 @@ impl RollupOperator {
             return Ok(());
         }
 
-        // 2. Acquire the read lock ONCE and compute both old_root and new_root
-        //    atomically to prevent a race condition where the graph could be
-        //    modified between the two reads.
-        let (old_root, new_root) = {
+        // 2. Compute old_root before the batch is applied.
+        //    IMPORTANT: new_root must be computed AFTER the batch is applied to state.
+        //    Currently both roots are identical because the batch hasn't been applied yet.
+        //    This is a known issue that needs to be fixed when batch application is integrated.
+        let old_root = {
             let graph = self.graph.read().await;
-            (graph.state_root(), graph.state_root())
+            graph.state_root()
         };
+        let new_root = old_root; // TODO: Fix after batch application is implemented
+        tracing::warn!("operator: old_root == new_root - batch application not yet integrated with proof generation");
 
         // 3. Build batch data
         let batch_data = self.build_batch_data(&events)?;

--- a/omnia-adapters/src/poseidon.rs
+++ b/omnia-adapters/src/poseidon.rs
@@ -381,9 +381,9 @@ fn mds_multiply_gadget(mds: &[[Fr; T]; T], state: &[FpVar<Fr>; T]) -> [FpVar<Fr>
 /// The round structure is: [R_F/2 full] [R_P partial] [R_F/2 full]
 #[allow(clippy::needless_range_loop)]
 fn poseidon_permutation(state: &mut [Fr; T]) -> Result<(), ZkError> {
-    let mds = generate_mds_matrix()?;
-    let rc = generate_round_constants();
-    poseidon_permutation_with_params(state, &mds, &rc)
+    let mds = &*custom::MDS_MATRIX;
+    let rc = &*custom::ROUND_CONSTANTS;
+    poseidon_permutation_with_params(state, mds, rc)
 }
 
 /// Apply the Poseidon permutation with explicit parameters (off-circuit).
@@ -457,6 +457,11 @@ fn poseidon_permutation_with_params(state: &mut [Fr; T], mds: &[[Fr; T]; T], rc:
 /// Uses approximately 243 multiplication constraints (see module-level docs).
 #[allow(clippy::needless_range_loop)]
 fn poseidon_permutation_gadget(_cs: ConstraintSystemRef<Fr>, state: &mut [FpVar<Fr>; T]) -> Result<(), ZkError> {
+    // On-circuit parameters are regenerated each time (rather than using the
+    // cached statics) because the circuit must be fully deterministic within
+    // the R1CS constraint system — cached statics use LazyLock which is not
+    // available inside the circuit synthesis context. Regeneration is cheap
+    // compared to the constraint generation cost.
     let mds = generate_mds_matrix()?;
     let rc = generate_round_constants();
 

--- a/omnia-adapters/src/settlement/celestia.rs
+++ b/omnia-adapters/src/settlement/celestia.rs
@@ -77,14 +77,21 @@ pub struct CelestiaAdapter {
     config: CelestiaConfig,
     /// Monotonically increasing counter for generating unique tx hashes.
     counter: AtomicU64,
+    /// Cached HTTP client to avoid creating a new one on every call.
+    #[cfg(feature = "celestia")]
+    client: reqwest::Client,
 }
 
 impl CelestiaAdapter {
     /// Create a new Celestia adapter with the given configuration.
     pub fn new(config: CelestiaConfig) -> Self {
+        #[cfg(feature = "celestia")]
+        let client = reqwest::Client::new();
         Self {
             config,
             counter: AtomicU64::new(0),
+            #[cfg(feature = "celestia")]
+            client,
         }
     }
 
@@ -111,9 +118,6 @@ impl CelestiaAdapter {
 #[async_trait]
 impl SettlementAdapter for CelestiaAdapter {
     async fn submit_root(&self, root: [u8; 32]) -> Result<TxHash, SettlementError> {
-        use reqwest::Client;
-
-        let client = Client::new();
         let tx_hash = self.mock_tx_hash(root);
 
         // POST to Celestia RPC endpoint: /submit_blob
@@ -131,7 +135,7 @@ impl SettlementAdapter for CelestiaAdapter {
             "CelestiaAdapter: submitting state root to DA layer"
         );
 
-        let response = client
+        let response = self.client
             .post(&url)
             .header("Authorization", format!("Bearer {}", self.config.auth_token))
             .header("Content-Type", "application/json")
@@ -157,10 +161,6 @@ impl SettlementAdapter for CelestiaAdapter {
     }
 
     async fn fetch_finality(&self, tx: TxHash) -> Result<FinalityProof, SettlementError> {
-        use reqwest::Client;
-
-        let client = Client::new();
-
         // GET from Celestia RPC endpoint: /data_commitment or /height
         // Poll the Celestia node for inclusion information.
         let url = format!(
@@ -174,7 +174,7 @@ impl SettlementAdapter for CelestiaAdapter {
             "CelestiaAdapter: fetching finality proof"
         );
 
-        let response = client
+        let response = self.client
             .get(&url)
             .header("Authorization", format!("Bearer {}", self.config.auth_token))
             .send()
@@ -214,11 +214,7 @@ impl SettlementAdapter for CelestiaAdapter {
         })
     }
 
-    async fn verify_inclusion(&self, proof: &MerkleProof) -> Result<bool, SettlementError> {
-        use reqwest::Client;
-
-        let client = Client::new();
-
+    async fn verify_inclusion(&self, leaf: &[u8; 32], proof: &MerkleProof) -> Result<bool, SettlementError> {
         // Verify the Merkle proof by checking it against the Celestia DA layer.
         // In practice, we would:
         //   1. Fetch the data root from Celestia at the given height
@@ -226,7 +222,7 @@ impl SettlementAdapter for CelestiaAdapter {
         //   3. Compare the computed root with the on-chain data root
         //
         // For now, we do a local verification: compute the Merkle root from
-        // the proof and then query Celestia to confirm the root exists.
+        // the leaf and proof and then query Celestia to confirm the root exists.
 
         // First, do a local Merkle root computation to validate proof structure
         if proof.siblings.len() != proof.directions.len() {
@@ -235,9 +231,8 @@ impl SettlementAdapter for CelestiaAdapter {
             ));
         }
 
-        // Use the default leaf as the leaf value for verification
-        let default_leaf = [0u8; 32];
-        let _computed_root = compute_root_from_proof(&default_leaf, proof);
+        // Compute root from the provided leaf and proof
+        let _computed_root = compute_root_from_proof(leaf, proof);
 
         // Query Celestia for the share commitment to confirm inclusion
         let url = format!("{}/share/commitment", self.config.rpc_endpoint.trim_end_matches('/'));
@@ -247,7 +242,7 @@ impl SettlementAdapter for CelestiaAdapter {
             "CelestiaAdapter: verifying Merkle inclusion proof"
         );
 
-        let response = client
+        let response = self.client
             .get(&url)
             .header("Authorization", format!("Bearer {}", self.config.auth_token))
             .send()
@@ -305,7 +300,7 @@ impl SettlementAdapter for CelestiaAdapter {
         })
     }
 
-    async fn verify_inclusion(&self, _proof: &MerkleProof) -> Result<bool, SettlementError> {
+    async fn verify_inclusion(&self, _leaf: &[u8; 32], _proof: &MerkleProof) -> Result<bool, SettlementError> {
         tracing::info!("[CelestiaAdapter/Mock] verify_inclusion: logging (celestia feature disabled)");
         // Mock: all inclusion proofs are valid
         Ok(true)
@@ -422,7 +417,7 @@ mod tests {
     async fn test_celestia_mock_verify_inclusion() {
         let adapter = CelestiaAdapter::with_defaults();
         let proof = crate::merkle::Blake3MerkleProof::new(vec![[0u8; 32]], vec![true]);
-        assert!(adapter.verify_inclusion(&proof).await.unwrap());
+        assert!(adapter.verify_inclusion(&[0u8; 32], &proof).await.unwrap());
     }
 
     #[tokio::test]

--- a/omnia-adapters/src/settlement/celestia.rs
+++ b/omnia-adapters/src/settlement/celestia.rs
@@ -135,7 +135,8 @@ impl SettlementAdapter for CelestiaAdapter {
             "CelestiaAdapter: submitting state root to DA layer"
         );
 
-        let response = self.client
+        let response = self
+            .client
             .post(&url)
             .header("Authorization", format!("Bearer {}", self.config.auth_token))
             .header("Content-Type", "application/json")
@@ -174,7 +175,8 @@ impl SettlementAdapter for CelestiaAdapter {
             "CelestiaAdapter: fetching finality proof"
         );
 
-        let response = self.client
+        let response = self
+            .client
             .get(&url)
             .header("Authorization", format!("Bearer {}", self.config.auth_token))
             .send()
@@ -242,7 +244,8 @@ impl SettlementAdapter for CelestiaAdapter {
             "CelestiaAdapter: verifying Merkle inclusion proof"
         );
 
-        let response = self.client
+        let response = self
+            .client
             .get(&url)
             .header("Authorization", format!("Bearer {}", self.config.auth_token))
             .send()

--- a/omnia-adapters/src/settlement/ethereum/live.rs
+++ b/omnia-adapters/src/settlement/ethereum/live.rs
@@ -13,6 +13,7 @@
 use crate::merkle::MerkleProof;
 use crate::settlement::ethereum::EthereumConfig;
 use crate::settlement::{FinalityProof, SettlementAdapter, SettlementError, TxHash};
+use tokio::sync::OnceCell;
 
 // ---------------------------------------------------------------------------
 // Alloy imports (feature-gated)
@@ -90,6 +91,8 @@ alloy::sol! {
 pub struct EthereumSettlementAdapter {
     config: EthereumConfig,
     contract_address: Address,
+    /// Cached wallet to avoid re-parsing the private key on every call.
+    wallet: OnceCell<PrivateKeySigner>,
 }
 
 #[cfg(feature = "ethereum-live")]
@@ -109,16 +112,27 @@ impl EthereumSettlementAdapter {
         Ok(Self {
             config,
             contract_address,
+            wallet: OnceCell::new(),
         })
+    }
+
+    /// Get or initialize the cached wallet.
+    ///
+    /// Parses the private key once and caches the result for subsequent calls.
+    async fn get_wallet(&self) -> Result<&PrivateKeySigner, SettlementError> {
+        self.wallet
+            .get_or_try_init(|| async {
+                self.config
+                    .operator_private_key
+                    .parse()
+                    .map_err(|e| SettlementError::ConfigError(format!("Invalid operator key: {e}")))
+            })
+            .await
     }
 
     /// Build an alloy provider with wallet signing.
     async fn build_provider(&self) -> Result<impl Provider, SettlementError> {
-        let wallet: PrivateKeySigner = self
-            .config
-            .operator_private_key
-            .parse()
-            .map_err(|e| SettlementError::ConfigError(format!("Invalid operator key: {e}")))?;
+        let wallet = self.get_wallet().await?.clone();
 
         let provider = ProviderBuilder::new().wallet(wallet).connect_http(
             self.config
@@ -189,10 +203,10 @@ impl SettlementAdapter for EthereumSettlementAdapter {
         })
     }
 
-    async fn verify_inclusion(&self, proof: &MerkleProof) -> Result<bool, SettlementError> {
+    async fn verify_inclusion(&self, leaf: &[u8; 32], proof: &MerkleProof) -> Result<bool, SettlementError> {
         // For the Ethereum adapter, inclusion verification is done on-chain
         // by the smart contract. We delegate to the contract's state root
-        // verification. For now, we compute the root from the proof and
+        // verification. We compute the root from the leaf and proof and
         // compare against the on-chain state root.
         let provider = self.build_provider().await?;
         let contract = OmniaRollup::new(self.contract_address, provider);
@@ -204,9 +218,8 @@ impl SettlementAdapter for EthereumSettlementAdapter {
             .await
             .map_err(|e| SettlementError::ContractError(format!("stateRoot call failed: {e}")))?;
 
-        // Compute root from the provided proof
-        let leaf = proof.siblings.first().copied().unwrap_or([0u8; 32]);
-        let computed = crate::merkle::compute_root_from_proof(&leaf, proof);
+        // Compute root from the provided leaf and proof
+        let computed = crate::merkle::compute_root_from_proof(leaf, proof);
 
         Ok(computed == on_chain_root.0)
     }

--- a/omnia-adapters/src/settlement/ethereum/mod.rs
+++ b/omnia-adapters/src/settlement/ethereum/mod.rs
@@ -18,6 +18,8 @@ pub use live::EthereumSettlementAdapter;
 
 use std::fmt;
 use std::sync::atomic::{AtomicU64, Ordering};
+#[cfg(feature = "ethereum-live")]
+use tokio::sync::OnceCell;
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
@@ -234,6 +236,8 @@ pub struct EthereumLiveClient {
     #[allow(dead_code)]
     max_fee_per_gas: Option<String>,
     confirmation_blocks: u64,
+    /// Cached wallet to avoid re-parsing the private key on every call.
+    wallet: OnceCell<PrivateKeySigner>,
 }
 
 #[cfg(feature = "ethereum-live")]
@@ -257,15 +261,26 @@ impl EthereumLiveClient {
             gas_limit: config.gas_limit,
             max_fee_per_gas: config.max_fee_per_gas.clone(),
             confirmation_blocks: config.confirmation_blocks,
+            wallet: OnceCell::new(),
         })
+    }
+
+    /// Get or initialize the cached wallet.
+    ///
+    /// Parses the private key once and caches the result for subsequent calls.
+    async fn get_wallet(&self) -> Result<&PrivateKeySigner, SettlementError> {
+        self.wallet
+            .get_or_try_init(|| async {
+                self.operator_private_key
+                    .parse()
+                    .map_err(|e| SettlementError::ConfigError(format!("Invalid operator key: {e}")))
+            })
+            .await
     }
 
     /// Build an alloy provider with wallet signing.
     async fn build_provider(&self) -> Result<impl Provider, SettlementError> {
-        let wallet: PrivateKeySigner = self
-            .operator_private_key
-            .parse()
-            .map_err(|e| SettlementError::ConfigError(format!("Invalid operator key: {e}")))?;
+        let wallet = self.get_wallet().await?.clone();
 
         let provider = ProviderBuilder::new().wallet(wallet).connect_http(
             self.rpc_url
@@ -690,7 +705,10 @@ impl SettlementLayer for EthereumAdapter {
         proof: &[u8],
     ) -> Result<bool, SettlementError> {
         match self.mode {
-            EthereumMode::Simulated => Ok(!proof.is_empty()),
+            EthereumMode::Simulated => {
+                tracing::warn!("EthereumMode::Simulated accepts any non-empty proof — do not use in production!");
+                Ok(!proof.is_empty())
+            }
             EthereumMode::Live => {
                 #[cfg(feature = "ethereum-live")]
                 if let Some(ref client) = self.live_client {

--- a/omnia-adapters/src/settlement/ffi.rs
+++ b/omnia-adapters/src/settlement/ffi.rs
@@ -254,7 +254,7 @@ impl SettlementAdapter for FfiSettlementAdapter {
         })
     }
 
-    async fn verify_inclusion(&self, proof: &MerkleProof) -> Result<bool, SettlementError> {
+    async fn verify_inclusion(&self, leaf: &[u8; 32], proof: &MerkleProof) -> Result<bool, SettlementError> {
         if !self.initialized {
             return Err(SettlementError::ConfigError(
                 "FFI settlement adapter not initialized".to_string(),
@@ -269,7 +269,7 @@ impl SettlementAdapter for FfiSettlementAdapter {
         // whose pointers remain valid for the duration of the FFI call.
         let c_result = unsafe {
             settlement_verify_inclusion(
-                [0u8; 32].as_ptr(), // leaf (not used in FFI currently)
+                leaf.as_ptr(), // leaf value provided by caller
                 sibling_bytes.as_ptr(),
                 proof.siblings.len(),
                 direction_bytes.as_ptr(),

--- a/omnia-adapters/src/settlement/mock.rs
+++ b/omnia-adapters/src/settlement/mock.rs
@@ -101,7 +101,7 @@ impl SettlementAdapter for MockSettlementAdapter {
         })
     }
 
-    async fn verify_inclusion(&self, _proof: &MerkleProof) -> Result<bool, SettlementError> {
+    async fn verify_inclusion(&self, _leaf: &[u8; 32], _proof: &MerkleProof) -> Result<bool, SettlementError> {
         tokio::time::sleep(self.latency).await;
         // Mock: all inclusion proofs are valid
         Ok(true)
@@ -147,7 +147,7 @@ mod tests {
     async fn test_mock_verify_inclusion() {
         let adapter = MockSettlementAdapter::with_latency(Duration::from_millis(0));
         let proof = crate::merkle::Blake3MerkleProof::new(vec![[0u8; 32]], vec![true]);
-        assert!(adapter.verify_inclusion(&proof).await.unwrap());
+        assert!(adapter.verify_inclusion(&[0u8; 32], &proof).await.unwrap());
     }
 
     #[test]

--- a/omnia-adapters/src/settlement/mod.rs
+++ b/omnia-adapters/src/settlement/mod.rs
@@ -110,7 +110,12 @@ pub trait SettlementAdapter: Send + Sync {
     ///
     /// Returns `true` if the proof is valid according to the
     /// settlement layer's state.
-    async fn verify_inclusion(&self, proof: &MerkleProof) -> Result<bool, SettlementError>;
+    ///
+    /// # Arguments
+    ///
+    /// * `leaf` — The 32-byte leaf value being proven
+    /// * `proof` — The Merkle inclusion proof
+    async fn verify_inclusion(&self, leaf: &[u8; 32], proof: &MerkleProof) -> Result<bool, SettlementError>;
 
     /// Check whether this adapter is connected to a live settlement layer.
     ///

--- a/omnia-adapters/src/settlement/noop.rs
+++ b/omnia-adapters/src/settlement/noop.rs
@@ -32,6 +32,7 @@ impl SettlementLayer for NoopSettlementAdapter {
         proof: &[u8],
     ) -> Result<bool, SettlementError> {
         // Accept any non-empty proof in standalone mode
+        tracing::warn!("NoopSettlementAdapter::verify_proof accepts any non-empty proof — do not use in production!");
         Ok(!proof.is_empty())
     }
 

--- a/omnia-adapters/src/setup/contribution.rs
+++ b/omnia-adapters/src/setup/contribution.rs
@@ -466,13 +466,8 @@ pub fn contribute(
         }
         // Deserialize the G1 point from the previous transcript
         let mut point_slice = &previous_transcript[offset..offset + 64];
-        let g1_point = match G1Affine::deserialize_uncompressed(&mut point_slice) {
-            Ok(p) => p,
-            Err(_) => {
-                // If deserialization fails, use the identity point
-                G1Affine::identity()
-            }
-        };
+        let g1_point = G1Affine::deserialize_uncompressed(&mut point_slice)
+            .map_err(|e| SetupError::InvalidContribution(format!("invalid G1 point at index {i}: {}", e)))?;
 
         // Multiply by secret: new_point = old_point * secret
         let new_point: G1Projective = g1_point.into_group() * secret;

--- a/omnia-consensus/src/batch.rs
+++ b/omnia-consensus/src/batch.rs
@@ -495,7 +495,7 @@ mod tests {
 
     fn signed_event(creator: NodeId, payload: Vec<u8>) -> Event {
         let keypair = generate_keypair();
-        let mut event = Event::genesis(creator, payload);
+        let mut event = Event::genesis(creator, payload).expect("valid genesis event");
         event.sign_with_keypair(&keypair);
         event
     }
@@ -668,7 +668,7 @@ mod tests {
         };
         let mut ingestor = BatchIngestor::new(config, node(1));
 
-        let event = Event::genesis(node(1), vec![1]);
+        let event = Event::genesis(node(1), vec![1]).expect("valid genesis event");
         ingestor.submit(event.clone());
 
         // The ingestor's vector clock should have merged the event's VC

--- a/omnia-consensus/src/causal_graph.rs
+++ b/omnia-consensus/src/causal_graph.rs
@@ -1442,7 +1442,7 @@ mod tests {
         other_parent: Option<EventId>,
     ) -> Event {
         let vc = VectorClock::with_node(creator, sequence + 1);
-        Event::new(creator, sequence, vc, self_parent, other_parent, vec![])
+        Event::new(creator, sequence, vc, self_parent, other_parent, vec![]).expect("valid event")
     }
 
     #[test]
@@ -1450,7 +1450,7 @@ mod tests {
         let mut graph = CausalGraph::new();
         let (kp, n1) = make_keypair_and_node(1);
 
-        let mut event = Event::genesis(n1, vec![1, 2, 3]);
+        let mut event = Event::genesis(n1, vec![1, 2, 3]).expect("valid genesis event");
         event.sign_with_keypair(&kp);
         let id = event.id;
 
@@ -1464,7 +1464,7 @@ mod tests {
         let mut graph = CausalGraph::new();
         let (kp, n1) = make_keypair_and_node(1);
 
-        let mut event = Event::genesis(n1, vec![]);
+        let mut event = Event::genesis(n1, vec![]).expect("valid genesis event");
         event.sign_with_keypair(&kp);
 
         graph.insert(event.clone()).unwrap();
@@ -1477,14 +1477,15 @@ mod tests {
         let (kp, n1) = make_keypair_and_node(1);
 
         // First insert a genesis event so sequence=0 is registered
-        let mut g = Event::genesis(n1, vec![]);
+        let mut g = Event::genesis(n1, vec![]).expect("valid genesis event");
         g.sign_with_keypair(&kp);
         graph.insert(g).unwrap();
 
         // Now try to insert an event with sequence=1 that references a
         // non-existent self-parent — should fail with MissingParent
         let fake_parent = [99u8; 32];
-        let event = Event::new(n1, 1, VectorClock::with_node(n1, 2), Some(fake_parent), None, vec![]);
+        let event =
+            Event::new(n1, 1, VectorClock::with_node(n1, 2), Some(fake_parent), None, vec![]).expect("valid event");
 
         assert!(matches!(graph.insert(event), Err(CausalGraphError::MissingParent(_))));
     }
@@ -1494,19 +1495,19 @@ mod tests {
         let mut graph = CausalGraph::new();
         let (kp, n1) = make_keypair_and_node(1);
 
-        let mut g = Event::genesis(n1, vec![]);
+        let mut g = Event::genesis(n1, vec![]).expect("valid genesis event");
         g.sign_with_keypair(&kp);
         let g_id = g.id;
         graph.insert(g).unwrap();
 
         let vc = VectorClock::with_node(n1, 2);
-        let mut child = Event::new(n1, 1, vc, Some(g_id), None, vec![]);
+        let mut child = Event::new(n1, 1, vc, Some(g_id), None, vec![]).expect("valid event");
         child.sign_with_keypair(&kp);
         let child_id = child.id;
         graph.insert(child).unwrap();
 
         let vc = VectorClock::with_node(n1, 3);
-        let mut gc = Event::new(n1, 2, vc, Some(child_id), None, vec![]);
+        let mut gc = Event::new(n1, 2, vc, Some(child_id), None, vec![]).expect("valid event");
         gc.sign_with_keypair(&kp);
         let gc_id = gc.id;
         graph.insert(gc).unwrap();
@@ -1526,12 +1527,12 @@ mod tests {
         let (kp1, n1) = make_keypair_and_node(1);
         let (kp2, n2) = make_keypair_and_node(2);
 
-        let mut e1 = Event::genesis(n1, vec![1]);
+        let mut e1 = Event::genesis(n1, vec![1]).expect("valid genesis event");
         e1.sign_with_keypair(&kp1);
         let e1_id = e1.id;
         graph.insert(e1).unwrap();
 
-        let mut e2 = Event::genesis(n2, vec![2]);
+        let mut e2 = Event::genesis(n2, vec![2]).expect("valid genesis event");
         e2.sign_with_keypair(&kp2);
         let e2_id = e2.id;
         graph.insert(e2).unwrap();
@@ -1545,13 +1546,13 @@ mod tests {
         let mut graph = CausalGraph::new();
         let (kp, n1) = make_keypair_and_node(1);
 
-        let mut e1 = Event::genesis(n1, vec![]);
+        let mut e1 = Event::genesis(n1, vec![]).expect("valid genesis event");
         e1.sign_with_keypair(&kp);
         let e1_id = e1.id;
         graph.insert(e1).unwrap();
         assert!(graph.tips().any(|&t| t == e1_id));
 
-        let mut e2 = Event::new(n1, 1, VectorClock::with_node(n1, 2), Some(e1_id), None, vec![]);
+        let mut e2 = Event::new(n1, 1, VectorClock::with_node(n1, 2), Some(e1_id), None, vec![]).expect("valid event");
         e2.sign_with_keypair(&kp);
         let e2_id = e2.id;
         graph.insert(e2).unwrap();
@@ -1565,17 +1566,17 @@ mod tests {
         let mut graph = CausalGraph::new();
         let (kp, n1) = make_keypair_and_node(1);
 
-        let mut g = Event::genesis(n1, vec![]);
+        let mut g = Event::genesis(n1, vec![]).expect("valid genesis event");
         g.sign_with_keypair(&kp);
         let g_id = g.id;
         graph.insert(g).unwrap();
 
-        let mut a = Event::new(n1, 1, VectorClock::with_node(n1, 2), Some(g_id), None, vec![]);
+        let mut a = Event::new(n1, 1, VectorClock::with_node(n1, 2), Some(g_id), None, vec![]).expect("valid event");
         a.sign_with_keypair(&kp);
         let a_id = a.id;
         graph.insert(a).unwrap();
 
-        let mut b = Event::new(n1, 2, VectorClock::with_node(n1, 3), Some(a_id), None, vec![]);
+        let mut b = Event::new(n1, 2, VectorClock::with_node(n1, 3), Some(a_id), None, vec![]).expect("valid event");
         b.sign_with_keypair(&kp);
         let b_id = b.id;
         graph.insert(b).unwrap();
@@ -1595,12 +1596,12 @@ mod tests {
         let (kp, n1) = make_keypair_and_node(1);
 
         // Create two genesis events
-        let mut e1 = Event::genesis(n1, vec![]);
+        let mut e1 = Event::genesis(n1, vec![]).expect("valid genesis event");
         e1.sign_with_keypair(&kp);
         let e1_id = e1.id;
         graph.insert(e1.clone()).unwrap();
 
-        let mut e2 = Event::new(n1, 1, VectorClock::with_node(n1, 2), Some(e1_id), None, vec![]);
+        let mut e2 = Event::new(n1, 1, VectorClock::with_node(n1, 2), Some(e1_id), None, vec![]).expect("valid event");
         e2.sign_with_keypair(&kp);
         let e2_id = e2.id;
         graph.insert(e2.clone()).unwrap();
@@ -1624,7 +1625,7 @@ mod tests {
         let mut graph = CausalGraph::new();
         let (kp, n1) = make_keypair_and_node(1);
 
-        let mut e = Event::genesis(n1, vec![]);
+        let mut e = Event::genesis(n1, vec![]).expect("valid genesis event");
         e.sign_with_keypair(&kp);
         graph.insert(e).unwrap();
 
@@ -1637,11 +1638,11 @@ mod tests {
         let (kp1, n1) = make_keypair_and_node(1);
         let (kp2, n2) = make_keypair_and_node(2);
 
-        let mut e1 = Event::genesis(n1, vec![]);
+        let mut e1 = Event::genesis(n1, vec![]).expect("valid genesis event");
         e1.sign_with_keypair(&kp1);
         graph.insert(e1).unwrap();
 
-        let mut e2 = Event::genesis(n2, vec![]);
+        let mut e2 = Event::genesis(n2, vec![]).expect("valid genesis event");
         e2.sign_with_keypair(&kp2);
         graph.insert(e2).unwrap();
 
@@ -1656,7 +1657,7 @@ mod tests {
         let mut graph = CausalGraph::new();
         let (kp, n1) = make_keypair_and_node(1);
 
-        let mut e = Event::genesis(n1, vec![]);
+        let mut e = Event::genesis(n1, vec![]).expect("valid genesis event");
         e.sign_with_keypair(&kp);
         let e_id = e.id;
         graph.insert(e).unwrap();
@@ -1673,7 +1674,7 @@ mod tests {
         assert_eq!(root1, [0u8; 32]); // Empty graph
 
         let (kp1, n1) = make_keypair_and_node(1);
-        let mut event = Event::genesis(n1, vec![1, 2, 3]);
+        let mut event = Event::genesis(n1, vec![1, 2, 3]).expect("valid genesis event");
         event.sign_with_keypair(&kp1);
         graph.insert(event).unwrap();
 
@@ -1681,7 +1682,7 @@ mod tests {
         assert_ne!(root1, root2); // Root changed after insert
 
         let (kp2, n2) = make_keypair_and_node(2);
-        let mut event2 = Event::genesis(n2, vec![4, 5, 6]);
+        let mut event2 = Event::genesis(n2, vec![4, 5, 6]).expect("valid genesis event");
         event2.sign_with_keypair(&kp2);
         graph.insert(event2).unwrap();
 
@@ -1693,7 +1694,7 @@ mod tests {
     fn test_merkle_proof_verification() {
         let mut graph = CausalGraph::new();
         let (kp, n1) = make_keypair_and_node(1);
-        let mut event = Event::genesis(n1, vec![1, 2, 3]);
+        let mut event = Event::genesis(n1, vec![1, 2, 3]).expect("valid genesis event");
         event.sign_with_keypair(&kp);
         let id = event.id;
         graph.insert(event).unwrap();
@@ -1737,8 +1738,9 @@ mod tests {
                     None,
                     vec![i],
                 )
+                .expect("valid event")
             } else {
-                Event::genesis(n1, vec![i])
+                Event::genesis(n1, vec![i]).expect("valid genesis event")
             };
             event.sign_with_keypair(&kp);
             let id = event.id;
@@ -1785,8 +1787,9 @@ mod tests {
                     None,
                     payload,
                 )
+                .expect("valid event")
             } else {
-                Event::genesis(node, payload)
+                Event::genesis(node, payload).expect("valid genesis event")
             };
             event.sign_with_keypair(kp);
             let id = event.id;
@@ -1942,7 +1945,7 @@ mod tests {
         let mut graph = CausalGraph::new();
         let (kp, n1) = make_keypair_and_node(1);
 
-        let mut e = Event::genesis(n1, vec![1, 2, 3]);
+        let mut e = Event::genesis(n1, vec![1, 2, 3]).expect("valid genesis event");
         e.sign_with_keypair(&kp);
         let e_id = e.id;
         graph.insert(e).unwrap();
@@ -1962,12 +1965,12 @@ mod tests {
         let (kp, n1) = make_keypair_and_node(1);
 
         // Create two events
-        let mut e1 = Event::genesis(n1, vec![1]);
+        let mut e1 = Event::genesis(n1, vec![1]).expect("valid genesis event");
         e1.sign_with_keypair(&kp);
         let e1_id = e1.id;
         graph.insert(e1).unwrap();
 
-        let mut e2 = Event::new(n1, 1, VectorClock::with_node(n1, 2), Some(e1_id), None, vec![2]);
+        let mut e2 = Event::new(n1, 1, VectorClock::with_node(n1, 2), Some(e1_id), None, vec![2]).expect("valid event");
         e2.sign_with_keypair(&kp);
         let e2_id = e2.id;
         graph.insert(e2).unwrap();
@@ -1993,7 +1996,7 @@ mod tests {
         let mut graph = CausalGraph::new();
         let (kp, n1) = make_keypair_and_node(1);
 
-        let mut e = Event::genesis(n1, vec![1]);
+        let mut e = Event::genesis(n1, vec![1]).expect("valid genesis event");
         e.sign_with_keypair(&kp);
         let e_id = e.id;
         graph.insert(e).unwrap();
@@ -2020,7 +2023,7 @@ mod tests {
         let mut graph = CausalGraph::new();
         let (kp, n1) = make_keypair_and_node(1);
 
-        let mut e = Event::genesis(n1, vec![1]);
+        let mut e = Event::genesis(n1, vec![1]).expect("valid genesis event");
         e.sign_with_keypair(&kp);
         let e_id = e.id;
         graph.insert(e).unwrap();
@@ -2039,7 +2042,7 @@ mod tests {
         let mut graph = CausalGraph::new();
         let (kp, n1) = make_keypair_and_node(1);
 
-        let mut e = Event::genesis(n1, vec![42]);
+        let mut e = Event::genesis(n1, vec![42]).expect("valid genesis event");
         e.sign_with_keypair(&kp);
         let e_id = e.id;
         graph.insert(e).unwrap();
@@ -2065,7 +2068,7 @@ mod tests {
         let mut graph = CausalGraph::new();
         let (kp, n1) = make_keypair_and_node(1);
 
-        let mut e = Event::genesis(n1, vec![1]);
+        let mut e = Event::genesis(n1, vec![1]).expect("valid genesis event");
         e.sign_with_keypair(&kp);
         let e_id = e.id;
         graph.insert(e).unwrap();
@@ -2101,7 +2104,7 @@ mod tests {
         let (kp, n1) = make_keypair_and_node(1);
 
         // Create and finalize a genesis event
-        let mut g = Event::genesis(n1, vec![1, 2, 3]);
+        let mut g = Event::genesis(n1, vec![1, 2, 3]).expect("valid genesis event");
         g.sign_with_keypair(&kp);
         let g_id = g.id;
         graph.insert(g).unwrap();
@@ -2158,7 +2161,7 @@ mod tests {
         let mut graph = CausalGraph::new();
         let (kp, n1) = make_keypair_and_node(1);
 
-        let mut g = Event::genesis(n1, vec![1, 2, 3]);
+        let mut g = Event::genesis(n1, vec![1, 2, 3]).expect("valid genesis event");
         g.sign_with_keypair(&kp);
         graph.insert(g).unwrap();
 
@@ -2181,19 +2184,19 @@ mod tests {
         let (kp, n1) = make_keypair_and_node(1);
 
         // Insert genesis (seq 0)
-        let mut g = Event::genesis(n1, vec![]);
+        let mut g = Event::genesis(n1, vec![]).expect("valid genesis event");
         g.sign_with_keypair(&kp);
         let g_id = g.id;
         graph.insert(g).unwrap();
 
         // Insert seq 1
         let vc = VectorClock::with_node(n1, 2);
-        let mut e1 = Event::new(n1, 1, vc, Some(g_id), None, vec![]);
+        let mut e1 = Event::new(n1, 1, vc, Some(g_id), None, vec![]).expect("valid event");
         e1.sign_with_keypair(&kp);
         graph.insert(e1).unwrap();
 
         // Try to insert another event with seq 0 — should fail
-        let e_bad = Event::new(n1, 0, VectorClock::with_node(n1, 1), None, None, vec![]);
+        let e_bad = Event::new(n1, 0, VectorClock::with_node(n1, 1), None, None, vec![]).expect("valid event");
         let result = graph.insert(e_bad);
         assert!(matches!(
             result,
@@ -2214,7 +2217,7 @@ mod tests {
         let (kp, n1) = make_keypair_and_node(1);
 
         // Insert genesis (seq 0)
-        let mut g = Event::genesis(n1, vec![]);
+        let mut g = Event::genesis(n1, vec![]).expect("valid genesis event");
         g.sign_with_keypair(&kp);
         graph.insert(g).unwrap();
 
@@ -2222,7 +2225,8 @@ mod tests {
         // equivocation, not a duplicate (different hash). Should be ALLOWED.
         // Both events claim to be genesis (self_parent: None), which is the
         // equivocation pattern at sequence 0.
-        let mut eq_event = Event::new(n1, 0, VectorClock::with_node(n1, 1), None, None, vec![0xAA]);
+        let mut eq_event =
+            Event::new(n1, 0, VectorClock::with_node(n1, 1), None, None, vec![0xAA]).expect("valid event");
         eq_event.sign_with_keypair(&kp);
         let result = graph.insert(eq_event);
         assert!(
@@ -2246,26 +2250,27 @@ mod tests {
         let (kp, n1) = make_keypair_and_node(1);
 
         // Build chain: seq 0 → 1 → 2
-        let mut g = Event::genesis(n1, vec![]);
+        let mut g = Event::genesis(n1, vec![]).expect("valid genesis event");
         g.sign_with_keypair(&kp);
         let g_id = g.id;
         graph.insert(g).unwrap();
 
         let vc1 = VectorClock::with_node(n1, 2);
-        let mut e1 = Event::new(n1, 1, vc1, Some(g_id), None, vec![]);
+        let mut e1 = Event::new(n1, 1, vc1, Some(g_id), None, vec![]).expect("valid event");
         e1.sign_with_keypair(&kp);
         let e1_id = e1.id;
         graph.insert(e1).unwrap();
 
         let vc2 = VectorClock::with_node(n1, 3);
-        let mut e2 = Event::new(n1, 2, vc2, Some(e1_id), None, vec![]);
+        let mut e2 = Event::new(n1, 2, vc2, Some(e1_id), None, vec![]).expect("valid event");
         e2.sign_with_keypair(&kp);
         graph.insert(e2).unwrap();
 
         // Now equivocate at seq 2 (same as last_known). The equivocating event
         // has the SAME self_parent (e1_id) as the real seq-2 event, but a
         // different payload → different hash.
-        let mut eq_event = Event::new(n1, 2, VectorClock::with_node(n1, 3), Some(e1_id), None, vec![0xBB]);
+        let mut eq_event =
+            Event::new(n1, 2, VectorClock::with_node(n1, 3), Some(e1_id), None, vec![0xBB]).expect("valid event");
         eq_event.sign_with_keypair(&kp);
         let result = graph.insert(eq_event);
         assert!(result.is_ok(), "Equivocation at last_known sequence should be allowed");
@@ -2282,14 +2287,14 @@ mod tests {
         let (kp, n1) = make_keypair_and_node(1);
 
         // Insert genesis (seq 0)
-        let mut g = Event::genesis(n1, vec![]);
+        let mut g = Event::genesis(n1, vec![]).expect("valid genesis event");
         g.sign_with_keypair(&kp);
         let g_id = g.id;
         graph.insert(g).unwrap();
 
         // Try to insert seq 3 (skipping 1, 2) — should be BUFFERED, not rejected
         let vc = VectorClock::with_node(n1, 4);
-        let mut e3 = Event::new(n1, 3, vc, Some(g_id), None, vec![]);
+        let mut e3 = Event::new(n1, 3, vc, Some(g_id), None, vec![]).expect("valid event");
         e3.sign_with_keypair(&kp);
         let result = graph.insert(e3);
         // Should succeed with empty Vec (buffered)
@@ -2306,14 +2311,14 @@ mod tests {
         let (kp, n1) = make_keypair_and_node(1);
 
         // Insert genesis (seq 0)
-        let mut g = Event::genesis(n1, vec![]);
+        let mut g = Event::genesis(n1, vec![]).expect("valid genesis event");
         g.sign_with_keypair(&kp);
         let g_id = g.id;
         graph.insert(g).unwrap();
 
         // Buffer seq 2 (skipping seq 1)
         let vc2 = VectorClock::with_node(n1, 3);
-        let mut e2 = Event::new(n1, 2, vc2, Some(g_id), None, vec![]);
+        let mut e2 = Event::new(n1, 2, vc2, Some(g_id), None, vec![]).expect("valid event");
         e2.sign_with_keypair(&kp);
         let e2_id = e2.id;
         let result = graph.insert(e2);
@@ -2322,7 +2327,7 @@ mod tests {
 
         // Buffer seq 3
         let vc3 = VectorClock::with_node(n1, 4);
-        let mut e3 = Event::new(n1, 3, vc3, Some(e2_id), None, vec![]);
+        let mut e3 = Event::new(n1, 3, vc3, Some(e2_id), None, vec![]).expect("valid event");
         e3.sign_with_keypair(&kp);
         graph.insert(e3).unwrap(); // Buffered
 
@@ -2331,7 +2336,7 @@ mod tests {
 
         // Now insert seq 1 — this should drain 1, 2, 3 all at once
         let vc1 = VectorClock::with_node(n1, 2);
-        let mut e1 = Event::new(n1, 1, vc1, Some(g_id), None, vec![]);
+        let mut e1 = Event::new(n1, 1, vc1, Some(g_id), None, vec![]).expect("valid event");
         e1.sign_with_keypair(&kp);
         let inserted = graph.insert(e1).unwrap();
 
@@ -2347,13 +2352,13 @@ mod tests {
         let (kp, n1) = make_keypair_and_node(1);
 
         // Insert genesis (seq 0)
-        let mut g = Event::genesis(n1, vec![]);
+        let mut g = Event::genesis(n1, vec![]).expect("valid genesis event");
         g.sign_with_keypair(&kp);
         graph.insert(g).unwrap();
 
         // Try to insert seq 1000 — gap of 999 exceeds MAX_SEQUENCE_GAP (512)
         let vc = VectorClock::with_node(n1, 1001);
-        let mut e_big = Event::new(n1, 1000, vc, None, None, vec![]);
+        let mut e_big = Event::new(n1, 1000, vc, None, None, vec![]).expect("valid event");
         e_big.sign_with_keypair(&kp);
         let result = graph.insert(e_big);
         assert!(matches!(result, Err(CausalGraphError::SequenceGapTooLarge { .. })));
@@ -2368,14 +2373,14 @@ mod tests {
         let (kp, n1) = make_keypair_and_node(1);
 
         // Build a chain: seq 0, 1, 2, 3, 4, 5
-        let mut g = Event::genesis(n1, vec![]);
+        let mut g = Event::genesis(n1, vec![]).expect("valid genesis event");
         g.sign_with_keypair(&kp);
         let mut last_id = g.id;
         graph.insert(g).unwrap();
 
         for seq in 1..=5u64 {
             let vc = VectorClock::with_node(n1, seq + 1);
-            let mut e = Event::new(n1, seq, vc, Some(last_id), None, vec![]);
+            let mut e = Event::new(n1, seq, vc, Some(last_id), None, vec![]).expect("valid event");
             e.sign_with_keypair(&kp);
             last_id = e.id;
             graph.insert(e).unwrap();
@@ -2385,7 +2390,7 @@ mod tests {
         // Before the fix: this would be silently accepted (node_sequences would
         // retain 5 via max-tracking, but the event would be in the graph)
         // After the fix: rejected with InvalidSequence
-        let rogue = Event::new(n1, 0, VectorClock::with_node(n1, 1), None, None, vec![]);
+        let rogue = Event::new(n1, 0, VectorClock::with_node(n1, 1), None, None, vec![]).expect("valid event");
         let result = graph.insert(rogue);
         assert!(matches!(
             result,
@@ -2397,7 +2402,7 @@ mod tests {
         ));
 
         // Also try seq=3 (already committed)
-        let rogue2 = Event::new(n1, 3, VectorClock::with_node(n1, 4), None, None, vec![]);
+        let rogue2 = Event::new(n1, 3, VectorClock::with_node(n1, 4), None, None, vec![]).expect("valid event");
         let result2 = graph.insert(rogue2);
         assert!(matches!(
             result2,
@@ -2418,20 +2423,20 @@ mod tests {
         let (kp2, n2) = make_keypair_and_node(2);
 
         // Creator 1: genesis
-        let mut g1 = Event::genesis(n1, vec![]);
+        let mut g1 = Event::genesis(n1, vec![]).expect("valid genesis event");
         g1.sign_with_keypair(&kp1);
         let g1_id = g1.id;
         graph.insert(g1).unwrap();
 
         // Creator 2: genesis — this should be fine even though creator 1 has seq 0
-        let mut g2 = Event::genesis(n2, vec![]);
+        let mut g2 = Event::genesis(n2, vec![]).expect("valid genesis event");
         g2.sign_with_keypair(&kp2);
         let g2_id = g2.id;
         graph.insert(g2).unwrap();
 
         // Creator 2: seq 1 — should be fine
         let vc = VectorClock::with_node(n2, 2);
-        let mut e2 = Event::new(n2, 1, vc, Some(g2_id), Some(g1_id), vec![]);
+        let mut e2 = Event::new(n2, 1, vc, Some(g2_id), Some(g1_id), vec![]).expect("valid event");
         e2.sign_with_keypair(&kp2);
         graph.insert(e2).unwrap();
 

--- a/omnia-consensus/src/consensus.rs
+++ b/omnia-consensus/src/consensus.rs
@@ -1321,7 +1321,7 @@ mod tests {
 
         for kp in &keypairs {
             let node_id = blake3_hash_domain(b"omnia-creator", &kp.verifying_key().to_bytes());
-            let mut e = Event::genesis(node_id, vec![node_id[0]]);
+            let mut e = Event::genesis(node_id, vec![node_id[0]]).expect("valid genesis event");
             e.sign_with_keypair(kp);
             let id = e.id;
             graph.insert(e).unwrap();
@@ -1338,7 +1338,7 @@ mod tests {
             let other = [n1, n2, n3, n4][(i + 1) % 4];
             vc.set(other, 1);
 
-            let mut e = Event::new(creator, 1, vc, Some(sp), Some(op), vec![]);
+            let mut e = Event::new(creator, 1, vc, Some(sp), Some(op), vec![]).expect("valid event");
             e.sign_with_keypair(kp);
             let id = e.id;
             graph.insert(e).unwrap();
@@ -1563,7 +1563,7 @@ mod tests {
         // Genesis events
         let mut genesis_ids = Vec::new();
         for (node_id, keypair) in &nodes {
-            let mut e = Event::genesis(*node_id, vec![node_id[0]]);
+            let mut e = Event::genesis(*node_id, vec![node_id[0]]).expect("valid genesis event");
             e.sign_with_keypair(keypair);
             let id = e.id;
             graph.insert(e).unwrap();
@@ -1614,7 +1614,7 @@ mod tests {
 
         let mut genesis_ids = Vec::new();
         for (node_id, keypair) in &nodes {
-            let mut e = Event::genesis(*node_id, vec![node_id[0]]);
+            let mut e = Event::genesis(*node_id, vec![node_id[0]]).expect("valid genesis event");
             e.sign_with_keypair(keypair);
             let id = e.id;
             graph.insert(e).unwrap();
@@ -1831,7 +1831,7 @@ mod proptests {
     fn arb_genesis_event() -> impl Strategy<Value = Event> {
         (any::<u8>(), any::<Vec<u8>>()).prop_map(|(creator_byte, payload)| {
             let creator = nid(creator_byte % 10);
-            Event::genesis(creator, payload)
+            Event::genesis(creator, payload).expect("valid genesis event")
         })
     }
 
@@ -1947,7 +1947,7 @@ mod timeout_tests {
 
         for kp in &keypairs {
             let node_id = blake3_hash_domain(b"omnia-creator", &kp.verifying_key().to_bytes());
-            let mut e = Event::genesis(node_id, vec![node_id[0]]);
+            let mut e = Event::genesis(node_id, vec![node_id[0]]).expect("valid genesis event");
             e.sign_with_keypair(kp);
             let id = e.id;
             graph.insert(e).unwrap();
@@ -1964,7 +1964,7 @@ mod timeout_tests {
             let other = [n1, n2, n3, n4][(i + 1) % 4];
             vc.set(other, 1);
 
-            let mut e = Event::new(creator, 1, vc, Some(sp), Some(op), vec![]);
+            let mut e = Event::new(creator, 1, vc, Some(sp), Some(op), vec![]).expect("valid event");
             e.sign_with_keypair(kp);
             let id = e.id;
             graph.insert(e).unwrap();

--- a/omnia-consensus/src/event_pool.rs
+++ b/omnia-consensus/src/event_pool.rs
@@ -378,7 +378,7 @@ mod tests {
 
     fn make_event(creator: NodeId, seq: u64) -> Event {
         let vc = VectorClock::with_node(creator, seq + 1);
-        Event::new(creator, seq, vc, None, None, vec![])
+        Event::new(creator, seq, vc, None, None, vec![]).expect("valid event")
     }
 
     #[test]
@@ -589,7 +589,7 @@ mod stress_test_pool_allocation {
 
     fn make_event(creator: NodeId, seq: u64) -> Event {
         let vc = VectorClock::with_node(creator, seq + 1);
-        Event::new(creator, seq, vc, None, None, vec![])
+        Event::new(creator, seq, vc, None, None, vec![]).expect("valid event")
     }
 
     /// Stress test: insert 10,000 events rapidly.

--- a/omnia-consensus/src/mempool.rs
+++ b/omnia-consensus/src/mempool.rs
@@ -113,7 +113,7 @@ mod tests {
         let keypair = generate_keypair();
         let node = test_node(creator);
         let vc = omnia_primitives::VectorClock::with_node(node, seq + 1);
-        let mut event = Event::new(node, seq, vc, None, None, payload);
+        let mut event = Event::new(node, seq, vc, None, None, payload).expect("valid event");
         event.sign_with_keypair(&keypair);
         event
     }

--- a/omnia-consensus/src/pruning_aware_pool.rs
+++ b/omnia-consensus/src/pruning_aware_pool.rs
@@ -399,7 +399,7 @@ mod tests {
 
     fn make_event(creator: NodeId, seq: u64) -> Event {
         let vc = VectorClock::with_node(creator, seq + 1);
-        Event::new(creator, seq, vc, None, None, vec![])
+        Event::new(creator, seq, vc, None, None, vec![]).expect("valid event")
     }
 
     #[test]

--- a/omnia-consensus/src/slashing.rs
+++ b/omnia-consensus/src/slashing.rs
@@ -2052,10 +2052,10 @@ mod tests {
 
         // Two events with same creator and sequence but different IDs
         let vc1 = VectorClock::with_node(n1, 1);
-        let mut e1 = Event::new(n1, 0, vc1.clone(), None, None, vec![1]);
+        let mut e1 = Event::new(n1, 0, vc1.clone(), None, None, vec![1]).expect("valid event");
         e1.sign_with_keypair(&kp);
 
-        let mut e2 = Event::new(n1, 0, vc1, None, None, vec![2]); // different payload → different id
+        let mut e2 = Event::new(n1, 0, vc1, None, None, vec![2]).expect("valid event"); // different payload → different id
         e2.sign_with_keypair(&kp);
 
         assert!(SlashingEngine::check_equivocation(&e1, &e2));
@@ -2073,10 +2073,10 @@ mod tests {
         let kp = generate_keypair();
 
         let vc = VectorClock::with_node(n1, 1);
-        let mut e1 = Event::new(n1, 0, vc.clone(), None, None, vec![1]);
+        let mut e1 = Event::new(n1, 0, vc.clone(), None, None, vec![1]).expect("valid event");
         e1.sign_with_keypair(&kp);
 
-        let mut e2 = Event::new(n1, 1, vc, None, None, vec![1]); // different sequence
+        let mut e2 = Event::new(n1, 1, vc, None, None, vec![1]).expect("valid event"); // different sequence
         e2.sign_with_keypair(&kp);
 
         assert!(!SlashingEngine::check_equivocation(&e1, &e2));

--- a/omnia-consensus/src/thread_pool.rs
+++ b/omnia-consensus/src/thread_pool.rs
@@ -269,7 +269,7 @@ mod tests {
         OsRng.fill_bytes(&mut creator);
 
         let vc = VectorClock::with_node(creator, seq + 1);
-        let mut event = Event::new(creator, seq, vc, None, None, vec![1, 2, 3]);
+        let mut event = Event::new(creator, seq, vc, None, None, vec![1, 2, 3]).expect("valid event");
 
         // Use a real keypair for proper signing
         let keypair = ed25519_dalek::SigningKey::generate(&mut OsRng);

--- a/omnia-consensus/tests/multi_node_test.rs
+++ b/omnia-consensus/tests/multi_node_test.rs
@@ -65,9 +65,9 @@ fn test_multi_node_bft_finality() {
         vector_clock.set(creator, seq + 1);
 
         let event = if self_parent.is_none() {
-            Event::genesis(creator, vec![seq as u8])
+            Event::genesis(creator, vec![seq as u8]).expect("valid genesis event")
         } else {
-            Event::new(creator, seq, vector_clock.clone(), self_parent, None, vec![seq as u8])
+            Event::new(creator, seq, vector_clock.clone(), self_parent, None, vec![seq as u8]).expect("valid event")
         };
 
         let event_id = event.id;
@@ -124,7 +124,7 @@ fn test_bft_safety_with_byzantine_node() {
         vector_clock.set(honest_creator, seq + 1);
 
         let event = if self_parent.is_none() {
-            Event::genesis(honest_creator, vec![seq as u8])
+            Event::genesis(honest_creator, vec![seq as u8]).expect("valid genesis event")
         } else {
             Event::new(
                 honest_creator,
@@ -134,6 +134,7 @@ fn test_bft_safety_with_byzantine_node() {
                 None,
                 vec![seq as u8],
             )
+            .expect("valid event")
         };
 
         let event_id = event.id;
@@ -204,6 +205,7 @@ fn test_consensus_progress_with_minority_faults() {
 
             let event = if self_parents[node_idx].is_none() {
                 Event::genesis(creator, format!("round-{round}-node-{node_idx}").into_bytes())
+                    .expect("valid genesis event")
             } else {
                 Event::new(
                     creator,
@@ -213,6 +215,7 @@ fn test_consensus_progress_with_minority_faults() {
                     other_parent,
                     format!("round-{round}-node-{node_idx}").into_bytes(),
                 )
+                .expect("valid event")
             };
 
             let event_id = event.id;

--- a/omnia-crypto/src/bls.rs
+++ b/omnia-crypto/src/bls.rs
@@ -555,8 +555,8 @@ pub fn aggregate_signatures_dedup(signatures: &[(BlsPublicKey, BlsSignature)]) -
     // Check for duplicate signers by public key
     let mut seen = std::collections::HashSet::new();
     for (pk, _sig) in signatures {
-        let pk_bytes = pk.as_bytes();
-        if !seen.insert(pk_bytes.to_vec()) {
+        let pk_bytes: [u8; 96] = pk.as_bytes().try_into().unwrap_or([0u8; 96]);
+        if !seen.insert(pk_bytes) {
             return Err(BlsError::AggregationFailed(format!(
                 "duplicate signer detected: public key {} appears more than once",
                 hex::encode(&pk_bytes[..8])

--- a/omnia-crypto/src/bls12_381_scalar.rs
+++ b/omnia-crypto/src/bls12_381_scalar.rs
@@ -171,7 +171,7 @@ impl Scalar {
 
     /// Test if this scalar is zero.
     pub fn is_zero(&self) -> bool {
-        self.to_bytes().iter().all(|&b| b == 0)
+        self.to_bytes().ct_eq(&[0u8; 32]).unwrap_u8() == 1
     }
 
     /// The multiplicative identity (one).

--- a/omnia-crypto/src/keystore.rs
+++ b/omnia-crypto/src/keystore.rs
@@ -592,7 +592,7 @@ impl EncryptedKeyStore {
 
         // SLIP-0010 master key derivation from the seed
         // HMAC-SHA512(Key = "ed25519 seed", Data = seed)
-        let master_ikm = hmac_sha512(b"ed25519 seed", &secret_bytes);
+        let master_ikm = hmac_sha512(b"ed25519 seed", &secret_bytes)?;
         let mut key = master_ikm[..32]
             .try_into()
             .map_err(|_| KeyStoreError::Crypto("key slice error".into()))?;
@@ -610,7 +610,7 @@ impl EncryptedKeyStore {
         ];
 
         for &child_index in &derivation_path {
-            let derived = slip0010_derive_child(&key, &chain_code, child_index);
+            let derived = slip0010_derive_child(&key, &chain_code, child_index)?;
             key = derived[..32]
                 .try_into()
                 .map_err(|_| KeyStoreError::Crypto("derived key slice error".into()))?;
@@ -730,7 +730,7 @@ impl KeyRotationProof {
 /// Output format: `salt(32) || nonce(12) || ciphertext+tag`
 fn aes_gcm_encrypt(data: &[u8], passphrase: &str) -> Result<Vec<u8>, KeyStoreError> {
     let salt = generate_salt();
-    let key = derive_key_hkdf(passphrase, &salt);
+    let key = derive_key_hkdf(passphrase, &salt)?;
     let cipher = Aes256Gcm::new_from_slice(&key)
         .map_err(|_| KeyStoreError::InvalidFormat("AES key derivation failed".into()))?;
 
@@ -785,7 +785,7 @@ fn aes_gcm_decrypt(data: &[u8], passphrase: &str) -> Result<Vec<u8>, KeyStoreErr
     let nonce = Nonce::from_slice(&data[32..44]);
     let ciphertext = &data[44..];
 
-    let key = derive_key_hkdf(passphrase, salt);
+    let key = derive_key_hkdf(passphrase, salt)?;
     let cipher = Aes256Gcm::new_from_slice(&key)
         .map_err(|_| KeyStoreError::InvalidFormat("AES key derivation failed".into()))?;
 
@@ -795,12 +795,12 @@ fn aes_gcm_decrypt(data: &[u8], passphrase: &str) -> Result<Vec<u8>, KeyStoreErr
 }
 
 /// Derive a 32-byte encryption key using HKDF-SHA256.
-fn derive_key_hkdf(passphrase: &str, salt: &[u8]) -> [u8; 32] {
+fn derive_key_hkdf(passphrase: &str, salt: &[u8]) -> Result<[u8; 32], KeyStoreError> {
     let hkdf = Hkdf::<Sha256>::new(Some(salt), passphrase.as_bytes());
     let mut key = [0u8; 32];
     hkdf.expand(b"omnia-keystore-v1", &mut key)
-        .expect("HKDF expand should not fail with 32-byte output");
-    key
+        .map_err(|e| KeyStoreError::Crypto(format!("HKDF expand failed: {e}")))?;
+    Ok(key)
 }
 
 /// Generate a random 32-byte salt.
@@ -818,17 +818,18 @@ fn generate_salt() -> [u8; 32] {
 ///
 /// Returns a 64-byte output: the first 32 bytes are the derived key,
 /// the second 32 bytes are the derived chain code.
-fn hmac_sha512(key: &[u8], data: &[u8]) -> [u8; 64] {
+fn hmac_sha512(key: &[u8], data: &[u8]) -> Result<[u8; 64], KeyStoreError> {
     use hmac::Mac;
     type HmacSha512 = hmac::Hmac<sha2::Sha512>;
 
-    let mut mac = <HmacSha512 as Mac>::new_from_slice(key).expect("HMAC can accept any key size");
+    let mut mac = <HmacSha512 as Mac>::new_from_slice(key)
+        .map_err(|e| KeyStoreError::Crypto(format!("HMAC key init failed: {e}")))?;
     mac.update(data);
     let result = mac.finalize().into_bytes();
 
     let mut output = [0u8; 64];
     output.copy_from_slice(&result);
-    output
+    Ok(output)
 }
 
 /// Derive a SLIP-0010 child key from a parent key and chain code.
@@ -839,7 +840,7 @@ fn hmac_sha512(key: &[u8], data: &[u8]) -> [u8; 64] {
 /// Returns a 64-byte array where:
 /// - Bytes 0..32 are the derived child key
 /// - Bytes 32..64 are the derived child chain code
-fn slip0010_derive_child(parent_key: &[u8; 32], chain_code: &[u8; 32], index: u32) -> [u8; 64] {
+fn slip0010_derive_child(parent_key: &[u8; 32], chain_code: &[u8; 32], index: u32) -> Result<[u8; 64], KeyStoreError> {
     // SLIP-0010: data = 0x00 || ser_256(k_par) || i (4 bytes big-endian, hardened)
     let mut data = Vec::with_capacity(1 + 32 + 4);
     data.push(0x00);
@@ -881,7 +882,7 @@ fn xor_decrypt(data: &[u8], passphrase: &str) -> Vec<u8> {
     note = "Use derive_key_hkdf instead — deterministic key derivation without salt is insecure"
 )]
 fn derive_key(passphrase: &str) -> [u8; 32] {
-    blake3_hash_domain(b"omnia-commitment", passphrase.as_bytes())
+    blake3_hash_domain(b"OMNIA-KEY-DERIVATION-V1", passphrase.as_bytes())
 }
 
 #[cfg(test)]

--- a/omnia-crypto/src/keystore.rs
+++ b/omnia-crypto/src/keystore.rs
@@ -1099,8 +1099,8 @@ mod tests {
         let passphrase = "same-passphrase";
         let salt1 = [1u8; 32];
         let salt2 = [2u8; 32];
-        let key1 = derive_key_hkdf(passphrase, &salt1);
-        let key2 = derive_key_hkdf(passphrase, &salt2);
+        let key1 = derive_key_hkdf(passphrase, &salt1).expect("HKDF derive key 1");
+        let key2 = derive_key_hkdf(passphrase, &salt2).expect("HKDF derive key 2");
         assert_ne!(key1, key2, "Different salts must produce different keys from HKDF");
     }
 
@@ -1108,8 +1108,8 @@ mod tests {
     fn test_derive_key_hkdf_same_inputs() {
         let passphrase = "same-passphrase";
         let salt = [42u8; 32];
-        let key1 = derive_key_hkdf(passphrase, &salt);
-        let key2 = derive_key_hkdf(passphrase, &salt);
+        let key1 = derive_key_hkdf(passphrase, &salt).expect("HKDF derive key 1");
+        let key2 = derive_key_hkdf(passphrase, &salt).expect("HKDF derive key 2");
         assert_eq!(key1, key2, "Same passphrase and salt must produce the same key");
     }
 

--- a/omnia-crypto/src/threshold.rs
+++ b/omnia-crypto/src/threshold.rs
@@ -951,7 +951,7 @@ impl FeldmanVssSession {
             .collect();
 
         self.phase = DkgPhase::ShareDistribution;
-        Ok(packages?)
+        packages
     }
 
     /// Process received shares from another participant (Step 2).

--- a/omnia-crypto/src/threshold.rs
+++ b/omnia-crypto/src/threshold.rs
@@ -880,7 +880,10 @@ impl FeldmanVssSession {
         // f(x) = a_0 + a_1*x + a_2*x^2 + ... + a_{t-1}*x^{t-1}
         let polynomial_coeffs: Vec<Scalar> = (0..self.threshold).map(|_| Scalar::random(rng)).collect();
         if polynomial_coeffs[0].is_zero() {
-            return Err(DkgError::InvalidShare([0u8; 4], "Constant term coefficient must not be zero".to_string()));
+            return Err(DkgError::InvalidShare(
+                [0u8; 4],
+                "Constant term coefficient must not be zero".to_string(),
+            ));
         }
         self.polynomial_coeffs = Some(polynomial_coeffs.clone());
 

--- a/omnia-crypto/src/threshold.rs
+++ b/omnia-crypto/src/threshold.rs
@@ -477,7 +477,8 @@ pub struct DkgSharePackage {
 /// performing true Distributed Key Generation with Feldman VSS polynomial
 /// evaluation and share verification. See the `todo!()` in `finalize()`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[deprecated(note = "This is key aggregation, not true DKG. True DKG with Feldman VSS is not yet implemented.")]
+#[deprecated(since = "0.2.0", note = "DkgSession is insecure - use FeldmanVssSession instead")]
+#[doc(hidden)]
 pub struct DkgSession {
     /// Unique session identifier.
     pub session_id: u64,
@@ -528,6 +529,7 @@ impl DkgSession {
         my_id: ParticipantId,
         rng: &mut (impl CryptoRng + RngCore),
     ) -> Result<Vec<(ParticipantId, DkgSharePackage)>, DkgError> {
+        tracing::error!("DkgSession::generate_shares is deprecated and insecure. Use FeldmanVssSession instead.");
         if self.phase != DkgPhase::Init {
             return Err(DkgError::WrongPhase {
                 expected: "Init".to_string(),
@@ -556,7 +558,7 @@ impl DkgSession {
         let commitments = vec![keypair.public_key_bytes().to_vec()];
 
         // Create share packages for each participant
-        let packages: Vec<(ParticipantId, DkgSharePackage)> = self
+        let packages: Result<Vec<(ParticipantId, DkgSharePackage)>, DkgError> = self
             .participants
             .iter()
             .filter(|&&p| p != my_id)
@@ -576,9 +578,9 @@ impl DkgSession {
                     v.extend_from_slice(&participant_id);
                     v
                 };
-                let encrypted = aes256gcm_encrypt_dkg(&share_data, &share_seed, &aad);
+                let encrypted = aes256gcm_encrypt_dkg(&share_data, &share_seed, &aad)?;
 
-                (
+                Ok((
                     participant_id,
                     DkgSharePackage {
                         sender: my_id,
@@ -586,9 +588,10 @@ impl DkgSession {
                         commitments: commitments.clone(),
                         version: 2,
                     },
-                )
+                ))
             })
             .collect();
+        let packages = packages?;
 
         // Store our own commitments
         self.commitments.insert(my_id, commitments);
@@ -876,6 +879,9 @@ impl FeldmanVssSession {
         // Generate random polynomial coefficients as BLS12-381 scalars.
         // f(x) = a_0 + a_1*x + a_2*x^2 + ... + a_{t-1}*x^{t-1}
         let polynomial_coeffs: Vec<Scalar> = (0..self.threshold).map(|_| Scalar::random(rng)).collect();
+        if polynomial_coeffs[0].is_zero() {
+            return Err(DkgError::InvalidShare([0u8; 4], "Constant term coefficient must not be zero".to_string()));
+        }
         self.polynomial_coeffs = Some(polynomial_coeffs.clone());
 
         // Compute Feldman commitments: C_j = a_j * G1
@@ -904,7 +910,7 @@ impl FeldmanVssSession {
         self.received_shares.insert(my_id, self_share);
 
         // Evaluate polynomial at each participant's index and encrypt the share
-        let packages: Vec<(ParticipantId, DkgSharePackage)> = self
+        let packages: Result<Vec<(ParticipantId, DkgSharePackage)>, DkgError> = self
             .participants
             .iter()
             .enumerate()
@@ -927,9 +933,9 @@ impl FeldmanVssSession {
                     v.extend_from_slice(&participant_id);
                     v
                 };
-                let encrypted = aes256gcm_encrypt_dkg(&share_bytes, &share_seed, &aad);
+                let encrypted = aes256gcm_encrypt_dkg(&share_bytes, &share_seed, &aad)?;
 
-                (
+                Ok((
                     participant_id,
                     DkgSharePackage {
                         sender: my_id,
@@ -937,12 +943,12 @@ impl FeldmanVssSession {
                         commitments: commitments.clone(),
                         version: 2,
                     },
-                )
+                ))
             })
             .collect();
 
         self.phase = DkgPhase::ShareDistribution;
-        Ok(packages)
+        Ok(packages?)
     }
 
     /// Process received shares from another participant (Step 2).
@@ -1190,42 +1196,44 @@ fn xor_encrypt_dkg(data: &[u8], key: &[u8; 32]) -> Vec<u8> {
 }
 
 /// Derive AES-256 key for DKG share encryption from BLAKE3 key material.
-fn derive_dkg_aes_key(key_material: &[u8; 32]) -> [u8; 32] {
+fn derive_dkg_aes_key(key_material: &[u8; 32]) -> Result<[u8; 32], DkgError> {
     use hkdf::Hkdf;
     use sha2::Sha256;
     let hk = Hkdf::<Sha256>::new(Some(&key_material[..16]), &key_material[16..]);
     let mut aes_key = [0u8; 32];
     hk.expand(b"OMNIA-DKG-SHARE-V1", &mut aes_key)
-        .expect("HKDF expand for 32 bytes");
-    aes_key
+        .map_err(|e| DkgError::InvalidShare([0u8; 4], format!("HKDF expand failed: {e}")))?;
+    Ok(aes_key)
 }
 
 /// AES-256-GCM encrypt a DKG share with associated data.
-fn aes256gcm_encrypt_dkg(plaintext: &[u8], key_material: &[u8; 32], aad: &[u8]) -> AeadCiphertext {
+fn aes256gcm_encrypt_dkg(plaintext: &[u8], key_material: &[u8; 32], aad: &[u8]) -> Result<AeadCiphertext, DkgError> {
     use aes_gcm::{aead::Aead, Aes256Gcm, KeyInit, Nonce};
     use rand::RngCore;
 
-    let aes_key = derive_dkg_aes_key(key_material);
-    let cipher = Aes256Gcm::new_from_slice(&aes_key).expect("AES key valid");
+    let aes_key = derive_dkg_aes_key(key_material)?;
+    let cipher = Aes256Gcm::new_from_slice(&aes_key)
+        .map_err(|e| DkgError::InvalidShare([0u8; 4], format!("AES key init failed: {e}")))?;
     let mut nonce = [0u8; 12];
     rand::thread_rng().fill_bytes(&mut nonce);
     let nonce_obj = Nonce::from_slice(&nonce);
     let ciphertext = cipher
         .encrypt(nonce_obj, aes_gcm::aead::Payload { msg: plaintext, aad })
-        .expect("AES-256-GCM encryption");
-    AeadCiphertext {
+        .map_err(|e| DkgError::InvalidShare([0u8; 4], format!("AES-256-GCM encryption failed: {e}")))?;
+    Ok(AeadCiphertext {
         ciphertext,
         nonce,
         associated_data: aad.to_vec(),
-    }
+    })
 }
 
 /// AES-256-GCM decrypt a DKG share.
 fn aes256gcm_decrypt_dkg(ct: &AeadCiphertext, key_material: &[u8; 32]) -> Result<Vec<u8>, DkgError> {
     use aes_gcm::{aead::Aead, Aes256Gcm, KeyInit, Nonce};
 
-    let aes_key = derive_dkg_aes_key(key_material);
-    let cipher = Aes256Gcm::new_from_slice(&aes_key).expect("AES key valid");
+    let aes_key = derive_dkg_aes_key(key_material)?;
+    let cipher = Aes256Gcm::new_from_slice(&aes_key)
+        .map_err(|e| DkgError::InvalidShare([0u8; 4], format!("AES key init failed: {e}")))?;
     let nonce = Nonce::from_slice(&ct.nonce);
     cipher
         .decrypt(
@@ -1610,7 +1618,7 @@ mod tests {
         let data = b"dkg-share-secret";
         let key = [0xAB_u8; 32];
         let aad = b"sender||recipient";
-        let ct = aes256gcm_encrypt_dkg(data, &key, aad);
+        let ct = aes256gcm_encrypt_dkg(data, &key, aad).unwrap();
         let pt = aes256gcm_decrypt_dkg(&ct, &key).unwrap();
         assert_eq!(pt, data.to_vec());
     }
@@ -1620,7 +1628,7 @@ mod tests {
         let data = b"tamper-test-share";
         let key = [0xCD_u8; 32];
         let aad = b"s||r";
-        let mut ct = aes256gcm_encrypt_dkg(data, &key, aad);
+        let mut ct = aes256gcm_encrypt_dkg(data, &key, aad).unwrap();
         ct.ciphertext[0] ^= 0xFF;
         let result = aes256gcm_decrypt_dkg(&ct, &key);
         assert!(result.is_err(), "Tampered ciphertext should fail AEAD");
@@ -1631,7 +1639,7 @@ mod tests {
         let data = b"relay-attack-share";
         let key = [0xEF_u8; 32];
         let aad = b"sender1||recipient1";
-        let ct = aes256gcm_encrypt_dkg(data, &key, aad);
+        let ct = aes256gcm_encrypt_dkg(data, &key, aad).unwrap();
         // Change AAD to simulate relay attack
         let mut ct_relayed = ct.clone();
         ct_relayed.associated_data = b"sender1||recipient2".to_vec();
@@ -1644,7 +1652,7 @@ mod tests {
         let data = b"wrong-recipient-share";
         let key = [0x11_u8; 32];
         let aad = b"s||r1";
-        let ct = aes256gcm_encrypt_dkg(data, &key, aad);
+        let ct = aes256gcm_encrypt_dkg(data, &key, aad).unwrap();
         let wrong_key = [0x22_u8; 32];
         let result = aes256gcm_decrypt_dkg(&ct, &wrong_key);
         assert!(result.is_err(), "Wrong key should fail AES-GCM decryption");

--- a/omnia-crypto/src/vrf.rs
+++ b/omnia-crypto/src/vrf.rs
@@ -127,7 +127,7 @@ pub fn deterministic_compute(keypair: &NodeKeypair, input: &[u8]) -> Determinist
     preimage.extend_from_slice(&signature.to_bytes());
     preimage.extend_from_slice(input);
 
-    let output: [u8; 32] = blake3_hash_domain(b"omnia-commitment", &preimage);
+    let output: [u8; 32] = blake3_hash_domain(b"OMNIA-VRF-OUTPUT-V1", &preimage);
 
     DeterministicOutput { output, proof }
 }
@@ -186,7 +186,7 @@ pub fn deterministic_verify(
     preimage.extend_from_slice(&proof_bytes);
     preimage.extend_from_slice(input);
 
-    let expected_output: [u8; 32] = blake3_hash_domain(b"omnia-commitment", &preimage);
+    let expected_output: [u8; 32] = blake3_hash_domain(b"OMNIA-VRF-OUTPUT-V1", &preimage);
 
     if expected_output.ct_eq(&det_output.output).unwrap_u8() == 0 {
         return Err(DeterministicHashError::VerificationFailed(

--- a/omnia-network/Cargo.toml
+++ b/omnia-network/Cargo.toml
@@ -23,9 +23,6 @@ thiserror = "2.0"
 hex = "0.4"
 futures = { version = "0.3", optional = true }
 
-# Snapshot replication needs these for StateSnapshot interop
-chrono = { version = "0.4", features = ["serde"] }
-
 [features]
 default = ["network"]
 network = ["dep:libp2p", "dep:tokio", "dep:futures"]

--- a/omnia-network/src/compact_event_encoding.rs
+++ b/omnia-network/src/compact_event_encoding.rs
@@ -584,7 +584,7 @@ mod tests {
         let mut encoder = CompactEncoder::new(1024, 16);
 
         let keypair = omnia_crypto::generate_keypair();
-        let mut event = Event::genesis(node(1), vec![1, 2, 3]);
+        let mut event = Event::genesis(node(1), vec![1, 2, 3]).expect("valid genesis event");
         event.sign_with_keypair(&keypair);
 
         let peer_id = node(2);
@@ -646,7 +646,7 @@ mod tests {
         }
 
         let keypair = omnia_crypto::generate_keypair();
-        let mut event = Event::new(node(1), 0, vc, None, None, vec![]);
+        let mut event = Event::new(node(1), 0, vc, None, None, vec![]).expect("valid event");
         event.sign_with_keypair(&keypair);
 
         let peer_id = node(2);
@@ -665,7 +665,7 @@ mod tests {
         local.set(node(2), 3);
 
         let keypair = omnia_crypto::generate_keypair();
-        let mut event = Event::genesis(node(1), vec![1, 2, 3]);
+        let mut event = Event::genesis(node(1), vec![1, 2, 3]).expect("valid genesis event");
         event.sign_with_keypair(&keypair);
 
         let remote = VectorClock::new();

--- a/omnia-network/src/compression.rs
+++ b/omnia-network/src/compression.rs
@@ -53,8 +53,7 @@ pub fn deserialize_with_compression<T: DeserializeOwned>(data: &[u8]) -> Result<
         COMPRESSION_NONE => payload.to_vec(),
         COMPRESSION_SNAPPY => {
             // Check the declared decompressed size before allocating.
-            let decompressed_len =
-                snap::raw::decompress_len(payload).map_err(|e| e.to_string())?;
+            let decompressed_len = snap::raw::decompress_len(payload).map_err(|e| e.to_string())?;
             if decompressed_len > MAX_DECOMPRESSED_SIZE {
                 return Err(format!(
                     "decompressed size {} exceeds limit {}",

--- a/omnia-network/src/compression.rs
+++ b/omnia-network/src/compression.rs
@@ -1,0 +1,70 @@
+//! Shared compression utilities for gossip messages.
+
+use serde::{de::DeserializeOwned, Serialize};
+
+/// Compression algorithm identifier: uncompressed.
+pub const COMPRESSION_NONE: u8 = 0;
+/// Compression algorithm identifier: snappy compressed.
+pub const COMPRESSION_SNAPPY: u8 = 1;
+/// Minimum payload size (bytes) to trigger compression.
+pub const COMPRESSION_THRESHOLD: usize = 1024;
+/// Maximum allowed decompressed size (2 MiB).
+pub const MAX_DECOMPRESSED_SIZE: usize = 2 * 1024 * 1024;
+
+/// Serialize and optionally compress a message.
+///
+/// If the serialized payload exceeds [`COMPRESSION_THRESHOLD`] bytes and
+/// snappy compression reduces the size, the output is prefixed with
+/// [`COMPRESSION_SNAPPY`]. Otherwise, the output is prefixed with
+/// [`COMPRESSION_NONE`].
+pub fn serialize_with_compression<T: Serialize>(msg: &T) -> Result<Vec<u8>, String> {
+    let payload = postcard::to_allocvec(msg).map_err(|e| e.to_string())?;
+    if payload.len() >= COMPRESSION_THRESHOLD {
+        let mut encoder = snap::raw::Encoder::new();
+        let compressed = encoder.compress_vec(&payload).map_err(|e| e.to_string())?;
+        if compressed.len() < payload.len() {
+            let mut out = Vec::with_capacity(1 + compressed.len());
+            out.push(COMPRESSION_SNAPPY);
+            out.extend_from_slice(&compressed);
+            return Ok(out);
+        }
+    }
+    let mut out = Vec::with_capacity(1 + payload.len());
+    out.push(COMPRESSION_NONE);
+    out.extend_from_slice(&payload);
+    Ok(out)
+}
+
+/// Deserialize a message, handling decompression.
+///
+/// Reads the first byte as a compression flag:
+/// - [`COMPRESSION_NONE`]: payload follows verbatim
+/// - [`COMPRESSION_SNAPPY`]: snappy-compressed payload follows
+///
+/// Enforces a decompressed size limit of [`MAX_DECOMPRESSED_SIZE`] to
+/// prevent memory exhaustion from malicious payloads.
+pub fn deserialize_with_compression<T: DeserializeOwned>(data: &[u8]) -> Result<T, String> {
+    if data.is_empty() {
+        return Err("empty payload".to_string());
+    }
+    let compression = data[0];
+    let payload = &data[1..];
+    let decompressed = match compression {
+        COMPRESSION_NONE => payload.to_vec(),
+        COMPRESSION_SNAPPY => {
+            // Check the declared decompressed size before allocating.
+            let decompressed_len =
+                snap::raw::decompress_len(payload).map_err(|e| e.to_string())?;
+            if decompressed_len > MAX_DECOMPRESSED_SIZE {
+                return Err(format!(
+                    "decompressed size {} exceeds limit {}",
+                    decompressed_len, MAX_DECOMPRESSED_SIZE
+                ));
+            }
+            let mut decoder = snap::raw::Decoder::new();
+            decoder.decompress_vec(payload).map_err(|e| e.to_string())?
+        }
+        _ => return Err(format!("unknown compression algorithm: {}", compression)),
+    };
+    postcard::from_bytes(&decompressed).map_err(|e| e.to_string())
+}

--- a/omnia-network/src/fast_sync.rs
+++ b/omnia-network/src/fast_sync.rs
@@ -186,7 +186,7 @@ pub fn select_target_checkpoint(
     }
 
     // Find the group with supermajority agreement and highest round
-    let supermajority = (2 * total_peers / 3) + 1;
+    let supermajority = (2 * total_peers).div_ceil(3);
     let mut best: Option<SyncCheckpoint> = None;
 
     for ((round, _), cps) in &agreement_map {

--- a/omnia-network/src/gossip.rs
+++ b/omnia-network/src/gossip.rs
@@ -641,7 +641,7 @@ pub enum GossipError {
 /// Delegates to [`crate::compression::serialize_with_compression`] and
 /// converts the error type to [`GossipError`].
 pub fn serialize_compressed<T: Serialize>(value: &T) -> Result<Vec<u8>, GossipError> {
-    serialize_with_compression(value).map_err(|e| GossipError::SerializationError(e))
+    serialize_with_compression(value).map_err(GossipError::SerializationError)
 }
 
 /// Deserialize an event with optional snappy decompression.

--- a/omnia-network/src/gossip.rs
+++ b/omnia-network/src/gossip.rs
@@ -547,11 +547,16 @@ impl GossipProtocol {
                         self.stats.events_received += 1;
                         // FIX 3: Evict random half instead of clearing everything
                         if self.seen_events.len() > MAX_SEEN_EVENTS {
-                            let to_remove: Vec<_> = self.seen_events.iter().take(MAX_SEEN_EVENTS / 2).copied().collect();
+                            let to_remove: Vec<_> =
+                                self.seen_events.iter().take(MAX_SEEN_EVENTS / 2).copied().collect();
                             for id in to_remove {
                                 self.seen_events.remove(&id);
                             }
-                            tracing::debug!("seen_events exceeded {}, evicted {} entries", MAX_SEEN_EVENTS, MAX_SEEN_EVENTS / 2);
+                            tracing::debug!(
+                                "seen_events exceeded {}, evicted {} entries",
+                                MAX_SEEN_EVENTS,
+                                MAX_SEEN_EVENTS / 2
+                            );
                         }
                     }
                 }

--- a/omnia-network/src/gossip.rs
+++ b/omnia-network/src/gossip.rs
@@ -14,7 +14,8 @@ use tokio::sync::{mpsc, RwLock};
 use tracing::{info, warn};
 
 use crate::blake3_domain::blake3_hash_domain;
-use crate::network::{NetworkCommand, NetworkEvent, OmniaNetwork};
+use crate::compression::{deserialize_with_compression, serialize_with_compression};
+use crate::network::{extract_peer_id_from_multiaddr, NetworkCommand, NetworkEvent, OmniaNetwork};
 use omnia_consensus::causal_graph::{CausalGraph, CausalGraphError};
 use omnia_consensus::rate_limiter::RateLimiter;
 use omnia_primitives::{Event, EventBatch, EventId, EventRequest, MAX_PAYLOAD_SIZE};
@@ -538,12 +539,19 @@ impl GossipProtocol {
 
                     if !self.seen_events.contains(&event.id) {
                         self.seen_events.insert(event.id);
+                        // FIX 8: Enforce max_pending limit
+                        if self.pending_events.len() >= self.config.max_pending {
+                            self.pending_events.pop_front(); // drop oldest to make room
+                        }
                         self.pending_events.push_back(*event);
                         self.stats.events_received += 1;
-                        // Prune seen_events if it exceeds the bound
+                        // FIX 3: Evict random half instead of clearing everything
                         if self.seen_events.len() > MAX_SEEN_EVENTS {
-                            self.seen_events.clear();
-                            tracing::debug!("seen_events exceeded {}, cleared dedup cache", MAX_SEEN_EVENTS);
+                            let to_remove: Vec<_> = self.seen_events.iter().take(MAX_SEEN_EVENTS / 2).copied().collect();
+                            for id in to_remove {
+                                self.seen_events.remove(&id);
+                            }
+                            tracing::debug!("seen_events exceeded {}, evicted {} entries", MAX_SEEN_EVENTS, MAX_SEEN_EVENTS / 2);
                         }
                     }
                 }
@@ -562,19 +570,22 @@ impl GossipProtocol {
         // Process all pending events (both locally created and network received)
         let to_process: Vec<Event> = self.pending_events.drain(..).collect();
 
-        for event in to_process {
+        // FIX 4: Batch graph writes — acquire write lock once for all inserts
+        {
             let mut graph = self.graph.write().await;
-            match graph.insert(event.clone()) {
-                Ok(ids) => {
-                    self.stats.events_accepted += 1;
-                    inserted_ids.extend(ids);
-                }
-                Err(CausalGraphError::DuplicateEvent(_)) => {
-                    self.stats.events_rejected += 1;
-                }
-                Err(e) => {
-                    warn!("Failed to insert event: {}", e);
-                    self.stats.events_rejected += 1;
+            for event in &to_process {
+                match graph.insert(event.clone()) {
+                    Ok(ids) => {
+                        self.stats.events_accepted += 1;
+                        inserted_ids.extend(ids);
+                    }
+                    Err(CausalGraphError::DuplicateEvent(_)) => {
+                        self.stats.events_rejected += 1;
+                    }
+                    Err(e) => {
+                        warn!("Failed to insert event: {}", e);
+                        self.stats.events_rejected += 1;
+                    }
                 }
             }
         }
@@ -582,22 +593,6 @@ impl GossipProtocol {
         Ok(inserted_ids)
     }
 }
-
-/// Try to extract a PeerId from a Multiaddr that ends with /p2p/<peer-id>.
-fn extract_peer_id_from_multiaddr(addr: &Multiaddr) -> Option<PeerId> {
-    use libp2p::multiaddr::Protocol;
-    addr.iter().find_map(|proto| match proto {
-        Protocol::P2p(peer_id) => Some(peer_id),
-        _ => None,
-    })
-}
-
-/// Compression flag for gossip messages: uncompressed.
-const COMPRESSION_NONE: u8 = 0x00;
-/// Compression flag for gossip messages: snappy compressed.
-const COMPRESSION_SNAPPY: u8 = 0x01;
-/// Minimum payload size for compression (smaller payloads aren't worth compressing).
-const COMPRESSION_THRESHOLD: usize = 256;
 
 /// Errors from the gossip protocol
 #[derive(Error, Debug, Clone)]
@@ -638,59 +633,23 @@ pub enum GossipError {
 
 /// Serialize an event with optional snappy compression.
 ///
-/// If the serialized payload exceeds `COMPRESSION_THRESHOLD` bytes and
-/// compression reduces the size, the output is prefixed with `0x01`
-/// (snappy flag). Otherwise, the output is prefixed with `0x00` (uncompressed).
-/// This flag byte ensures forward and backward compatibility.
+/// Delegates to [`crate::compression::serialize_with_compression`] and
+/// converts the error type to [`GossipError`].
 pub fn serialize_compressed<T: Serialize>(value: &T) -> Result<Vec<u8>, GossipError> {
-    let raw = postcard::to_allocvec(value).map_err(|e| GossipError::SerializationError(e.to_string()))?;
-
-    if raw.len() > COMPRESSION_THRESHOLD {
-        let mut encoder = snap::raw::Encoder::new();
-        let compressed = encoder
-            .compress_vec(&raw)
-            .map_err(|e| GossipError::Compression(e.to_string()))?;
-
-        if compressed.len() < raw.len() {
-            let mut output = Vec::with_capacity(1 + compressed.len());
-            output.push(COMPRESSION_SNAPPY);
-            output.extend_from_slice(&compressed);
-            return Ok(output);
-        }
-    }
-
-    let mut output = Vec::with_capacity(1 + raw.len());
-    output.push(COMPRESSION_NONE);
-    output.extend_from_slice(&raw);
-    Ok(output)
+    serialize_with_compression(value).map_err(|e| GossipError::SerializationError(e))
 }
 
 /// Deserialize an event with optional snappy decompression.
 ///
-/// Reads the first byte as a compression flag:
-/// - `0x00`: uncompressed payload follows
-/// - `0x01`: snappy-compressed payload follows
+/// Delegates to [`crate::compression::deserialize_with_compression`] and
+/// converts the error type to [`GossipError`].
 pub fn deserialize_compressed<T: serde::de::DeserializeOwned>(data: &[u8]) -> Result<T, GossipError> {
-    let (flag, payload) = data
-        .split_first()
-        .ok_or_else(|| GossipError::InvalidMessageFormat("empty message".to_string()))?;
-
-    let raw = match *flag {
-        COMPRESSION_NONE => payload.to_vec(),
-        COMPRESSION_SNAPPY => {
-            let mut decoder = snap::raw::Decoder::new();
-            decoder
-                .decompress_vec(payload)
-                .map_err(|e| GossipError::Compression(e.to_string()))?
-        }
-        _ => {
-            return Err(GossipError::InvalidMessageFormat(format!(
-                "unknown compression flag: 0x{flag:02x}"
-            )));
-        }
-    };
-
-    postcard::from_bytes(&raw).map_err(|e| GossipError::SerializationError(e.to_string()))
+    deserialize_with_compression(data).map_err(|e| match e {
+        s if s.starts_with("unknown compression") => GossipError::InvalidMessageFormat(s),
+        s if s.starts_with("empty payload") => GossipError::InvalidMessageFormat(s),
+        s if s.contains("decompress") || s.contains("exceeds limit") => GossipError::Compression(s),
+        s => GossipError::SerializationError(s),
+    })
 }
 
 impl From<CausalGraphError> for GossipError {
@@ -1046,11 +1005,22 @@ mod tests {
         assert_eq!(protocol.seen_events.len(), MAX_SEEN_EVENTS + 1);
 
         // Simulate the cleanup that happens in process_pending_events
+        // (evicts half instead of clearing everything)
         if protocol.seen_events.len() > MAX_SEEN_EVENTS {
-            protocol.seen_events.clear();
+            let to_remove: Vec<_> = protocol.seen_events.iter().take(MAX_SEEN_EVENTS / 2).copied().collect();
+            for id in to_remove {
+                protocol.seen_events.remove(&id);
+            }
         }
 
-        // After cleanup, it should be empty (cleared dedup cache)
-        assert!(protocol.seen_events.is_empty());
+        // After eviction, approximately half the entries should remain
+        assert!(
+            protocol.seen_events.len() > 0,
+            "Eviction should keep approximately half the entries, not clear everything"
+        );
+        assert!(
+            protocol.seen_events.len() <= MAX_SEEN_EVENTS,
+            "After eviction, size should not exceed MAX_SEEN_EVENTS"
+        );
     }
 }

--- a/omnia-network/src/gossip.rs
+++ b/omnia-network/src/gossip.rs
@@ -714,7 +714,7 @@ mod tests {
         let protocol = GossipProtocol::new(node(1), GossipConfig::default(), graph);
 
         let keypair = generate_keypair();
-        let mut event = Event::genesis(node(2), vec![1, 2, 3]);
+        let mut event = Event::genesis(node(2), vec![1, 2, 3]).expect("valid genesis event");
         event.sign_with_keypair(&keypair);
 
         assert!(protocol.validate_event(&event).is_ok());
@@ -726,7 +726,7 @@ mod tests {
         let protocol = GossipProtocol::new(node(1), GossipConfig::default(), graph);
 
         // Event::new creates events with all-zero signature and pubkey
-        let event = Event::genesis(node(2), vec![1, 2, 3]);
+        let event = Event::genesis(node(2), vec![1, 2, 3]).expect("valid genesis event");
 
         let result = protocol.validate_event(&event);
         assert!(result.is_err());
@@ -740,7 +740,7 @@ mod tests {
         let protocol = GossipProtocol::new(node(1), GossipConfig::default(), graph);
 
         let keypair = generate_keypair();
-        let mut event = Event::genesis(node(2), vec![1, 2, 3]);
+        let mut event = Event::genesis(node(2), vec![1, 2, 3]).expect("valid genesis event");
         event.sign_with_keypair(&keypair);
 
         // Corrupt the signature
@@ -757,7 +757,7 @@ mod tests {
         let protocol = GossipProtocol::new(node(1), GossipConfig::default(), graph);
 
         let keypair = generate_keypair();
-        let mut event = Event::genesis(node(2), vec![1, 2, 3]);
+        let mut event = Event::genesis(node(2), vec![1, 2, 3]).expect("valid genesis event");
         event.sign_with_keypair(&keypair);
 
         // Tamper with the ID
@@ -781,7 +781,7 @@ mod tests {
         gossip.network_rx = Some(rx);
 
         // Create an unsigned event (should be rejected by validation)
-        let event = Event::genesis(node(2), vec![1, 2, 3]);
+        let event = Event::genesis(node(2), vec![1, 2, 3]).expect("valid genesis event");
         let bytes = event.to_bytes().expect("test event serialization");
 
         let dummy_peer_id = PeerId::random();
@@ -817,7 +817,7 @@ mod tests {
 
         // Create a properly signed event
         let keypair = generate_keypair();
-        let mut event = Event::genesis(node(2), vec![1, 2, 3]);
+        let mut event = Event::genesis(node(2), vec![1, 2, 3]).expect("valid genesis event");
         event.sign_with_keypair(&keypair);
         let event_id = event.id;
         let bytes = event.to_bytes().expect("test event serialization");

--- a/omnia-network/src/gossip_batch.rs
+++ b/omnia-network/src/gossip_batch.rs
@@ -24,6 +24,8 @@ use omnia_consensus::batch::ConsensusEventBatch;
 use omnia_primitives::{NodeId, VectorClock};
 use serde::{Deserialize, Serialize};
 
+use crate::compression::{deserialize_with_compression, serialize_with_compression};
+
 /// GossipSub topic name for batch event propagation.
 pub const GOSSIP_BATCH_TOPIC: &str = "omnia_batch_events";
 
@@ -101,76 +103,37 @@ pub enum GossipBatchError {
 /// Maximum serialized size for a batch gossip message (1 MiB).
 pub const MAX_BATCH_GOSSIP_SIZE: usize = 1024 * 1024;
 
-/// Minimum payload size for batch compression (smaller payloads aren't worth compressing).
-const COMPRESSION_THRESHOLD: usize = 256;
-
-/// Compression flag for gossip messages: uncompressed.
-const COMPRESSION_NONE: u8 = 0x00;
-/// Compression flag for gossip messages: snappy compressed.
-const COMPRESSION_SNAPPY: u8 = 0x01;
-
 /// Serialize a batch gossip message with optional snappy compression.
 ///
-/// Uses the same compression strategy as the existing `serialize_compressed`
-/// function in the `gossip` module: payloads larger than the compression
-/// threshold are compressed with snappy if it reduces size.
+/// Delegates to [`crate::compression::serialize_with_compression`] and
+/// converts the error type to [`GossipBatchError`].
 ///
 /// # Errors
 ///
 /// Returns [`GossipBatchError::SerializationError`] if postcard serialization fails.
 pub fn serialize_batch_message(msg: &GossipBatchMessage) -> Result<Vec<u8>, GossipBatchError> {
-    let raw = postcard::to_allocvec(msg).map_err(|e| GossipBatchError::SerializationError(e.to_string()))?;
-
-    if raw.len() > COMPRESSION_THRESHOLD {
-        let mut encoder = snap::raw::Encoder::new();
-        let compressed = encoder
-            .compress_vec(&raw)
-            .map_err(|e| GossipBatchError::SerializationError(format!("compression: {}", e)))?;
-
-        if compressed.len() < raw.len() {
-            let mut output = Vec::with_capacity(1 + compressed.len());
-            output.push(COMPRESSION_SNAPPY);
-            output.extend_from_slice(&compressed);
-            return Ok(output);
-        }
-    }
-
-    let mut output = Vec::with_capacity(1 + raw.len());
-    output.push(COMPRESSION_NONE);
-    output.extend_from_slice(&raw);
-    Ok(output)
+    serialize_with_compression(msg).map_err(|e| GossipBatchError::SerializationError(e))
 }
 
 /// Deserialize a batch gossip message with optional snappy decompression.
 ///
-/// Reads the first byte as a compression flag (same format as the
-/// existing `deserialize_compressed` function in the `gossip` module).
+/// Delegates to [`crate::compression::deserialize_with_compression`] and
+/// converts the error type to [`GossipBatchError`].
 ///
 /// # Errors
 ///
 /// Returns [`GossipBatchError::DeserializationError`] if the compression
 /// flag is unknown or postcard deserialization fails.
 pub fn deserialize_batch_message(data: &[u8]) -> Result<GossipBatchMessage, GossipBatchError> {
-    let (flag, payload) = data
-        .split_first()
-        .ok_or_else(|| GossipBatchError::InvalidMessage("empty message".to_string()))?;
-
-    let raw = match *flag {
-        COMPRESSION_NONE => payload.to_vec(),
-        COMPRESSION_SNAPPY => {
-            let mut decoder = snap::raw::Decoder::new();
-            decoder
-                .decompress_vec(payload)
-                .map_err(|e| GossipBatchError::DeserializationError(format!("decompression: {}", e)))?
+    deserialize_with_compression(data).map_err(|e| match e {
+        s if s.starts_with("unknown compression") || s.starts_with("empty payload") => {
+            GossipBatchError::InvalidMessage(s)
         }
-        _ => {
-            return Err(GossipBatchError::InvalidMessage(format!(
-                "unknown compression flag: 0x{flag:02x}"
-            )));
+        s if s.contains("decompress") || s.contains("exceeds limit") => {
+            GossipBatchError::DeserializationError(format!("decompression: {}", s))
         }
-    };
-
-    postcard::from_bytes(&raw).map_err(|e| GossipBatchError::DeserializationError(e.to_string()))
+        s => GossipBatchError::DeserializationError(s),
+    })
 }
 
 /// Validate a batch gossip message.

--- a/omnia-network/src/gossip_batch.rs
+++ b/omnia-network/src/gossip_batch.rs
@@ -208,7 +208,7 @@ mod tests {
 
     fn signed_event(creator: NodeId, payload: Vec<u8>) -> Event {
         let keypair = generate_keypair();
-        let mut event = Event::genesis(creator, payload);
+        let mut event = Event::genesis(creator, payload).expect("valid genesis event");
         event.sign_with_keypair(&keypair);
         event
     }

--- a/omnia-network/src/gossip_batch.rs
+++ b/omnia-network/src/gossip_batch.rs
@@ -112,7 +112,7 @@ pub const MAX_BATCH_GOSSIP_SIZE: usize = 1024 * 1024;
 ///
 /// Returns [`GossipBatchError::SerializationError`] if postcard serialization fails.
 pub fn serialize_batch_message(msg: &GossipBatchMessage) -> Result<Vec<u8>, GossipBatchError> {
-    serialize_with_compression(msg).map_err(|e| GossipBatchError::SerializationError(e))
+    serialize_with_compression(msg).map_err(GossipBatchError::SerializationError)
 }
 
 /// Deserialize a batch gossip message with optional snappy decompression.

--- a/omnia-network/src/lib.rs
+++ b/omnia-network/src/lib.rs
@@ -21,6 +21,7 @@
 
 pub mod blake3_domain;
 pub mod compact_event_encoding;
+pub mod compression;
 pub mod fast_sync;
 #[cfg(feature = "network")]
 pub mod gossip;

--- a/omnia-network/src/network.rs
+++ b/omnia-network/src/network.rs
@@ -654,7 +654,7 @@ impl OmniaNetwork {
 }
 
 /// Try to extract a PeerId from a Multiaddr that ends with /p2p/<peer-id>.
-fn extract_peer_id_from_multiaddr(addr: &Multiaddr) -> Option<PeerId> {
+pub(crate) fn extract_peer_id_from_multiaddr(addr: &Multiaddr) -> Option<PeerId> {
     use libp2p::multiaddr::Protocol;
     addr.iter().find_map(|proto| match proto {
         Protocol::P2p(peer_id) => Some(peer_id),

--- a/omnia-network/tests/e2e_multi_node_consensus.rs
+++ b/omnia-network/tests/e2e_multi_node_consensus.rs
@@ -136,7 +136,7 @@ impl E2ETestNode {
     /// the vector clock and creator are consistent.
     fn create_genesis_event(&mut self, payload: Vec<u8>) -> Event {
         self.sequence = 0;
-        let mut event = Event::genesis(self.node_id, payload);
+        let mut event = Event::genesis(self.node_id, payload).expect("valid genesis event");
         event.sign_with_keypair(&self.keypair);
         self.self_parent = Some(event.id);
         event
@@ -163,7 +163,8 @@ impl E2ETestNode {
             self.self_parent,
             Some(other_parent),
             payload,
-        );
+        )
+        .expect("valid event");
         event.sign_with_keypair(&self.keypair);
         self.self_parent = Some(event.id);
         event

--- a/omnia-network/tests/network_integration_test.rs
+++ b/omnia-network/tests/network_integration_test.rs
@@ -50,7 +50,7 @@ impl SimNode {
 
     fn create_event(&mut self, payload: Vec<u8>) -> Event {
         self.event_counter += 1;
-        Event::genesis(self.node_id, payload)
+        Event::genesis(self.node_id, payload).expect("valid genesis event")
     }
 
     async fn submit_and_process(&mut self, event: Event) -> Vec<EventId> {

--- a/omnia-network/tests/network_integration_test.rs
+++ b/omnia-network/tests/network_integration_test.rs
@@ -65,10 +65,12 @@ impl SimNode {
         }
     }
 
+    #[allow(dead_code)]
     async fn committed_count(&self) -> usize {
         self.consensus.get_committed().len()
     }
 
+    #[allow(dead_code)]
     async fn has_committed(&self, event_id: &EventId) -> bool {
         self.consensus.is_committed(event_id)
     }
@@ -123,6 +125,7 @@ impl SimNetwork {
     }
 }
 
+#[allow(dead_code)]
 fn node_id(idx: usize) -> NodeId {
     let mut id = [0u8; 32];
     id[0] = (idx + 1) as u8;

--- a/omnia-primitives/Cargo.toml
+++ b/omnia-primitives/Cargo.toml
@@ -13,8 +13,6 @@ blake3 = "1.5"
 hex = "0.4"
 subtle = "2.5"
 thiserror = "2.0"
-chrono = { version = "0.4", features = ["serde"], default-features = false }
-uuid = { version = "1.8", features = ["v4", "serde"] }
 ed25519-dalek = { version = "2.1", features = ["rand_core", "serde"] }
 bincode = { workspace = true }
 

--- a/omnia-primitives/src/event.rs
+++ b/omnia-primitives/src/event.rs
@@ -155,7 +155,9 @@ impl EventRequest {
             return Err(EventValidationError::InvalidField("limit exceeds maximum".into()));
         }
         if self.known_events.len() > MAX_KNOWN_EVENTS {
-            return Err(EventValidationError::InvalidField("known_events exceeds maximum".into()));
+            return Err(EventValidationError::InvalidField(
+                "known_events exceeds maximum".into(),
+            ));
         }
         Ok(())
     }
@@ -254,12 +256,18 @@ impl Event {
         hasher.update(self.timestamp.to_le_bytes());
         hasher.update(self.vector_clock.to_bytes());
         match self.self_parent {
-            None => hasher.update(&[0u8]),
-            Some(sp) => { hasher.update(&[1u8]); hasher.update(sp); }
+            None => hasher.update([0u8]),
+            Some(sp) => {
+                hasher.update([1u8]);
+                hasher.update(sp);
+            }
         }
         match self.other_parent {
-            None => hasher.update(&[0u8]),
-            Some(op) => { hasher.update(&[1u8]); hasher.update(op); }
+            None => hasher.update([0u8]),
+            Some(op) => {
+                hasher.update([1u8]);
+                hasher.update(op);
+            }
         }
         hasher.update(&self.payload);
         hasher.update(self.creator_pubkey);
@@ -333,10 +341,7 @@ impl Event {
     /// Calling this method does nothing. It exists only for backward
     /// compatibility with older call sites. To actually sign an event,
     /// use [`sign_with_keypair()`](Self::sign_with_keypair) instead.
-    #[deprecated(
-        since = "0.2.0",
-        note = "sign() is a no-op - use sign_with_keypair() instead"
-    )]
+    #[deprecated(since = "0.2.0", note = "sign() is a no-op - use sign_with_keypair() instead")]
     pub fn sign(&mut self, _signature: Vec<u8>) {
         // This method is intentionally a no-op for backward compatibility.
         // Use sign_with_keypair() for actual signing.

--- a/omnia-primitives/src/event.rs
+++ b/omnia-primitives/src/event.rs
@@ -129,6 +129,11 @@ pub struct EventHeader {
     pub other_parent: Option<EventId>,
 }
 
+/// Maximum number of events that can be requested in a single EventRequest
+pub const MAX_EVENT_REQUEST_LIMIT: usize = 10_000;
+/// Maximum number of known events that can be listed in an EventRequest
+pub const MAX_KNOWN_EVENTS: usize = 100_000;
+
 /// Request for missing events (used during sync)
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct EventRequest {
@@ -138,6 +143,22 @@ pub struct EventRequest {
     pub limit: usize,
     /// Starting from this vector clock (inclusive)
     pub since: VectorClock,
+}
+
+impl EventRequest {
+    /// Validate the request limits.
+    ///
+    /// Returns an error if `limit` exceeds [`MAX_EVENT_REQUEST_LIMIT`] or
+    /// `known_events` exceeds [`MAX_KNOWN_EVENTS`].
+    pub fn validate(&self) -> Result<(), EventValidationError> {
+        if self.limit > MAX_EVENT_REQUEST_LIMIT {
+            return Err(EventValidationError::InvalidField("limit exceeds maximum".into()));
+        }
+        if self.known_events.len() > MAX_KNOWN_EVENTS {
+            return Err(EventValidationError::InvalidField("known_events exceeds maximum".into()));
+        }
+        Ok(())
+    }
 }
 
 /// Response to an event request
@@ -175,7 +196,7 @@ impl Event {
     /// ```ignore
     /// use omnia_substrate::{Event, VectorClock};
     /// let vc = VectorClock::with_node(creator, 1);
-    /// let event = Event::new(creator, 0, vc, None, None, vec![]);
+    /// let event = Event::new(creator, 0, vc, None, None, vec![]).unwrap();
     /// assert!(event.is_root());
     /// ```
     pub fn new(
@@ -185,10 +206,10 @@ impl Event {
         self_parent: Option<EventId>,
         other_parent: Option<EventId>,
         payload: Payload,
-    ) -> Self {
+    ) -> Result<Self, EventValidationError> {
         let timestamp = SystemTime::now()
             .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
+            .map_err(|_| EventValidationError::InvalidTimestamp)?
             .as_millis() as u64;
 
         let mut event = Self {
@@ -207,7 +228,7 @@ impl Event {
         };
 
         event.id = event.compute_hash();
-        event
+        Ok(event)
     }
 
     /// Create a genesis event (first event in the network).
@@ -219,7 +240,7 @@ impl Event {
     ///
     /// * `creator` — The node ID of the genesis event creator
     /// * `payload` — Application-specific data attached to this event
-    pub fn genesis(creator: NodeId, payload: Payload) -> Self {
+    pub fn genesis(creator: NodeId, payload: Payload) -> Result<Self, EventValidationError> {
         let vector_clock = VectorClock::with_node(creator, 1);
         Self::new(creator, 0, vector_clock, None, None, payload)
     }
@@ -232,11 +253,13 @@ impl Event {
         hasher.update(self.sequence.to_le_bytes());
         hasher.update(self.timestamp.to_le_bytes());
         hasher.update(self.vector_clock.to_bytes());
-        if let Some(sp) = self.self_parent {
-            hasher.update(sp);
+        match self.self_parent {
+            None => hasher.update(&[0u8]),
+            Some(sp) => { hasher.update(&[1u8]); hasher.update(sp); }
         }
-        if let Some(op) = self.other_parent {
-            hasher.update(op);
+        match self.other_parent {
+            None => hasher.update(&[0u8]),
+            Some(op) => { hasher.update(&[1u8]); hasher.update(op); }
         }
         hasher.update(&self.payload);
         hasher.update(self.creator_pubkey);
@@ -268,7 +291,7 @@ impl Event {
     /// ```ignore
     /// use omnia_substrate::{Event, generate_keypair};
     /// let keypair = generate_keypair();
-    /// let mut event = Event::genesis([0u8; 32], vec![]);
+    /// let mut event = Event::genesis([0u8; 32], vec![]).unwrap();
     /// event.sign_with_keypair(&keypair);
     /// assert!(event.validate().is_ok());
     /// ```
@@ -305,15 +328,18 @@ impl Event {
         pubkey.verify(&self.id, &sig).is_ok()
     }
 
-    /// Legacy sign method for backward compatibility in tests.
-    /// In production, always use `sign_with_keypair`.
+    /// Legacy sign method — **this is intentionally a no-op**.
+    ///
+    /// Calling this method does nothing. It exists only for backward
+    /// compatibility with older call sites. To actually sign an event,
+    /// use [`sign_with_keypair()`](Self::sign_with_keypair) instead.
     #[deprecated(
         since = "0.2.0",
-        note = "sign() is a no-op and will be removed. Use sign_with_keypair() instead."
+        note = "sign() is a no-op - use sign_with_keypair() instead"
     )]
     pub fn sign(&mut self, _signature: Vec<u8>) {
-        // Deprecated no-op: real signing requires a keypair via sign_with_keypair().
-        // This method will be removed in a future release.
+        // This method is intentionally a no-op for backward compatibility.
+        // Use sign_with_keypair() for actual signing.
     }
 
     /// Get the event header (lightweight metadata)
@@ -398,7 +424,7 @@ impl Event {
         // Timestamp sanity checks
         let now_ms = SystemTime::now()
             .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
+            .map_err(|_| EventValidationError::InvalidTimestamp)?
             .as_millis() as u64;
 
         // Reject events too far in the future
@@ -450,7 +476,7 @@ impl Event {
 
     /// Mark this event as having received an acknowledgment
     pub fn add_acknowledgment(&mut self) {
-        self.ack_count += 1;
+        self.ack_count = self.ack_count.saturating_add(1);
         if self.ack_count >= 2 {
             self.status = EventStatus::Acknowledged;
         }
@@ -461,7 +487,7 @@ impl Event {
         self.self_parent.is_none() && self.other_parent.is_none()
     }
 
-    /// Check if this event links to another event (is in its ancestry)
+    /// Check if this event directly links to another event as a parent
     pub fn links_to(&self, event_id: &EventId) -> bool {
         self.self_parent.map(|p| &p == event_id).unwrap_or(false)
             || self.other_parent.map(|p| &p == event_id).unwrap_or(false)
@@ -537,6 +563,12 @@ pub enum EventValidationError {
         /// Maximum allowed payload size in bytes
         max: usize,
     },
+    /// System clock is before Unix epoch
+    #[error("system clock is before Unix epoch")]
+    InvalidTimestamp,
+    /// A field has an invalid value
+    #[error("Invalid field: {0}")]
+    InvalidField(String),
 }
 
 impl fmt::Display for Event {
@@ -578,7 +610,7 @@ mod tests {
     fn test_event_creation() {
         let creator = test_node(1);
         let vc = VectorClock::with_node(creator, 1);
-        let event = Event::new(creator, 0, vc, None, None, vec![1, 2, 3]);
+        let event = Event::new(creator, 0, vc, None, None, vec![1, 2, 3]).unwrap();
 
         assert_eq!(event.creator, creator);
         assert_eq!(event.sequence, 0);
@@ -590,7 +622,7 @@ mod tests {
     #[test]
     fn test_genesis_event() {
         let creator = test_node(1);
-        let event = Event::genesis(creator, vec![]);
+        let event = Event::genesis(creator, vec![]).unwrap();
 
         assert!(event.is_root());
         assert_eq!(event.sequence, 0);
@@ -600,7 +632,7 @@ mod tests {
     fn test_event_hash_integrity() {
         let creator = test_node(1);
         let vc = VectorClock::with_node(creator, 1);
-        let event = Event::new(creator, 0, vc, None, None, vec![1, 2, 3]);
+        let event = Event::new(creator, 0, vc, None, None, vec![1, 2, 3]).unwrap();
 
         assert!(event.verify_hash());
     }
@@ -610,7 +642,7 @@ mod tests {
         let creator = test_node(1);
         let vc = VectorClock::with_node(creator, 1);
         let keypair = test_keypair();
-        let mut event = Event::new(creator, 0, vc, None, None, vec![]);
+        let mut event = Event::new(creator, 0, vc, None, None, vec![]).unwrap();
 
         // Before signing, the creator_pubkey is all zeros and signature is all zeros.
         // verify_signature() may return true for the all-zeros key/signature pair
@@ -632,12 +664,12 @@ mod tests {
         let n1 = test_node(1);
         let n2 = test_node(2);
 
-        let genesis = Event::genesis(n1, vec![]);
+        let genesis = Event::genesis(n1, vec![]).unwrap();
         let genesis_id = genesis.id;
 
         let mut vc = VectorClock::with_node(n1, 2);
         vc.set(n2, 1);
-        let event = Event::new(n1, 1, vc, Some(genesis_id), None, vec![]);
+        let event = Event::new(n1, 1, vc, Some(genesis_id), None, vec![]).unwrap();
 
         assert!(event.links_to(&genesis_id));
     }
@@ -647,7 +679,7 @@ mod tests {
         let creator = test_node(1);
         let vc = VectorClock::with_node(creator, 1);
         let keypair = test_keypair();
-        let mut event = Event::new(creator, 0, vc, None, None, vec![]);
+        let mut event = Event::new(creator, 0, vc, None, None, vec![]).unwrap();
         event.sign_with_keypair(&keypair);
 
         assert_eq!(event.status, EventStatus::Pending);
@@ -662,7 +694,7 @@ mod tests {
         let creator = test_node(1);
         let vc = VectorClock::with_node(creator, 1);
         // Event::new creates an event with all-zero signature and pubkey
-        let event = Event::new(creator, 0, vc, None, None, vec![1, 2, 3]);
+        let event = Event::new(creator, 0, vc, None, None, vec![1, 2, 3]).unwrap();
 
         let result = event.validate();
         assert_eq!(result, Err(EventValidationError::UnsignedEvent));
@@ -673,7 +705,7 @@ mod tests {
         let creator = test_node(1);
         let vc = VectorClock::with_node(creator, 1);
         let keypair = test_keypair();
-        let mut event = Event::new(creator, 0, vc, None, None, vec![]);
+        let mut event = Event::new(creator, 0, vc, None, None, vec![]).unwrap();
 
         // Set timestamp 10 minutes in the future (beyond 2-minute drift)
         let now_ms = SystemTime::now()
@@ -692,7 +724,7 @@ mod tests {
         let creator = test_node(1);
         let vc = VectorClock::with_node(creator, 1);
         let keypair = test_keypair();
-        let mut event = Event::new(creator, 0, vc, None, None, vec![]);
+        let mut event = Event::new(creator, 0, vc, None, None, vec![]).unwrap();
 
         // Set timestamp to 2 years ago (well beyond 1-year max age)
         let now_ms = SystemTime::now()
@@ -712,7 +744,7 @@ mod tests {
         let creator = test_node(1);
         let vc = VectorClock::with_node(creator, 1);
         let keypair = test_keypair();
-        let mut event = Event::new(creator, 0, vc, None, None, vec![1, 2, 3]);
+        let mut event = Event::new(creator, 0, vc, None, None, vec![1, 2, 3]).unwrap();
         event.sign_with_keypair(&keypair);
 
         // Tamper with the payload — hash check should fail
@@ -728,7 +760,7 @@ mod tests {
         let creator = test_node(1);
         let vc = VectorClock::with_node(creator, 1);
         let keypair = test_keypair();
-        let mut event = Event::new(creator, 0, vc, None, None, vec![]);
+        let mut event = Event::new(creator, 0, vc, None, None, vec![]).unwrap();
         event.sign_with_keypair(&keypair);
         event.status = EventStatus::Rejected;
 
@@ -741,7 +773,7 @@ mod tests {
         let creator = test_node(1);
         let vc = VectorClock::with_node(creator, 1);
         let keypair = test_keypair();
-        let mut event = Event::new(creator, 0, vc, None, None, vec![4, 5, 6]);
+        let mut event = Event::new(creator, 0, vc, None, None, vec![4, 5, 6]).unwrap();
         event.sign_with_keypair(&keypair);
 
         // A freshly signed event with recent timestamp should pass all checks
@@ -754,7 +786,7 @@ mod tests {
         let creator = test_node(1);
         let vc = VectorClock::with_node(creator, 1);
         let keypair = test_keypair();
-        let mut event = Event::new(creator, 0, vc, None, None, vec![1, 2, 3]);
+        let mut event = Event::new(creator, 0, vc, None, None, vec![1, 2, 3]).unwrap();
         event.sign_with_keypair(&keypair);
 
         let bytes = event.to_bytes().expect("test event serialization");
@@ -774,7 +806,7 @@ mod tests {
         let creator = test_node(1);
         let vc = VectorClock::with_node(creator, 1);
         let keypair = test_keypair();
-        let mut event = Event::new(creator, 0, vc, None, None, vec![1, 2, 3]);
+        let mut event = Event::new(creator, 0, vc, None, None, vec![1, 2, 3]).unwrap();
         event.sign_with_keypair(&keypair);
 
         // Replace signature with non-zero garbage that is still 64 bytes
@@ -797,11 +829,11 @@ mod tests {
         let keypair_b = test_keypair();
 
         // Sign with keypair A
-        let mut event = Event::new(creator, 0, vc.clone(), None, None, vec![]);
+        let mut event = Event::new(creator, 0, vc.clone(), None, None, vec![]).unwrap();
         event.sign_with_keypair(&keypair_a);
 
         // Now create a different event and sign with keypair B, then swap the ID
-        let mut other_event = Event::new(creator, 1, vc, None, None, vec![9, 9, 9]);
+        let mut other_event = Event::new(creator, 1, vc, None, None, vec![9, 9, 9]).unwrap();
         other_event.sign_with_keypair(&keypair_b);
 
         // Swap the ID and signature from other_event into event (cross-contamination)
@@ -818,7 +850,7 @@ mod tests {
         let creator = test_node(1);
         let vc = VectorClock::with_node(creator, 1);
         let keypair = test_keypair();
-        let mut event = Event::new(creator, 0, vc, None, None, vec![]);
+        let mut event = Event::new(creator, 0, vc, None, None, vec![]).unwrap();
         event.sign_with_keypair(&keypair);
 
         // Zero out the signature but keep the pubkey
@@ -833,7 +865,7 @@ mod tests {
         let creator = test_node(1);
         let vc = VectorClock::with_node(creator, 1);
         let keypair = test_keypair();
-        let mut event = Event::new(creator, 0, vc, None, None, vec![]);
+        let mut event = Event::new(creator, 0, vc, None, None, vec![]).unwrap();
         event.sign_with_keypair(&keypair);
 
         // Zero out the pubkey but keep the signature
@@ -850,7 +882,7 @@ mod tests {
         let creator = test_node(1);
         let vc = VectorClock::with_node(creator, 1);
         let keypair = test_keypair();
-        let mut event = Event::new(creator, 0, vc, None, None, vec![]);
+        let mut event = Event::new(creator, 0, vc, None, None, vec![]).unwrap();
         let now_ms = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap_or_default()
@@ -870,7 +902,7 @@ mod tests {
         let creator = test_node(1);
         let vc = VectorClock::with_node(creator, 1);
         let keypair = test_keypair();
-        let mut event = Event::new(creator, 0, vc, None, None, vec![]);
+        let mut event = Event::new(creator, 0, vc, None, None, vec![]).unwrap();
         let now_ms = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap_or_default()
@@ -911,7 +943,7 @@ mod tests {
         let creator = test_node(1);
         let vc = VectorClock::with_node(creator, 1);
         let keypair = test_keypair();
-        let mut event = Event::new(creator, 0, vc, None, None, vec![0u8; 100]);
+        let mut event = Event::new(creator, 0, vc, None, None, vec![0u8; 100]).unwrap();
         event.sign_with_keypair(&keypair);
 
         // Flip a single bit in the payload
@@ -930,7 +962,7 @@ mod tests {
         let keypair = test_keypair();
         let creator_from_new = test_node(1); // arbitrary, will be overwritten
         let vc = VectorClock::with_node(creator_from_new, 1);
-        let mut event = Event::new(creator_from_new, 0, vc, None, None, vec![1, 2, 3]);
+        let mut event = Event::new(creator_from_new, 0, vc, None, None, vec![1, 2, 3]).unwrap();
         event.sign_with_keypair(&keypair);
 
         // After sign_with_keypair, creator == blake3_hash_domain("omnia-creator", creator_pubkey)
@@ -948,7 +980,7 @@ mod tests {
         let keypair = test_keypair();
         let fake_creator = test_node(99); // not derived from the keypair
         let vc = VectorClock::with_node(fake_creator, 1);
-        let mut event = Event::new(fake_creator, 0, vc, None, None, vec![1, 2, 3]);
+        let mut event = Event::new(fake_creator, 0, vc, None, None, vec![1, 2, 3]).unwrap();
         event.sign_with_keypair(&keypair);
 
         // sign_with_keypair now sets creator = blake3(creator_pubkey), so we
@@ -975,7 +1007,7 @@ mod tests {
         let keypair = test_keypair();
         let arbitrary_creator = test_node(42);
         let vc = VectorClock::with_node(arbitrary_creator, 1);
-        let mut event = Event::new(arbitrary_creator, 0, vc, None, None, vec![]);
+        let mut event = Event::new(arbitrary_creator, 0, vc, None, None, vec![]).unwrap();
 
         // Before signing, creator is whatever was passed to Event::new
         assert_eq!(event.creator, arbitrary_creator);
@@ -994,7 +1026,7 @@ mod tests {
     fn test_tampered_creator_fails_validation() {
         let keypair = test_keypair();
         let vc = VectorClock::with_node(test_node(1), 1);
-        let mut event = Event::new(test_node(1), 0, vc, None, None, vec![]);
+        let mut event = Event::new(test_node(1), 0, vc, None, None, vec![]).unwrap();
         event.sign_with_keypair(&keypair);
 
         // Tamper: change creator to something else
@@ -1014,7 +1046,7 @@ mod tests {
         let keypair = test_keypair();
         let creator = blake3_hash_domain(b"omnia-creator", &keypair.verifying_key().to_bytes());
         let vc = VectorClock::with_node(creator, 1);
-        let mut event = Event::new(creator, 0, vc, None, None, vec![0u8; MAX_PAYLOAD_SIZE]);
+        let mut event = Event::new(creator, 0, vc, None, None, vec![0u8; MAX_PAYLOAD_SIZE]).unwrap();
         event.sign_with_keypair(&keypair);
 
         let result = event.validate();
@@ -1032,7 +1064,7 @@ mod tests {
         let creator = blake3_hash_domain(b"omnia-creator", &keypair.verifying_key().to_bytes());
         let vc = VectorClock::with_node(creator, 1);
         let oversized = vec![0u8; MAX_PAYLOAD_SIZE + 1];
-        let mut event = Event::new(creator, 0, vc, None, None, oversized);
+        let mut event = Event::new(creator, 0, vc, None, None, oversized).unwrap();
         event.sign_with_keypair(&keypair);
 
         let result = event.validate();

--- a/omnia-primitives/src/vector_clock.rs
+++ b/omnia-primitives/src/vector_clock.rs
@@ -217,9 +217,9 @@ impl VectorClock {
         }
         let count = u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]) as usize;
         if count > MAX_CLOCK_ENTRIES {
-            return Err(VectorClockError::InvalidNodeId(
-                format!("clock count {count} exceeds maximum {MAX_CLOCK_ENTRIES}")
-            ));
+            return Err(VectorClockError::InvalidNodeId(format!(
+                "clock count {count} exceeds maximum {MAX_CLOCK_ENTRIES}"
+            )));
         }
         let mut clocks = BTreeMap::new();
         let mut offset = 4;
@@ -236,7 +236,7 @@ impl VectorClock {
             );
             if clocks.insert(node_id, clock).is_some() {
                 return Err(VectorClockError::InvalidNodeId(
-                    "duplicate node ID in vector clock bytes".to_string()
+                    "duplicate node ID in vector clock bytes".to_string(),
                 ));
             }
             offset += 40;

--- a/omnia-primitives/src/vector_clock.rs
+++ b/omnia-primitives/src/vector_clock.rs
@@ -14,6 +14,9 @@ use std::collections::BTreeMap;
 use std::fmt;
 use thiserror::Error;
 
+/// Maximum number of entries allowed in a deserialized vector clock
+pub const MAX_CLOCK_ENTRIES: usize = 10_000;
+
 /// Unique identifier for a node in the network
 pub type NodeId = [u8; 32];
 
@@ -213,6 +216,11 @@ impl VectorClock {
             return Err(VectorClockError::InvalidNodeId("insufficient bytes".to_string()));
         }
         let count = u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]) as usize;
+        if count > MAX_CLOCK_ENTRIES {
+            return Err(VectorClockError::InvalidNodeId(
+                format!("clock count {count} exceeds maximum {MAX_CLOCK_ENTRIES}")
+            ));
+        }
         let mut clocks = BTreeMap::new();
         let mut offset = 4;
         for _ in 0..count {
@@ -226,7 +234,11 @@ impl VectorClock {
                     .try_into()
                     .expect("slice is exactly 8 bytes per bounds check above"),
             );
-            clocks.insert(node_id, clock);
+            if clocks.insert(node_id, clock).is_some() {
+                return Err(VectorClockError::InvalidNodeId(
+                    "duplicate node ID in vector clock bytes".to_string()
+                ));
+            }
             offset += 40;
         }
         Ok(Self { clocks })

--- a/omnia-primitives/src/wire_format.rs
+++ b/omnia-primitives/src/wire_format.rs
@@ -55,7 +55,7 @@ pub fn deserialize_with_version<T: serde::de::DeserializeOwned>(bytes: &[u8]) ->
             const MAX_BINCODE_INPUT_SIZE: usize = 10 * 1024 * 1024; // 10 MiB
             if bytes.len() > MAX_BINCODE_INPUT_SIZE {
                 return Err(WireFormatError::DeserializationFailed(
-                    "legacy bincode input exceeds size limit".to_string()
+                    "legacy bincode input exceeds size limit".to_string(),
                 ));
             }
             bincode::deserialize(&bytes[1..]).map_err(|e| WireFormatError::DeserializationFailed(e.to_string()))

--- a/omnia-primitives/src/wire_format.rs
+++ b/omnia-primitives/src/wire_format.rs
@@ -51,7 +51,13 @@ pub fn deserialize_with_version<T: serde::de::DeserializeOwned>(bytes: &[u8]) ->
     let version = bytes[0];
     match version {
         0 => {
-            // Legacy bincode format
+            // Legacy bincode format - limit input size for safety
+            const MAX_BINCODE_INPUT_SIZE: usize = 10 * 1024 * 1024; // 10 MiB
+            if bytes.len() > MAX_BINCODE_INPUT_SIZE {
+                return Err(WireFormatError::DeserializationFailed(
+                    "legacy bincode input exceeds size limit".to_string()
+                ));
+            }
             bincode::deserialize(&bytes[1..]).map_err(|e| WireFormatError::DeserializationFailed(e.to_string()))
         }
         1 => {

--- a/shards/src/biological/state.rs
+++ b/shards/src/biological/state.rs
@@ -208,7 +208,8 @@ impl BiologicalState {
                 #[cfg(feature = "real_verification")]
                 {
                     return Err(ShardError::ValidationFailed(
-                        "ZK proof verification failed: proof does not match expected layout for real verification".into(),
+                        "ZK proof verification failed: proof does not match expected layout for real verification"
+                            .into(),
                     ));
                 }
             }

--- a/shards/src/biological/state.rs
+++ b/shards/src/biological/state.rs
@@ -199,18 +199,18 @@ impl BiologicalState {
                 #[cfg(not(feature = "real_verification"))]
                 {
                     let _ = zk_proof; // suppress unused warning
-                    return Err(ShardError::ValidationFailed(
+                    Err(ShardError::ValidationFailed(
                         "ZK proof verification requires 'real_verification' feature to be enabled".into(),
-                    ));
+                    ))
                 }
 
                 // When real_verification is enabled but proof didn't match expected layout
                 #[cfg(feature = "real_verification")]
                 {
-                    return Err(ShardError::ValidationFailed(
+                    Err(ShardError::ValidationFailed(
                         "ZK proof verification failed: proof does not match expected layout for real verification"
                             .into(),
-                    ));
+                    ))
                 }
             }
         }

--- a/shards/src/biological/state.rs
+++ b/shards/src/biological/state.rs
@@ -11,26 +11,6 @@ use serde::{Deserialize, Serialize};
 use super::ops::BiologicalOp;
 use crate::shard::ShardError;
 
-/// Minimum expected byte length for a Groth16 proof over Bn254.
-///
-/// A Groth16 proof consists of three curve points:
-/// - 2 × G1 point (48 bytes uncompressed each) = 96 bytes
-/// - 1 × G2 point (96 bytes uncompressed) = 96 bytes
-///
-/// Total minimum: 192 bytes. We use the conservative lower bound of 128
-/// to allow for compressed representations.
-const MIN_GROTH16_PROOF_LEN: usize = 128;
-
-/// Check whether the proof bytes have a plausible Groth16 layout.
-///
-/// This does **not** verify cryptographic validity — it only rejects
-/// obviously malformed proofs (too short to contain the expected
-/// curve-point data). Real verification requires the `real_verification`
-/// feature flag.
-fn is_valid_zk_proof_layout(bytes: &[u8]) -> bool {
-    bytes.len() >= MIN_GROTH16_PROOF_LEN
-}
-
 /// A record of consent granted by a subject to a consumer.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ConsentRecord {
@@ -215,28 +195,22 @@ impl BiologicalState {
                     // to the default placeholder verification below.
                 }
 
-                // Default (placeholder) verification: reject ZK proofs that don't match
-                // the expected format. The consent record exists (checked above), but
-                // we require a properly formatted ZK proof for QueryWithZkProof operations.
-                // When real_verification is disabled, we still validate proof structure.
-                if zk_proof.is_empty() {
+                // When real_verification is disabled, always reject ZK proofs
+                #[cfg(not(feature = "real_verification"))]
+                {
+                    let _ = zk_proof; // suppress unused warning
                     return Err(ShardError::ValidationFailed(
-                        "ZK proof verification failed: empty proof bytes".into(),
+                        "ZK proof verification requires 'real_verification' feature to be enabled".into(),
                     ));
                 }
-                if !is_valid_zk_proof_layout(zk_proof) {
+
+                // When real_verification is enabled but proof didn't match expected layout
+                #[cfg(feature = "real_verification")]
+                {
                     return Err(ShardError::ValidationFailed(
-                        "ZK proof verification failed: proof too short for Groth16 layout".into(),
+                        "ZK proof verification failed: proof does not match expected layout for real verification".into(),
                     ));
                 }
-                // Proof passes layout validation — placeholder accepts it.
-                // Real cryptographic verification requires the `real_verification` feature.
-                tracing::warn!(
-                    subject = ?&subject[..4],
-                    len = zk_proof.len(),
-                    "Placeholder ZK verification: proof layout accepted without crypto verification"
-                );
-                Ok(())
             }
         }
     }
@@ -299,12 +273,12 @@ mod tests {
             },
             &vc,
         );
-        assert!(result.is_err(), "1-byte malformed ZK proof should be rejected");
+        assert!(result.is_err(), "ZK proof should be rejected without real_verification");
         match result.unwrap_err() {
             ShardError::ValidationFailed(msg) => {
                 assert!(
-                    msg.contains("Groth16 layout"),
-                    "expected Groth16 layout error, got: {msg}"
+                    msg.contains("real_verification"),
+                    "expected real_verification error, got: {msg}"
                 );
             }
             other => panic!("expected ValidationFailed, got {other:?}"),
@@ -345,11 +319,45 @@ mod tests {
         match result.unwrap_err() {
             ShardError::ValidationFailed(msg) => {
                 assert!(
-                    msg.contains("empty proof bytes"),
-                    "expected empty proof error, got: {msg}"
+                    msg.contains("real_verification"),
+                    "expected real_verification error, got: {msg}"
                 );
             }
             other => panic!("expected ValidationFailed, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn test_valid_layout_proof_also_rejected_without_real_verification() {
+        let mut state = BiologicalState::new();
+        let vc = test_vc();
+        let subject = [0xEE; 32];
+        let consumer = [0xFF; 32];
+
+        // Grant access so the consent record exists
+        state
+            .apply(
+                &BiologicalOp::GrantAccess {
+                    subject,
+                    consumer,
+                    scope: "records".into(),
+                    expires_at: 0,
+                },
+                &vc,
+            )
+            .unwrap();
+
+        // Query with a well-formed (128+ byte) ZK proof — should STILL fail
+        // because real_verification is not enabled
+        let result = state.apply(
+            &BiologicalOp::QueryWithZkProof {
+                subject,
+                consumer,
+                zk_proof: vec![0u8; 192],
+                query: "test query".into(),
+            },
+            &vc,
+        );
+        assert!(result.is_err(), "ZK proof should be rejected without real_verification");
     }
 }

--- a/shards/src/computational/state.rs
+++ b/shards/src/computational/state.rs
@@ -227,7 +227,8 @@ impl ComputationalState {
                     task.status = TaskStatus::Failed;
                     task.last_update.merge(vc);
                     return Err(ShardError::ValidationFailed(
-                        "ZK proof verification failed: proof does not match expected layout for real verification".into(),
+                        "ZK proof verification failed: proof does not match expected layout for real verification"
+                            .into(),
                     ));
                 }
             }
@@ -365,7 +366,13 @@ mod tests {
 
         // Submit a well-formed (128+ byte) proof
         state
-            .apply(&ComputationalOp::SubmitProof { task_id, proof: vec![0u8; 192] }, &vc)
+            .apply(
+                &ComputationalOp::SubmitProof {
+                    task_id,
+                    proof: vec![0u8; 192],
+                },
+                &vc,
+            )
             .unwrap();
 
         // Verify — should STILL fail because real_verification is not enabled

--- a/shards/src/computational/state.rs
+++ b/shards/src/computational/state.rs
@@ -216,9 +216,9 @@ impl ComputationalState {
                 {
                     task.status = TaskStatus::Failed;
                     task.last_update.merge(vc);
-                    return Err(ShardError::ValidationFailed(
+                    Err(ShardError::ValidationFailed(
                         "ZK proof verification requires 'real_verification' feature to be enabled".into(),
-                    ));
+                    ))
                 }
 
                 // When real_verification is enabled but proof didn't match expected layout
@@ -226,10 +226,10 @@ impl ComputationalState {
                 {
                     task.status = TaskStatus::Failed;
                     task.last_update.merge(vc);
-                    return Err(ShardError::ValidationFailed(
+                    Err(ShardError::ValidationFailed(
                         "ZK proof verification failed: proof does not match expected layout for real verification"
                             .into(),
-                    ));
+                    ))
                 }
             }
         }

--- a/shards/src/computational/state.rs
+++ b/shards/src/computational/state.rs
@@ -11,26 +11,6 @@ use serde::{Deserialize, Serialize};
 use super::ops::ComputationalOp;
 use crate::shard::ShardError;
 
-/// Minimum expected byte length for a Groth16 proof over Bn254.
-///
-/// A Groth16 proof consists of three curve points:
-/// - 2 × G1 point (48 bytes uncompressed each) = 96 bytes
-/// - 1 × G2 point (96 bytes uncompressed) = 96 bytes
-///
-/// Total minimum: 192 bytes. We use the conservative lower bound of 128
-/// to allow for compressed representations.
-const MIN_GROTH16_PROOF_LEN: usize = 128;
-
-/// Check whether the proof bytes have a plausible Groth16 layout.
-///
-/// This does **not** verify cryptographic validity — it only rejects
-/// obviously malformed proofs (too short to contain the expected
-/// curve-point data). Real verification requires the `real_verification`
-/// feature flag.
-fn is_valid_zk_proof_layout(bytes: &[u8]) -> bool {
-    bytes.len() >= MIN_GROTH16_PROOF_LEN
-}
-
 /// Status of a compute task.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum TaskStatus {
@@ -231,34 +211,25 @@ impl ComputationalState {
                     // to the default placeholder verification below.
                 }
 
-                // Default (placeholder) verification: reject proofs that don't match
-                // the expected ZK proof format. When real_verification is disabled,
-                // we still validate proof structure — empty or obviously malformed
-                // proofs are rejected.
-                if proof_bytes.is_empty() {
+                // When real_verification is disabled, always reject
+                #[cfg(not(feature = "real_verification"))]
+                {
                     task.status = TaskStatus::Failed;
                     task.last_update.merge(vc);
                     return Err(ShardError::ValidationFailed(
-                        "Proof verification failed: empty proof bytes".into(),
+                        "ZK proof verification requires 'real_verification' feature to be enabled".into(),
                     ));
                 }
-                if !is_valid_zk_proof_layout(proof_bytes) {
+
+                // When real_verification is enabled but proof didn't match expected layout
+                #[cfg(feature = "real_verification")]
+                {
                     task.status = TaskStatus::Failed;
                     task.last_update.merge(vc);
                     return Err(ShardError::ValidationFailed(
-                        "Proof verification failed: proof too short for Groth16 layout".into(),
+                        "ZK proof verification failed: proof does not match expected layout for real verification".into(),
                     ));
                 }
-                // Proof passes layout validation — placeholder accepts it.
-                // Real cryptographic verification requires the `real_verification` feature.
-                tracing::warn!(
-                    task = ?&task_id[..4],
-                    len = proof_bytes.len(),
-                    "Placeholder ZK verification: proof layout accepted without crypto verification"
-                );
-                task.status = TaskStatus::Verified;
-                task.last_update.merge(vc);
-                Ok(())
             }
         }
     }
@@ -320,14 +291,14 @@ mod tests {
             )
             .unwrap();
 
-        // 3. Verify the 1-byte proof — should fail with ValidationFailed
+        // 3. Verify the 1-byte proof — should fail without real_verification
         let result = state.apply(&ComputationalOp::VerifyProof { task_id }, &vc);
-        assert!(result.is_err(), "1-byte malformed proof should be rejected");
+        assert!(result.is_err(), "ZK proof should be rejected without real_verification");
         match result.unwrap_err() {
             ShardError::ValidationFailed(msg) => {
                 assert!(
-                    msg.contains("Groth16 layout"),
-                    "expected Groth16 layout error, got: {msg}"
+                    msg.contains("real_verification"),
+                    "expected real_verification error, got: {msg}"
                 );
             }
             other => panic!("expected ValidationFailed, got {other:?}"),
@@ -362,15 +333,44 @@ mod tests {
 
         // Verify the empty proof — should fail
         let result = state.apply(&ComputationalOp::VerifyProof { task_id }, &vc);
-        assert!(result.is_err(), "empty proof should be rejected");
+        assert!(result.is_err(), "ZK proof should be rejected without real_verification");
         match result.unwrap_err() {
             ShardError::ValidationFailed(msg) => {
                 assert!(
-                    msg.contains("empty proof bytes"),
-                    "expected empty proof error, got: {msg}"
+                    msg.contains("real_verification"),
+                    "expected real_verification error, got: {msg}"
                 );
             }
             other => panic!("expected ValidationFailed, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn test_valid_layout_proof_also_rejected_without_real_verification() {
+        let mut state = ComputationalState::new();
+        let vc = test_vc();
+        let task_id = [0xEF; 32];
+
+        // Submit a task
+        state
+            .apply(
+                &ComputationalOp::SubmitTask {
+                    task_id,
+                    spec: vec![1, 2, 3],
+                    reward: 100,
+                },
+                &vc,
+            )
+            .unwrap();
+
+        // Submit a well-formed (128+ byte) proof
+        state
+            .apply(&ComputationalOp::SubmitProof { task_id, proof: vec![0u8; 192] }, &vc)
+            .unwrap();
+
+        // Verify — should STILL fail because real_verification is not enabled
+        let result = state.apply(&ComputationalOp::VerifyProof { task_id }, &vc);
+        assert!(result.is_err(), "ZK proof should be rejected without real_verification");
+        assert_eq!(state.tasks[&task_id].status, TaskStatus::Failed);
     }
 }

--- a/shards/src/domain_state.rs
+++ b/shards/src/domain_state.rs
@@ -60,7 +60,7 @@ impl ShardState for IdentityState {
     type Op = crate::identity::ops::IdentityOp;
 
     fn apply_op(&mut self, op: &Self::Op, event: &Event) -> Result<(), ShardError> {
-        self.apply(op, &event.vector_clock)
+        self.apply(op, &event.vector_clock, Some(&event.creator_pubkey))
     }
 
     fn snapshot(&self) -> Result<Vec<u8>, ShardError> {
@@ -114,10 +114,10 @@ impl ShardState for BiologicalState {
 impl ShardState for EconomicsState {
     type Op = omnia_economics::EconomicsOp;
 
-    fn apply_op(&mut self, op: &Self::Op, _event: &Event) -> Result<(), ShardError> {
-        // EconomicsState::apply takes (op, current_epoch).
-        // We use the state's tracked epoch.
-        self.apply(op, self.current_epoch())
+    fn apply_op(&mut self, op: &Self::Op, event: &Event) -> Result<(), ShardError> {
+        // EconomicsState::apply takes (op, current_epoch, event_creator).
+        // We use the state's tracked epoch and pass the event creator for admin gating.
+        self.apply(op, self.current_epoch(), Some(&event.creator_pubkey))
             .map_err(|e| ShardError::ValidationFailed(e.to_string()))
     }
 

--- a/shards/src/financial/state.rs
+++ b/shards/src/financial/state.rs
@@ -149,7 +149,9 @@ impl FinancialState {
         match op {
             FinancialOp::Transfer { to, amount } => {
                 if *amount == 0 {
-                    return Err(ShardError::InvalidOperation("Transfer amount must be greater than zero".into()));
+                    return Err(ShardError::InvalidOperation(
+                        "Transfer amount must be greater than zero".into(),
+                    ));
                 }
                 let from = event.creator_pubkey;
                 let vc = &event.vector_clock;
@@ -180,7 +182,11 @@ impl FinancialState {
                 match self.mint_authority {
                     Some(auth) if auth == minter => {}
                     Some(_) => return Err(ShardError::ValidationFailed("Unauthorized minter".into())),
-                    None => return Err(ShardError::ValidationFailed("Minting is disabled (no mint authority set)".into())),
+                    None => {
+                        return Err(ShardError::ValidationFailed(
+                            "Minting is disabled (no mint authority set)".into(),
+                        ))
+                    }
                 }
                 let vc = &event.vector_clock;
                 let balance = self.balances.entry(*to).or_default();

--- a/shards/src/financial/state.rs
+++ b/shards/src/financial/state.rs
@@ -113,11 +113,26 @@ impl FinancialState {
     const FINANCIAL_STATE_VERSION: u8 = 1;
 
     /// Create an empty financial state with no accounts.
+    ///
+    /// Note: `mint_authority` is `None`, which means minting is disabled.
+    /// Use [`with_mint_authority`](Self::with_mint_authority) to create
+    /// a state that allows minting.
     pub fn new() -> Self {
         Self {
             balances: HashMap::new(),
             total_supply: 0,
             mint_authority: None,
+        }
+    }
+
+    /// Create a `FinancialState` with a specific mint authority.
+    ///
+    /// Only the specified public key will be allowed to mint new tokens.
+    pub fn with_mint_authority(mint_authority: [u8; 32]) -> Self {
+        Self {
+            balances: HashMap::new(),
+            total_supply: 0,
+            mint_authority: Some(mint_authority),
         }
     }
 
@@ -133,18 +148,24 @@ impl FinancialState {
     pub fn apply(&mut self, op: &FinancialOp, event: &Event) -> Result<(), ShardError> {
         match op {
             FinancialOp::Transfer { to, amount } => {
+                if *amount == 0 {
+                    return Err(ShardError::InvalidOperation("Transfer amount must be greater than zero".into()));
+                }
                 let from = event.creator_pubkey;
                 let vc = &event.vector_clock;
 
-                // Debit the sender
+                // Validate first (read-only checks)
                 let from_balance = self
                     .balances
-                    .get_mut(&from)
+                    .get(&from)
                     .ok_or_else(|| ShardError::ValidationFailed("Sender account not found".into()))?;
 
                 if from_balance.value() < *amount {
                     return Err(ShardError::ValidationFailed("Insufficient balance".into()));
                 }
+
+                // Now apply mutations
+                let from_balance = self.balances.get_mut(&from).expect("checked above");
                 from_balance.decrement(*amount, vc)?;
 
                 // Credit the recipient
@@ -154,13 +175,12 @@ impl FinancialState {
                 Ok(())
             }
             FinancialOp::Mint { to, amount } => {
-                // Check mint authority: if set, only the authority can mint
-                if let Some(authority) = self.mint_authority {
-                    if event.creator_pubkey != authority {
-                        return Err(ShardError::ValidationFailed(
-                            "Only mint authority can mint new tokens".into(),
-                        ));
-                    }
+                // Authorization: check mint authority
+                let minter = event.creator_pubkey;
+                match self.mint_authority {
+                    Some(auth) if auth == minter => {}
+                    Some(_) => return Err(ShardError::ValidationFailed("Unauthorized minter".into())),
+                    None => return Err(ShardError::ValidationFailed("Minting is disabled (no mint authority set)".into())),
                 }
                 let vc = &event.vector_clock;
                 let balance = self.balances.entry(*to).or_default();

--- a/shards/src/financial/state.rs
+++ b/shards/src/financial/state.rs
@@ -181,7 +181,11 @@ impl FinancialState {
                 let minter = event.creator_pubkey;
                 match self.mint_authority {
                     Some(auth) if auth == minter => {}
-                    Some(_) => return Err(ShardError::ValidationFailed("Unauthorized: caller is not the mint authority".into())),
+                    Some(_) => {
+                        return Err(ShardError::ValidationFailed(
+                            "Unauthorized: caller is not the mint authority".into(),
+                        ))
+                    }
                     None => {
                         return Err(ShardError::ValidationFailed(
                             "Minting is disabled (no mint authority set)".into(),

--- a/shards/src/financial/state.rs
+++ b/shards/src/financial/state.rs
@@ -181,7 +181,7 @@ impl FinancialState {
                 let minter = event.creator_pubkey;
                 match self.mint_authority {
                     Some(auth) if auth == minter => {}
-                    Some(_) => return Err(ShardError::ValidationFailed("Unauthorized minter".into())),
+                    Some(_) => return Err(ShardError::ValidationFailed("Unauthorized: caller is not the mint authority".into())),
                     None => {
                         return Err(ShardError::ValidationFailed(
                             "Minting is disabled (no mint authority set)".into(),

--- a/shards/src/financial/validator.rs
+++ b/shards/src/financial/validator.rs
@@ -90,14 +90,14 @@ mod tests {
     fn make_signed_event(keypair: &omnia_substrate::crypto::NodeKeypair, payload: Vec<u8>) -> Event {
         let creator = keypair.verifying_key().to_bytes();
         let vc = VectorClock::with_node(creator, 1);
-        let mut event = Event::new(creator, 0, vc, None, None, payload);
+        let mut event = Event::new(creator, 0, vc, None, None, payload).expect("event creation should succeed");
         event.sign_with_keypair(keypair);
         event
     }
 
     /// Helper: create a FinancialState with a single account having the given balance.
     fn state_with_balance(account: AccountId, balance: u64) -> FinancialState {
-        let mut state = FinancialState::new();
+        let mut state = FinancialState::with_mint_authority(account);
         state.balances.insert(account, AccountBalance::with_balance(balance));
         state.total_supply = balance;
         state
@@ -202,12 +202,12 @@ mod tests {
     #[test]
     fn test_replay_mint_same_event() {
         let target = test_account(0xCC);
-        let mut state = FinancialState::new();
+        let keypair = generate_keypair();
+        let mut state = FinancialState::with_mint_authority(keypair.verifying_key().to_bytes());
 
         let mint_op = FinancialOp::Mint { to: target, amount: 50 };
 
         // Create two identical events (same keypair, same sequence — simulating replay)
-        let keypair = generate_keypair();
         let event1 = make_signed_event(&keypair, vec![1]);
 
         // First Mint — should succeed
@@ -364,7 +364,8 @@ mod tests {
     #[test]
     fn test_mint_to_new_account() {
         let new_account = test_account(0xFF);
-        let mut state = FinancialState::new();
+        let keypair = generate_keypair();
+        let mut state = FinancialState::with_mint_authority(keypair.verifying_key().to_bytes());
 
         // Verify the account doesn't exist yet
         assert_eq!(state.balance_of(&new_account), 0);
@@ -374,7 +375,6 @@ mod tests {
             to: new_account,
             amount: 200,
         };
-        let keypair = generate_keypair();
         let event = make_signed_event(&keypair, vec![1]);
 
         let result = state.apply(&mint, &event);
@@ -558,14 +558,14 @@ mod tests {
     fn test_state_serialization_after_operations() {
         let account_a = test_account(0x77);
         let account_b = test_account(0x88);
-        let mut state = FinancialState::new();
+        let keypair = generate_keypair();
+        let mut state = FinancialState::with_mint_authority(keypair.verifying_key().to_bytes());
 
         // Mint to account A
         let mint = FinancialOp::Mint {
             to: account_a,
             amount: 500,
         };
-        let keypair = generate_keypair();
         let event = make_signed_event(&keypair, vec![1]);
         state.apply(&mint, &event).unwrap();
 
@@ -585,8 +585,7 @@ mod tests {
         let authority_keypair = generate_keypair();
         let authority_pubkey: AccountId = authority_keypair.verifying_key().to_bytes();
 
-        let mut state = FinancialState::new();
-        state.mint_authority = Some(authority_pubkey);
+        let mut state = FinancialState::with_mint_authority(authority_pubkey);
 
         let target = test_account(0xAA);
         let mint = FinancialOp::Mint {

--- a/shards/src/financial/validator.rs
+++ b/shards/src/financial/validator.rs
@@ -271,16 +271,20 @@ mod tests {
         };
         let event = make_signed_event(&sender_keypair, vec![1]);
 
-        // Even if the validator were bypassed, apply still has the
-        // decrement check. With amount 0, decrement would succeed but
-        // increment would also succeed — the balance would be unchanged.
-        // However, in practice the FinancialShard::process_event calls
-        // validate() first, so this should never reach apply().
-        // Let's verify that direct apply with amount 0 is a no-op
-        // (decrement by 0 succeeds, increment by 0 succeeds).
+        // Defense in depth: apply() also rejects zero-amount transfers,
+        // even if the validator were bypassed.
         let result = state.apply(&transfer, &event);
-        // Amount 0 is handled gracefully — balance unchanged
-        assert!(result.is_ok(), "Zero-amount transfer via apply is a no-op");
+        assert!(result.is_err(), "Zero-amount transfer should be rejected by apply");
+        match result {
+            Err(ShardError::InvalidOperation(msg)) => {
+                assert!(
+                    msg.to_lowercase().contains("greater than zero"),
+                    "Error should mention zero amount, got: {msg}"
+                );
+            }
+            Err(other) => panic!("Expected InvalidOperation, got: {other:?}"),
+            Ok(()) => panic!("Zero-amount transfer should have been rejected by apply"),
+        }
         assert_eq!(state.balance_of(&sender_pubkey), 100);
     }
 

--- a/shards/src/identity/recovery.rs
+++ b/shards/src/identity/recovery.rs
@@ -22,6 +22,12 @@ pub enum ShamirError {
     /// Invalid share data provided.
     #[error("invalid share: {0}")]
     InvalidShare(String),
+    /// Invalid threshold parameter.
+    #[error("invalid threshold: {0}")]
+    InvalidThreshold(u8),
+    /// Invalid secret data provided.
+    #[error("invalid secret: {0}")]
+    InvalidSecret(String),
 }
 
 /// A single share in a Shamir secret sharing scheme.
@@ -40,13 +46,21 @@ impl ShamirRecovery {
     /// Split a secret into `total` shares, any `threshold` of which can
     /// reconstruct it.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if `threshold < 2`, `threshold > total`, or `secret` is empty.
-    pub fn split(secret: &[u8], threshold: u8, total: u8) -> Vec<RecoveryShare> {
-        assert!(threshold >= 2, "threshold must be at least 2");
-        assert!(threshold <= total, "threshold cannot exceed total");
-        assert!(!secret.is_empty(), "secret cannot be empty");
+    /// Returns [`ShamirError::InvalidThreshold`] if `threshold < 2` or
+    /// `threshold > total`.
+    /// Returns [`ShamirError::InvalidSecret`] if `secret` is empty.
+    pub fn split(secret: &[u8], threshold: u8, total: u8) -> Result<Vec<RecoveryShare>, ShamirError> {
+        if threshold < 2 {
+            return Err(ShamirError::InvalidThreshold(threshold));
+        }
+        if threshold > total {
+            return Err(ShamirError::InvalidThreshold(threshold));
+        }
+        if secret.is_empty() {
+            return Err(ShamirError::InvalidSecret("secret cannot be empty".into()));
+        }
 
         let mut rng = rand::thread_rng();
 
@@ -78,17 +92,40 @@ impl ShamirRecovery {
                 value: share_value,
             });
         }
-        shares
+        Ok(shares)
     }
 
     /// Reconstruct the secret from at least `threshold` shares.
     ///
-    /// Returns an error if the shares list is empty or interpolation fails.
+    /// Returns an error if the shares list is empty, shares have
+    /// inconsistent lengths, duplicate indices are present, or
+    /// interpolation fails.
     pub fn reconstruct(shares: &[RecoveryShare]) -> Result<Vec<u8>, ShamirError> {
         if shares.is_empty() {
             return Err(ShamirError::InvalidShare("no shares provided".into()));
         }
         let secret_len = shares[0].value.len();
+
+        // Validate share consistency: all shares must have the same value length
+        for (i, share) in shares.iter().enumerate().skip(1) {
+            if share.value.len() != secret_len {
+                return Err(ShamirError::InvalidShare(
+                    format!("inconsistent share lengths: share {} has {} bytes, expected {}",
+                        i, share.value.len(), secret_len)
+                ));
+            }
+        }
+
+        // Check for duplicate indices
+        let mut seen_indices = std::collections::HashSet::new();
+        for share in shares {
+            if !seen_indices.insert(share.index) {
+                return Err(ShamirError::InvalidShare(
+                    format!("duplicate share index: {}", share.index)
+                ));
+            }
+        }
+
         let mut secret = Vec::with_capacity(secret_len);
 
         for byte_pos in 0..secret_len {
@@ -202,7 +239,7 @@ mod tests {
     #[test]
     fn test_split_and_reconstruct_threshold() {
         let secret = b"my super secret key";
-        let shares = ShamirRecovery::split(secret, 3, 5);
+        let shares = ShamirRecovery::split(secret, 3, 5).unwrap();
         assert_eq!(shares.len(), 5);
 
         // Reconstruct with exactly threshold shares
@@ -221,7 +258,7 @@ mod tests {
     #[test]
     fn test_insufficient_shares_reveal_nothing() {
         let secret = b"my super secret key";
-        let shares = ShamirRecovery::split(secret, 3, 5);
+        let shares = ShamirRecovery::split(secret, 3, 5).unwrap();
 
         // With fewer than threshold shares, reconstruction should produce
         // different data (not the secret)
@@ -233,10 +270,35 @@ mod tests {
     #[test]
     fn test_single_byte_secret() {
         let secret = b"\x42";
-        let shares = ShamirRecovery::split(secret, 2, 3);
+        let shares = ShamirRecovery::split(secret, 2, 3).unwrap();
 
         let reconstructed = ShamirRecovery::reconstruct(&shares[0..2]).unwrap();
         assert_eq!(reconstructed, secret);
+    }
+
+    #[test]
+    fn test_split_invalid_threshold() {
+        let secret = b"test";
+
+        // threshold < 2
+        assert!(ShamirRecovery::split(secret, 1, 3).is_err());
+
+        // threshold > total
+        assert!(ShamirRecovery::split(secret, 5, 3).is_err());
+    }
+
+    #[test]
+    fn test_split_empty_secret() {
+        assert!(ShamirRecovery::split(&[], 2, 3).is_err());
+    }
+
+    #[test]
+    fn test_reconstruct_duplicate_indices() {
+        let secret = b"test";
+        let shares = ShamirRecovery::split(secret, 2, 3).unwrap();
+        // Duplicate the first share
+        let dup_shares = vec![shares[0].clone(), shares[0].clone()];
+        assert!(ShamirRecovery::reconstruct(&dup_shares).is_err());
     }
 
     #[test]

--- a/shards/src/identity/recovery.rs
+++ b/shards/src/identity/recovery.rs
@@ -109,10 +109,12 @@ impl ShamirRecovery {
         // Validate share consistency: all shares must have the same value length
         for (i, share) in shares.iter().enumerate().skip(1) {
             if share.value.len() != secret_len {
-                return Err(ShamirError::InvalidShare(
-                    format!("inconsistent share lengths: share {} has {} bytes, expected {}",
-                        i, share.value.len(), secret_len)
-                ));
+                return Err(ShamirError::InvalidShare(format!(
+                    "inconsistent share lengths: share {} has {} bytes, expected {}",
+                    i,
+                    share.value.len(),
+                    secret_len
+                )));
             }
         }
 
@@ -120,9 +122,10 @@ impl ShamirRecovery {
         let mut seen_indices = std::collections::HashSet::new();
         for share in shares {
             if !seen_indices.insert(share.index) {
-                return Err(ShamirError::InvalidShare(
-                    format!("duplicate share index: {}", share.index)
-                ));
+                return Err(ShamirError::InvalidShare(format!(
+                    "duplicate share index: {}",
+                    share.index
+                )));
             }
         }
 

--- a/shards/src/identity/state.rs
+++ b/shards/src/identity/state.rs
@@ -128,7 +128,11 @@ impl IdentityState {
     }
 
     /// Apply an identity operation, mutating state.
-    pub fn apply(&mut self, op: &IdentityOp, vc: &VectorClock) -> Result<(), ShardError> {
+    ///
+    /// The `caller_pubkey` parameter provides the public key of the event
+    /// creator for authorization checks. When `None`, authorization checks
+    /// are skipped (used in backward-compatible contexts like tests).
+    pub fn apply(&mut self, op: &IdentityOp, vc: &VectorClock, caller_pubkey: Option<&[u8; 32]>) -> Result<(), ShardError> {
         match op {
             IdentityOp::CreateDid { document } => {
                 if self.dids.contains_key(&document.id) {
@@ -136,6 +140,14 @@ impl IdentityState {
                         "DID already exists: {}",
                         document.id
                     )));
+                }
+                // Authorization: creator's public key must match the document's primary key
+                if let Some(caller) = caller_pubkey {
+                    if &document.public_key != caller {
+                        return Err(ShardError::ValidationFailed(
+                            "Unauthorized: creator public key must match DID document primary key".into()
+                        ));
+                    }
                 }
                 self.dids.insert(document.id.clone(), document.clone());
                 Ok(())
@@ -145,6 +157,13 @@ impl IdentityState {
                     .dids
                     .get_mut(did)
                     .ok_or_else(|| ShardError::ValidationFailed(format!("DID not found: {did}")))?;
+
+                // Authorization check: caller must be in the document's authentication set
+                if let Some(caller) = caller_pubkey {
+                    if !doc.authentication.iter().any(|key| key == caller) {
+                        return Err(ShardError::ValidationFailed("Unauthorized: caller not in authentication set".into()));
+                    }
+                }
 
                 for update in updates {
                     match update {
@@ -198,6 +217,13 @@ impl IdentityState {
                 if !self.dids.contains_key(did) {
                     return Err(ShardError::ValidationFailed(format!("Owner DID not found: {did}")));
                 }
+                // Authorization: caller must be in the DID's authentication set
+                if let Some(caller) = caller_pubkey {
+                    let doc = self.dids.get(did).expect("checked above");
+                    if !doc.authentication.iter().any(|key| key == caller) {
+                        return Err(ShardError::ValidationFailed("Unauthorized: caller not in authentication set for AddAgent".into()));
+                    }
+                }
                 if self.agent_registry.contains_key(&agent.did) {
                     return Err(ShardError::StateConflict(format!(
                         "Agent already exists: {}",
@@ -214,6 +240,13 @@ impl IdentityState {
             } => {
                 if !self.dids.contains_key(did) {
                     return Err(ShardError::ValidationFailed(format!("DID not found: {did}")));
+                }
+                // Authorization: caller must be in the DID's authentication set
+                if let Some(caller) = caller_pubkey {
+                    let doc = self.dids.get(did).expect("checked above");
+                    if !doc.authentication.iter().any(|key| key == caller) {
+                        return Err(ShardError::ValidationFailed("Unauthorized: caller not in authentication set for EnrollBiometric".into()));
+                    }
                 }
                 let anchor = BiometricAnchor::enroll(template, algorithm);
                 self.biometric_registry.insert(did.clone(), anchor);
@@ -246,7 +279,15 @@ impl IdentityState {
                 if !self.dids.contains_key(did) {
                     return Err(ShardError::ValidationFailed(format!("DID not found: {did}")));
                 }
-                let shares = ShamirRecovery::split(secret, *threshold, *total_shares);
+                // Authorization: caller must be in the DID's authentication set
+                if let Some(caller) = caller_pubkey {
+                    let doc = self.dids.get(did).expect("checked above");
+                    if !doc.authentication.iter().any(|key| key == caller) {
+                        return Err(ShardError::ValidationFailed("Unauthorized: caller not in authentication set for ConfigureRecovery".into()));
+                    }
+                }
+                let shares = ShamirRecovery::split(secret, *threshold, *total_shares)
+                    .map_err(|e| ShardError::ValidationFailed(format!("Recovery split failed: {e}")))?;
                 self.recovery_registry.insert(
                     did.clone(),
                     RecoveryConfig {
@@ -294,7 +335,8 @@ impl IdentityState {
         if !self.dids.contains_key(did) {
             return Err(ShardError::ValidationFailed(format!("DID not found: {did}")));
         }
-        let shares = ShamirRecovery::split(secret, threshold, total);
+        let shares = ShamirRecovery::split(secret, threshold, total)
+            .map_err(|e| ShardError::ValidationFailed(format!("Recovery split failed: {e}")))?;
         self.recovery_registry.insert(
             did.to_string(),
             RecoveryConfig {
@@ -557,7 +599,7 @@ mod tests {
         let original_pk: [u8; 32] = [0xAB; 32];
         let did = "did:omnia:abcd1234".to_string();
         let doc = DidDocument::new(did.clone(), original_pk, 1000);
-        state.apply(&IdentityOp::CreateDid { document: doc }, &vc).unwrap();
+        state.apply(&IdentityOp::CreateDid { document: doc }, &vc, None).unwrap();
 
         // Step 2: Configure recovery with 5 custodians, threshold=3
         let secret = b"my-super-secret-recovery-key";
@@ -570,6 +612,7 @@ mod tests {
                     total_shares: 5,
                 },
                 &vc,
+                None,
             )
             .unwrap();
 
@@ -613,6 +656,7 @@ mod tests {
                     shares: recovering_shares,
                 },
                 &vc,
+                None,
             )
             .unwrap();
 
@@ -646,7 +690,7 @@ mod tests {
         state.dids.insert(did.clone(), doc);
 
         let secret = b"test-secret-for-aes-gcm";
-        let shares = ShamirRecovery::split(secret, 2, 3);
+        let shares = ShamirRecovery::split(secret, 2, 3).unwrap();
 
         // Persist and then decrypt
         state.persist_shares(&did, &shares).unwrap();
@@ -685,7 +729,7 @@ mod tests {
         let doc = DidDocument::new(did.clone(), pk, 0);
         state.dids.insert(did.clone(), doc);
 
-        let shares = ShamirRecovery::split(b"secret", 2, 3);
+        let shares = ShamirRecovery::split(b"secret", 2, 3).unwrap();
         state.persist_shares(&did, &shares).unwrap();
 
         let encrypted = state.shares.get(&did).unwrap();
@@ -703,7 +747,7 @@ mod tests {
         state.dids.insert(did.clone(), doc);
 
         let secret = b"test-secret-for-aes-gcm";
-        let shares = ShamirRecovery::split(secret, 2, 3);
+        let shares = ShamirRecovery::split(secret, 2, 3).unwrap();
         state.persist_shares(&did, &shares).unwrap();
 
         // Verify version 2
@@ -734,7 +778,7 @@ mod tests {
         state.dids.insert(did.clone(), doc);
 
         let secret = b"tamper-detection-secret";
-        let shares = ShamirRecovery::split(secret, 2, 3);
+        let shares = ShamirRecovery::split(secret, 2, 3).unwrap();
         state.persist_shares(&did, &shares).unwrap();
 
         // Tamper with a ciphertext byte
@@ -757,7 +801,7 @@ mod tests {
         state.dids.insert(did.clone(), doc);
 
         let secret = b"v1-backward-compat-secret";
-        let shares = ShamirRecovery::split(secret, 2, 3);
+        let shares = ShamirRecovery::split(secret, 2, 3).unwrap();
 
         // Manually create v1 (XOR) encrypted shares
         let mut v1_encrypted = Vec::new();
@@ -800,7 +844,7 @@ mod tests {
         state.dids.insert(did.clone(), doc);
 
         let secret = b"wrong-key-test-secret";
-        let shares = ShamirRecovery::split(secret, 2, 3);
+        let shares = ShamirRecovery::split(secret, 2, 3).unwrap();
         state.persist_shares(&did, &shares).unwrap();
 
         // Corrupt the custodian index to use wrong decryption key
@@ -821,7 +865,7 @@ mod tests {
         let original_pk: [u8; 32] = [0xAB; 32];
         let did = "did:omnia:recovery-auth-test".to_string();
         let doc = DidDocument::new(did.clone(), original_pk, 1000);
-        state.apply(&IdentityOp::CreateDid { document: doc }, &vc).unwrap();
+        state.apply(&IdentityOp::CreateDid { document: doc }, &vc, None).unwrap();
 
         // Configure recovery with 5 custodians, threshold=3
         let secret = b"recovery-auth-secret";
@@ -834,6 +878,7 @@ mod tests {
                     total_shares: 5,
                 },
                 &vc,
+                None,
             )
             .unwrap();
 
@@ -850,6 +895,7 @@ mod tests {
                     shares: recovering_shares,
                 },
                 &vc,
+                None,
             )
             .unwrap();
 
@@ -879,7 +925,7 @@ mod tests {
         let original_pk: [u8; 32] = [0xCC; 32];
         let did = "did:omnia:replay-test".to_string();
         let doc = DidDocument::new(did.clone(), original_pk, 1000);
-        state.apply(&IdentityOp::CreateDid { document: doc }, &vc).unwrap();
+        state.apply(&IdentityOp::CreateDid { document: doc }, &vc, None).unwrap();
 
         let secret = b"replay-prevention-secret";
         state
@@ -891,6 +937,7 @@ mod tests {
                     total_shares: 3,
                 },
                 &vc,
+                None,
             )
             .unwrap();
 
@@ -904,6 +951,7 @@ mod tests {
                     shares: shares.clone(),
                 },
                 &vc,
+                None,
             )
             .unwrap();
 
@@ -918,6 +966,7 @@ mod tests {
                     shares: shares.clone(),
                 },
                 &vc,
+                None,
             )
             .unwrap();
 

--- a/shards/src/identity/state.rs
+++ b/shards/src/identity/state.rs
@@ -132,7 +132,12 @@ impl IdentityState {
     /// The `caller_pubkey` parameter provides the public key of the event
     /// creator for authorization checks. When `None`, authorization checks
     /// are skipped (used in backward-compatible contexts like tests).
-    pub fn apply(&mut self, op: &IdentityOp, vc: &VectorClock, caller_pubkey: Option<&[u8; 32]>) -> Result<(), ShardError> {
+    pub fn apply(
+        &mut self,
+        op: &IdentityOp,
+        vc: &VectorClock,
+        caller_pubkey: Option<&[u8; 32]>,
+    ) -> Result<(), ShardError> {
         match op {
             IdentityOp::CreateDid { document } => {
                 if self.dids.contains_key(&document.id) {
@@ -145,7 +150,7 @@ impl IdentityState {
                 if let Some(caller) = caller_pubkey {
                     if &document.public_key != caller {
                         return Err(ShardError::ValidationFailed(
-                            "Unauthorized: creator public key must match DID document primary key".into()
+                            "Unauthorized: creator public key must match DID document primary key".into(),
                         ));
                     }
                 }
@@ -161,7 +166,9 @@ impl IdentityState {
                 // Authorization check: caller must be in the document's authentication set
                 if let Some(caller) = caller_pubkey {
                     if !doc.authentication.iter().any(|key| key == caller) {
-                        return Err(ShardError::ValidationFailed("Unauthorized: caller not in authentication set".into()));
+                        return Err(ShardError::ValidationFailed(
+                            "Unauthorized: caller not in authentication set".into(),
+                        ));
                     }
                 }
 
@@ -221,7 +228,9 @@ impl IdentityState {
                 if let Some(caller) = caller_pubkey {
                     let doc = self.dids.get(did).expect("checked above");
                     if !doc.authentication.iter().any(|key| key == caller) {
-                        return Err(ShardError::ValidationFailed("Unauthorized: caller not in authentication set for AddAgent".into()));
+                        return Err(ShardError::ValidationFailed(
+                            "Unauthorized: caller not in authentication set for AddAgent".into(),
+                        ));
                     }
                 }
                 if self.agent_registry.contains_key(&agent.did) {
@@ -245,7 +254,9 @@ impl IdentityState {
                 if let Some(caller) = caller_pubkey {
                     let doc = self.dids.get(did).expect("checked above");
                     if !doc.authentication.iter().any(|key| key == caller) {
-                        return Err(ShardError::ValidationFailed("Unauthorized: caller not in authentication set for EnrollBiometric".into()));
+                        return Err(ShardError::ValidationFailed(
+                            "Unauthorized: caller not in authentication set for EnrollBiometric".into(),
+                        ));
                     }
                 }
                 let anchor = BiometricAnchor::enroll(template, algorithm);
@@ -283,7 +294,9 @@ impl IdentityState {
                 if let Some(caller) = caller_pubkey {
                     let doc = self.dids.get(did).expect("checked above");
                     if !doc.authentication.iter().any(|key| key == caller) {
-                        return Err(ShardError::ValidationFailed("Unauthorized: caller not in authentication set for ConfigureRecovery".into()));
+                        return Err(ShardError::ValidationFailed(
+                            "Unauthorized: caller not in authentication set for ConfigureRecovery".into(),
+                        ));
                     }
                 }
                 let shares = ShamirRecovery::split(secret, *threshold, *total_shares)
@@ -599,7 +612,9 @@ mod tests {
         let original_pk: [u8; 32] = [0xAB; 32];
         let did = "did:omnia:abcd1234".to_string();
         let doc = DidDocument::new(did.clone(), original_pk, 1000);
-        state.apply(&IdentityOp::CreateDid { document: doc }, &vc, None).unwrap();
+        state
+            .apply(&IdentityOp::CreateDid { document: doc }, &vc, None)
+            .unwrap();
 
         // Step 2: Configure recovery with 5 custodians, threshold=3
         let secret = b"my-super-secret-recovery-key";
@@ -865,7 +880,9 @@ mod tests {
         let original_pk: [u8; 32] = [0xAB; 32];
         let did = "did:omnia:recovery-auth-test".to_string();
         let doc = DidDocument::new(did.clone(), original_pk, 1000);
-        state.apply(&IdentityOp::CreateDid { document: doc }, &vc, None).unwrap();
+        state
+            .apply(&IdentityOp::CreateDid { document: doc }, &vc, None)
+            .unwrap();
 
         // Configure recovery with 5 custodians, threshold=3
         let secret = b"recovery-auth-secret";
@@ -925,7 +942,9 @@ mod tests {
         let original_pk: [u8; 32] = [0xCC; 32];
         let did = "did:omnia:replay-test".to_string();
         let doc = DidDocument::new(did.clone(), original_pk, 1000);
-        state.apply(&IdentityOp::CreateDid { document: doc }, &vc, None).unwrap();
+        state
+            .apply(&IdentityOp::CreateDid { document: doc }, &vc, None)
+            .unwrap();
 
         let secret = b"replay-prevention-secret";
         state

--- a/shards/src/lib.rs
+++ b/shards/src/lib.rs
@@ -67,6 +67,7 @@ pub mod physical;
 pub mod router;
 pub mod shard;
 pub mod validator;
+pub mod zk;
 
 // Re-export core types
 pub use cross_shard::CrossShardMessage;

--- a/shards/src/lib.rs
+++ b/shards/src/lib.rs
@@ -108,6 +108,19 @@ impl_shard!(
     ShardId::financial()
 );
 
+impl FinancialShard {
+    /// Create a Financial shard with a specific mint authority.
+    ///
+    /// Only the specified public key will be allowed to mint new tokens.
+    /// This is required for any test or deployment that needs minting,
+    /// since [`FinancialShard::new()`] creates a shard with minting disabled.
+    pub fn with_mint_authority(mint_authority: [u8; 32]) -> Self {
+        Self {
+            state: FinancialState::with_mint_authority(mint_authority),
+        }
+    }
+}
+
 impl_shard!(
     /// The Identity shard — handles DID lifecycle and social recovery.
     IdentityShard,

--- a/shards/src/router.rs
+++ b/shards/src/router.rs
@@ -160,6 +160,15 @@ impl ShardRouter {
         let inner_op: ShardOp =
             postcard::from_bytes(&msg.payload).map_err(|e| ShardError::DeserializationError(e.to_string()))?;
 
+        // Verify the source shard matches the shard type that would generate this event
+        let expected_source = Self::shard_id_from_op(&inner_op);
+        if expected_source != msg.source_shard {
+            return Err(ShardError::ValidationFailed(
+                format!("cross-shard message source mismatch: expected {:?}, got {:?}",
+                    expected_source, msg.source_shard)
+            ));
+        }
+
         let target_id = msg.target_shard;
         if let Some(shard) = self.shards.get_mut(&target_id) {
             shard.process_event(event, inner_op)
@@ -217,6 +226,13 @@ impl ShardRouter {
                 payload.nonce, last_nonce
             )));
         }
+        // Prevent nonce gap attacks: reject nonces more than 1000 above the last seen
+        if payload.nonce > last_nonce + 1000 {
+            return Err(ShardError::ValidationFailed(format!(
+                "nonce {} too far ahead of last nonce {} (max gap: 1000)",
+                payload.nonce, last_nonce
+            )));
+        }
         self.last_nonces.insert(creator, payload.nonce);
 
         // Persist nonce state (best-effort, log on failure)
@@ -269,19 +285,25 @@ impl ShardRouter {
         self.shards.len()
     }
 
-    /// Convert a 32-byte Ed25519 public key to a DID string.
-    ///
-    /// Uses hex encoding of the public key bytes to form a
-    /// `did:omnia:<hex>` identifier. This DID is used as the
-    /// account key in the quota system.
-    ///
-    /// # Security
-    ///
-    /// The DID is derived deterministically from the public key,
-    /// making it a stable identifier that cannot be forged without
-    /// the corresponding private key.
+    /// Convert a public key to a DID string.
     pub fn pubkey_to_did(pubkey: &[u8; 32]) -> String {
         format!("did:omnia:{}", hex::encode(pubkey))
+    }
+
+    /// Determine which shard an operation belongs to.
+    ///
+    /// Maps each `ShardOp` variant to its corresponding `ShardId`.
+    /// Used for cross-shard message source verification.
+    fn shard_id_from_op(op: &ShardOp) -> ShardId {
+        match op {
+            ShardOp::Financial(_) => ShardId::financial(),
+            ShardOp::Computational(_) => ShardId::computational(),
+            ShardOp::Physical(_) => ShardId::physical(),
+            ShardOp::Biological(_) => ShardId::biological(),
+            ShardOp::Identity(_) => ShardId::identity(),
+            ShardOp::Economics(_) => ShardId::economics(),
+            ShardOp::CrossShard(_) => ShardId::financial(), // nested cross-shard not expected
+        }
     }
 }
 

--- a/shards/src/router.rs
+++ b/shards/src/router.rs
@@ -163,10 +163,10 @@ impl ShardRouter {
         // Verify the source shard matches the shard type that would generate this event
         let expected_source = Self::shard_id_from_op(&inner_op);
         if expected_source != msg.source_shard {
-            return Err(ShardError::ValidationFailed(
-                format!("cross-shard message source mismatch: expected {:?}, got {:?}",
-                    expected_source, msg.source_shard)
-            ));
+            return Err(ShardError::ValidationFailed(format!(
+                "cross-shard message source mismatch: expected {:?}, got {:?}",
+                expected_source, msg.source_shard
+            )));
         }
 
         let target_id = msg.target_shard;

--- a/shards/src/zk.rs
+++ b/shards/src/zk.rs
@@ -30,9 +30,12 @@ pub fn is_valid_zk_proof_layout(proof_bytes: &[u8]) -> bool {
 /// this always returns an error to prevent accepting unverified proofs.
 pub fn verify_zk_proof(proof_bytes: &[u8], context: &str) -> Result<(), crate::shard::ShardError> {
     if !is_valid_zk_proof_layout(proof_bytes) {
-        return Err(crate::shard::ShardError::ValidationFailed(
-            format!("{}: invalid ZK proof layout ({} bytes, minimum {})", context, proof_bytes.len(), MIN_GROTH16_PROOF_LEN)
-        ));
+        return Err(crate::shard::ShardError::ValidationFailed(format!(
+            "{}: invalid ZK proof layout ({} bytes, minimum {})",
+            context,
+            proof_bytes.len(),
+            MIN_GROTH16_PROOF_LEN
+        )));
     }
 
     #[cfg(feature = "real_verification")]
@@ -45,8 +48,9 @@ pub fn verify_zk_proof(proof_bytes: &[u8], context: &str) -> Result<(), crate::s
     #[cfg(not(feature = "real_verification"))]
     {
         let _ = context;
-        Err(crate::shard::ShardError::ValidationFailed(
-            format!("{}: ZK proof verification requires 'real_verification' feature", context)
-        ))
+        Err(crate::shard::ShardError::ValidationFailed(format!(
+            "{}: ZK proof verification requires 'real_verification' feature",
+            context
+        )))
     }
 }

--- a/shards/src/zk.rs
+++ b/shards/src/zk.rs
@@ -1,0 +1,52 @@
+//! Shared ZK proof verification utilities.
+//!
+//! Centralises the minimum-proof-length constant and layout-check helper
+//! so that both the Biological and Computational shards use the same
+//! definition. When the `real_verification` feature is disabled, every
+//! ZK proof is **rejected** — the placeholder that previously accepted
+//! any well-formed proof has been removed as a security hardening measure.
+
+/// Minimum length of a Groth16 proof in bytes.
+///
+/// A Groth16 proof consists of three curve points:
+/// - 2 × G1 point (48 bytes uncompressed each) = 96 bytes
+/// - 1 × G2 point (96 bytes uncompressed) = 96 bytes
+///
+/// Total minimum: 192 bytes. We use the conservative lower bound of 128
+/// to allow for compressed representations.
+pub const MIN_GROTH16_PROOF_LEN: usize = 128;
+
+/// Check if proof bytes have a valid ZK proof layout (length check only).
+///
+/// This does **not** verify cryptographic validity — it only rejects
+/// obviously malformed proofs (too short to contain the expected
+/// curve-point data). Real verification requires the `real_verification`
+/// feature flag.
+pub fn is_valid_zk_proof_layout(proof_bytes: &[u8]) -> bool {
+    proof_bytes.len() >= MIN_GROTH16_PROOF_LEN
+}
+
+/// Verify a ZK proof. When the `real_verification` feature is disabled,
+/// this always returns an error to prevent accepting unverified proofs.
+pub fn verify_zk_proof(proof_bytes: &[u8], context: &str) -> Result<(), crate::shard::ShardError> {
+    if !is_valid_zk_proof_layout(proof_bytes) {
+        return Err(crate::shard::ShardError::ValidationFailed(
+            format!("{}: invalid ZK proof layout ({} bytes, minimum {})", context, proof_bytes.len(), MIN_GROTH16_PROOF_LEN)
+        ));
+    }
+
+    #[cfg(feature = "real_verification")]
+    {
+        // Real verification logic would go here.
+        // For now, still reject until real verification is implemented.
+        todo!("Real ZK proof verification not yet implemented")
+    }
+
+    #[cfg(not(feature = "real_verification"))]
+    {
+        let _ = context;
+        Err(crate::shard::ShardError::ValidationFailed(
+            format!("{}: ZK proof verification requires 'real_verification' feature", context)
+        ))
+    }
+}

--- a/shards/tests/authorization_rejection.rs
+++ b/shards/tests/authorization_rejection.rs
@@ -22,7 +22,7 @@ fn test_node(id: u8) -> NodeId {
 /// Build a signed `Event` whose `creator_pubkey` matches `keypair`.
 fn make_signed_event(keypair: &NodeKeypair, sequence: u64, node_id: NodeId) -> Event {
     let vc = VectorClock::with_node(node_id, sequence + 1);
-    let mut event = Event::new(node_id, sequence, vc, None, None, vec![]);
+    let mut event = Event::new(node_id, sequence, vc, None, None, vec![]).expect("event creation should succeed");
     event.sign_with_keypair(keypair);
     event
 }
@@ -91,7 +91,7 @@ fn test_burn_unauthorized() {
     let _attacker_id = account_id(&attacker_kp);
     let node = test_node(1);
 
-    let mut state = FinancialState::new();
+    let mut state = FinancialState::with_mint_authority(owner_id);
 
     // Mint tokens to the owner
     let mint_op = FinancialOp::Mint {

--- a/shards/tests/cross_shard.rs
+++ b/shards/tests/cross_shard.rs
@@ -20,7 +20,7 @@ fn test_node(id: u8) -> NodeId {
 /// Create a signed event with the given payload, creator, and keypair.
 fn create_test_event_with_keypair(creator: NodeId, payload: Vec<u8>, keypair: &NodeKeypair) -> Event {
     let vc = VectorClock::with_node(creator, 1);
-    let mut event = Event::new(creator, 0, vc, None, None, payload);
+    let mut event = Event::new(creator, 0, vc, None, None, payload).expect("event creation should succeed");
     event.sign_with_keypair(keypair);
     event
 }

--- a/shards/tests/cross_shard.rs
+++ b/shards/tests/cross_shard.rs
@@ -34,15 +34,17 @@ fn create_test_event(creator: NodeId, payload: Vec<u8>) -> Event {
 
 #[test]
 fn test_financial_transfer_lifecycle() {
-    // Set up router with Financial shard
-    let mut router = ShardRouter::new_without_fees();
-    router.register(Box::new(FinancialShard::new()));
-
+    // Set up router with Financial shard — mint authority is the sender's keypair
     let sender_keypair = generate_keypair();
     let sender_pubkey = sender_keypair.verifying_key().to_bytes();
+
+    let mut router = ShardRouter::new_without_fees();
+    router.register(Box::new(FinancialShard::with_mint_authority(sender_pubkey)));
+
     let recipient = test_node(2);
 
     // Mint tokens to the sender (using their public key as the account)
+    // The event must be signed by the mint authority (sender_keypair)
     let mint_op = FinancialOp::Mint {
         to: sender_pubkey,
         amount: 1000,
@@ -80,7 +82,7 @@ fn test_financial_transfer_lifecycle() {
         operation: ShardOp::Financial(mint_op2),
         nonce: 3,
     };
-    let mint_event2 = create_test_event(test_node(1), mint_payload2.to_bytes().unwrap());
+    let mint_event2 = create_test_event_with_keypair(test_node(1), mint_payload2.to_bytes().unwrap(), &sender_keypair);
     router.route_event(&mint_event2).expect("Second mint should succeed");
 }
 
@@ -112,29 +114,32 @@ fn test_identity_did_lifecycle() {
     let mut router = ShardRouter::new_without_fees();
     router.register(Box::new(IdentityShard::new()));
 
-    let owner = test_node(1);
+    // Use a real keypair so the DID document's primary key matches
+    // the event's creator_pubkey (set by sign_with_keypair)
+    let owner_keypair = generate_keypair();
+    let owner_pubkey = owner_keypair.verifying_key().to_bytes();
     let did = "did:omnia:abcdef1234567890".to_string();
 
-    // Create a DID
-    let doc = omnia_shards::DidDocument::new(did.clone(), owner, 1000);
+    // Create a DID — the document's public_key must match the signing key
+    let doc = omnia_shards::DidDocument::new(did.clone(), owner_pubkey, 1000);
     let create_op = omnia_shards::IdentityOp::CreateDid { document: doc };
     let create_payload = ShardPayload {
         shard_id: ShardId::identity(),
         operation: ShardOp::Identity(create_op),
         nonce: 1,
     };
-    let create_event = create_test_event(owner, create_payload.to_bytes().unwrap());
+    let create_event = create_test_event_with_keypair(owner_pubkey, create_payload.to_bytes().unwrap(), &owner_keypair);
     router.route_event(&create_event).expect("Create DID should succeed");
 
     // Try to create the same DID again (should fail)
-    let doc2 = omnia_shards::DidDocument::new(did.clone(), owner, 2000);
+    let doc2 = omnia_shards::DidDocument::new(did.clone(), owner_pubkey, 2000);
     let dup_op = omnia_shards::IdentityOp::CreateDid { document: doc2 };
     let dup_payload = ShardPayload {
         shard_id: ShardId::identity(),
         operation: ShardOp::Identity(dup_op),
         nonce: 2,
     };
-    let dup_event = create_test_event(owner, dup_payload.to_bytes().unwrap());
+    let dup_event = create_test_event_with_keypair(owner_pubkey, dup_payload.to_bytes().unwrap(), &owner_keypair);
     let result = router.route_event(&dup_event);
     assert!(result.is_err(), "Duplicate DID creation should fail");
 }
@@ -197,15 +202,15 @@ fn test_payload_serialization_roundtrip() {
 
 #[test]
 fn test_burn_operation() {
-    let mut router = ShardRouter::new_without_fees();
-    router.register(Box::new(FinancialShard::new()));
-
-    let minter = test_node(1);
     // Use a real keypair for the account so the burn event can be properly authorized
     let account_keypair = generate_keypair();
     let account: [u8; 32] = account_keypair.verifying_key().to_bytes();
 
-    // Mint some tokens
+    // Mint authority must match the signing key for mint events
+    let mut router = ShardRouter::new_without_fees();
+    router.register(Box::new(FinancialShard::with_mint_authority(account)));
+
+    // Mint some tokens — must be signed by the mint authority
     let mint_op = FinancialOp::Mint {
         to: account,
         amount: 1000,
@@ -215,7 +220,7 @@ fn test_burn_operation() {
         operation: ShardOp::Financial(mint_op),
         nonce: 1,
     };
-    let mint_event = create_test_event(minter, mint_payload.to_bytes().unwrap());
+    let mint_event = create_test_event_with_keypair(account, mint_payload.to_bytes().unwrap(), &account_keypair);
     router.route_event(&mint_event).expect("Mint should succeed");
 
     // Burn some tokens — must be signed by the account owner (creator_pubkey == from)

--- a/shards/tests/fee_enforcement.rs
+++ b/shards/tests/fee_enforcement.rs
@@ -26,7 +26,7 @@ fn test_node(id: u8) -> NodeId {
 /// Create a signed event with the given payload, creator, and keypair.
 fn create_test_event_with_keypair(creator: NodeId, payload: Vec<u8>, keypair: &NodeKeypair) -> Event {
     let vc = VectorClock::with_node(creator, 1);
-    let mut event = Event::new(creator, 0, vc, None, None, payload);
+    let mut event = Event::new(creator, 0, vc, None, None, payload).expect("event creation should succeed");
     event.sign_with_keypair(keypair);
     event
 }

--- a/shards/tests/fee_enforcement.rs
+++ b/shards/tests/fee_enforcement.rs
@@ -199,7 +199,7 @@ fn test_cross_shard_fee_deduction() {
     router.register(Box::new(IdentityShard::new()));
 
     let msg = CrossShardMessage::new(
-        ShardId::financial(),
+        ShardId::identity(),
         ShardId::identity(),
         postcard::to_allocvec(&ShardOp::Identity(omnia_shards::IdentityOp::CreateDid {
             document: omnia_shards::DidDocument::new(

--- a/shards/tests/financial_adversarial.rs
+++ b/shards/tests/financial_adversarial.rs
@@ -28,9 +28,14 @@ fn test_node(id: u8) -> NodeId {
 /// financial shard uses vector clocks for conflict tracking.
 fn make_signed_event(keypair: &NodeKeypair, sequence: u64, node_id: NodeId) -> Event {
     let vc = VectorClock::with_node(node_id, sequence + 1);
-    let mut event = Event::new(node_id, sequence, vc, None, None, vec![]);
+    let mut event = Event::new(node_id, sequence, vc, None, None, vec![]).expect("event creation should succeed");
     event.sign_with_keypair(keypair);
     event
+}
+
+/// Helper: create a FinancialState with mint authority set to the given keypair.
+fn state_with_mint_authority(authority_keypair: &NodeKeypair) -> FinancialState {
+    FinancialState::with_mint_authority(account_id(authority_keypair))
 }
 
 /// Helper: extract the 32-byte public key (AccountId) from a keypair.
@@ -53,7 +58,7 @@ fn test_double_spend_attack() {
     let c = account_id(&kp_c);
     let node = test_node(1);
 
-    let mut state = FinancialState::new();
+    let mut state = state_with_mint_authority(&kp_a);
 
     // Mint 100 to A
     let mint_op = FinancialOp::Mint { to: a, amount: 100 };
@@ -102,7 +107,7 @@ fn test_negative_balance_prevention() {
     let b = account_id(&kp_b);
     let node = test_node(1);
 
-    let mut state = FinancialState::new();
+    let mut state = state_with_mint_authority(&kp_a);
 
     // Mint only 50 to A
     let mint_op = FinancialOp::Mint { to: a, amount: 50 };
@@ -149,8 +154,8 @@ fn test_replay_attack_nonce_bypass() {
     let node = test_node(1);
 
     // Build two identical starting states
-    let mut state1 = FinancialState::new();
-    let mut state2 = FinancialState::new();
+    let mut state1 = state_with_mint_authority(&kp_a);
+    let mut state2 = state_with_mint_authority(&kp_a);
 
     let mint_op = FinancialOp::Mint { to: a, amount: 200 };
     let event0 = make_signed_event(&kp_a, 0, node);
@@ -196,7 +201,7 @@ fn test_concurrent_transfers_balance_consistency() {
     let c = account_id(&kp_c);
     let node = test_node(1);
 
-    let mut state = FinancialState::new();
+    let mut state = state_with_mint_authority(&kp_a);
 
     // Mint 100 to A
     let mint_op = FinancialOp::Mint { to: a, amount: 100 };
@@ -284,7 +289,7 @@ fn test_zero_amount_burn_rejected() {
     let kp_a = generate_keypair();
     let a = account_id(&kp_a);
 
-    let mut state = FinancialState::new();
+    let mut state = state_with_mint_authority(&kp_a);
     // Give A some balance so the only failure reason is the zero amount
     let mint_op = FinancialOp::Mint { to: a, amount: 100 };
     let event0 = make_signed_event(&kp_a, 0, test_node(1));
@@ -314,7 +319,7 @@ fn test_burn_insufficient_balance() {
     let a = account_id(&kp_a);
     let node = test_node(1);
 
-    let mut state = FinancialState::new();
+    let mut state = state_with_mint_authority(&kp_a);
 
     // Mint only 30 to A
     let mint_op = FinancialOp::Mint { to: a, amount: 30 };
@@ -360,7 +365,7 @@ fn test_total_supply_consistency() {
     let c = account_id(&kp_c);
     let node = test_node(1);
 
-    let mut state = FinancialState::new();
+    let mut state = state_with_mint_authority(&kp_a);
     assert_eq!(state.total_supply, 0);
 
     // Mint 500 to A
@@ -370,8 +375,8 @@ fn test_total_supply_consistency() {
         .expect("mint A");
     assert_eq!(state.total_supply, 500, "mint should add to total_supply");
 
-    // Mint 300 to B
-    let event1 = make_signed_event(&kp_b, 1, node);
+    // Mint 300 to B — mint event must be signed by the mint authority (kp_a)
+    let event1 = make_signed_event(&kp_a, 1, node);
     state
         .apply(&FinancialOp::Mint { to: b, amount: 300 }, &event1)
         .expect("mint B");
@@ -421,7 +426,7 @@ fn test_transfer_to_self() {
     let a = account_id(&kp_a);
     let node = test_node(1);
 
-    let mut state = FinancialState::new();
+    let mut state = state_with_mint_authority(&kp_a);
 
     // Mint 100 to A
     let event0 = make_signed_event(&kp_a, 0, node);

--- a/shards/tests/identity_hardening.rs
+++ b/shards/tests/identity_hardening.rs
@@ -97,7 +97,9 @@ fn test_full_identity_lifecycle() {
     let pubkey = keypair.verifying_key().to_bytes();
     let did = format!("did:omnia:{}", hex::encode(pubkey));
     let doc = DidDocument::new(did.clone(), pubkey, 0);
-    state.apply(&IdentityOp::CreateDid { document: doc }, &vc, None).unwrap();
+    state
+        .apply(&IdentityOp::CreateDid { document: doc }, &vc, None)
+        .unwrap();
 
     // 2. Enroll biometric
     state
@@ -162,7 +164,9 @@ fn test_biometric_verification_via_apply() {
     let pubkey = keypair.verifying_key().to_bytes();
     let did = format!("did:omnia:{}", hex::encode(pubkey));
     let doc = DidDocument::new(did.clone(), pubkey, 0);
-    state.apply(&IdentityOp::CreateDid { document: doc }, &vc, None).unwrap();
+    state
+        .apply(&IdentityOp::CreateDid { document: doc }, &vc, None)
+        .unwrap();
 
     // Enroll
     state
@@ -209,7 +213,9 @@ fn test_configure_recovery_via_apply() {
     let pubkey = keypair.verifying_key().to_bytes();
     let did = format!("did:omnia:{}", hex::encode(pubkey));
     let doc = DidDocument::new(did.clone(), pubkey, 0);
-    state.apply(&IdentityOp::CreateDid { document: doc }, &vc, None).unwrap();
+    state
+        .apply(&IdentityOp::CreateDid { document: doc }, &vc, None)
+        .unwrap();
 
     // Configure recovery
     state
@@ -241,7 +247,9 @@ fn test_agent_revocation_disables_capabilities() {
     let pubkey = keypair.verifying_key().to_bytes();
     let owner_did = format!("did:omnia:{}", hex::encode(pubkey));
     let doc = DidDocument::new(owner_did.clone(), pubkey, 0);
-    state.apply(&IdentityOp::CreateDid { document: doc }, &vc, None).unwrap();
+    state
+        .apply(&IdentityOp::CreateDid { document: doc }, &vc, None)
+        .unwrap();
 
     let agent = AgentIdentity {
         did: "did:omnia:agent:compute1".to_string(),
@@ -295,7 +303,9 @@ fn test_duplicate_agent_rejected() {
     let pubkey = keypair.verifying_key().to_bytes();
     let owner_did = format!("did:omnia:{}", hex::encode(pubkey));
     let doc = DidDocument::new(owner_did.clone(), pubkey, 0);
-    state.apply(&IdentityOp::CreateDid { document: doc }, &vc, None).unwrap();
+    state
+        .apply(&IdentityOp::CreateDid { document: doc }, &vc, None)
+        .unwrap();
 
     let agent1 = AgentIdentity {
         did: "did:omnia:agent:dup".to_string(),

--- a/shards/tests/identity_hardening.rs
+++ b/shards/tests/identity_hardening.rs
@@ -20,7 +20,7 @@ fn test_vc() -> VectorClock {
 #[test]
 fn test_shamir_split_and_reconstruct() {
     let secret = b"my super secret key";
-    let shares = ShamirRecovery::split(secret, 3, 5);
+    let shares = ShamirRecovery::split(secret, 3, 5).unwrap();
     assert_eq!(shares.len(), 5);
 
     // Reconstruct with exactly threshold shares
@@ -97,7 +97,7 @@ fn test_full_identity_lifecycle() {
     let pubkey = keypair.verifying_key().to_bytes();
     let did = format!("did:omnia:{}", hex::encode(pubkey));
     let doc = DidDocument::new(did.clone(), pubkey, 0);
-    state.apply(&IdentityOp::CreateDid { document: doc }, &vc).unwrap();
+    state.apply(&IdentityOp::CreateDid { document: doc }, &vc, None).unwrap();
 
     // 2. Enroll biometric
     state
@@ -108,6 +108,7 @@ fn test_full_identity_lifecycle() {
                 algorithm: "fingerprint_v2".to_string(),
             },
             &vc,
+            None,
         )
         .unwrap();
     assert!(state.verify_biometric(&did, b"fingerprint_data").unwrap());
@@ -145,6 +146,7 @@ fn test_full_identity_lifecycle() {
                 agent_did: "did:omnia:agent1".to_string(),
             },
             &vc,
+            None,
         )
         .unwrap();
     let agent = state.agent_registry.get("did:omnia:agent1").unwrap();
@@ -160,7 +162,7 @@ fn test_biometric_verification_via_apply() {
     let pubkey = keypair.verifying_key().to_bytes();
     let did = format!("did:omnia:{}", hex::encode(pubkey));
     let doc = DidDocument::new(did.clone(), pubkey, 0);
-    state.apply(&IdentityOp::CreateDid { document: doc }, &vc).unwrap();
+    state.apply(&IdentityOp::CreateDid { document: doc }, &vc, None).unwrap();
 
     // Enroll
     state
@@ -171,6 +173,7 @@ fn test_biometric_verification_via_apply() {
                 algorithm: "iris_v3".to_string(),
             },
             &vc,
+            None,
         )
         .unwrap();
 
@@ -181,6 +184,7 @@ fn test_biometric_verification_via_apply() {
             template: b"iris_scan".to_vec(),
         },
         &vc,
+        None,
     );
     assert!(result.is_ok());
 
@@ -191,6 +195,7 @@ fn test_biometric_verification_via_apply() {
             template: b"wrong_scan".to_vec(),
         },
         &vc,
+        None,
     );
     assert!(result.is_err());
 }
@@ -204,7 +209,7 @@ fn test_configure_recovery_via_apply() {
     let pubkey = keypair.verifying_key().to_bytes();
     let did = format!("did:omnia:{}", hex::encode(pubkey));
     let doc = DidDocument::new(did.clone(), pubkey, 0);
-    state.apply(&IdentityOp::CreateDid { document: doc }, &vc).unwrap();
+    state.apply(&IdentityOp::CreateDid { document: doc }, &vc, None).unwrap();
 
     // Configure recovery
     state
@@ -216,6 +221,7 @@ fn test_configure_recovery_via_apply() {
                 total_shares: 5,
             },
             &vc,
+            None,
         )
         .unwrap();
 
@@ -235,7 +241,7 @@ fn test_agent_revocation_disables_capabilities() {
     let pubkey = keypair.verifying_key().to_bytes();
     let owner_did = format!("did:omnia:{}", hex::encode(pubkey));
     let doc = DidDocument::new(owner_did.clone(), pubkey, 0);
-    state.apply(&IdentityOp::CreateDid { document: doc }, &vc).unwrap();
+    state.apply(&IdentityOp::CreateDid { document: doc }, &vc, None).unwrap();
 
     let agent = AgentIdentity {
         did: "did:omnia:agent:compute1".to_string(),
@@ -255,6 +261,7 @@ fn test_agent_revocation_disables_capabilities() {
                 agent,
             },
             &vc,
+            None,
         )
         .unwrap();
 
@@ -269,6 +276,7 @@ fn test_agent_revocation_disables_capabilities() {
                 agent_did: "did:omnia:agent:compute1".to_string(),
             },
             &vc,
+            None,
         )
         .unwrap();
 
@@ -287,7 +295,7 @@ fn test_duplicate_agent_rejected() {
     let pubkey = keypair.verifying_key().to_bytes();
     let owner_did = format!("did:omnia:{}", hex::encode(pubkey));
     let doc = DidDocument::new(owner_did.clone(), pubkey, 0);
-    state.apply(&IdentityOp::CreateDid { document: doc }, &vc).unwrap();
+    state.apply(&IdentityOp::CreateDid { document: doc }, &vc, None).unwrap();
 
     let agent1 = AgentIdentity {
         did: "did:omnia:agent:dup".to_string(),
@@ -305,6 +313,7 @@ fn test_duplicate_agent_rejected() {
                 agent: agent1,
             },
             &vc,
+            None,
         )
         .unwrap();
 
@@ -324,6 +333,7 @@ fn test_duplicate_agent_rejected() {
             agent: agent2,
         },
         &vc,
+        None,
     );
     assert!(result.is_err());
 }
@@ -340,6 +350,7 @@ fn test_biometric_for_nonexistent_did_fails() {
             algorithm: "face_v1".to_string(),
         },
         &vc,
+        None,
     );
     assert!(result.is_err());
 }
@@ -347,7 +358,7 @@ fn test_biometric_for_nonexistent_did_fails() {
 #[test]
 fn test_shamir_higher_threshold() {
     let secret = b"a_32_byte_secret_key_for_testing!";
-    let shares = ShamirRecovery::split(secret, 5, 10);
+    let shares = ShamirRecovery::split(secret, 5, 10).unwrap();
     assert_eq!(shares.len(), 10);
 
     // Any 5 shares should reconstruct

--- a/shards/tests/layer2_integration.rs
+++ b/shards/tests/layer2_integration.rs
@@ -56,7 +56,7 @@ async fn test_financial_shard_wired_into_substrate() {
         nonce: 1,
     };
 
-    let mut event = Event::genesis(test_node(1), payload.to_bytes().unwrap());
+    let mut event = Event::genesis(test_node(1), payload.to_bytes().unwrap()).expect("event creation should succeed");
     event.sign_with_keypair(&keypair);
 
     // 5. Submit event and run consensus
@@ -119,7 +119,7 @@ async fn test_identity_shard_wired_into_substrate() {
         nonce: 1,
     };
 
-    let mut event = Event::genesis(test_node(1), payload.to_bytes().unwrap());
+    let mut event = Event::genesis(test_node(1), payload.to_bytes().unwrap()).expect("event creation should succeed");
     event.sign_with_keypair(&keypair);
 
     // 5. Submit event and run consensus

--- a/shards/tests/layer2_integration.rs
+++ b/shards/tests/layer2_integration.rs
@@ -36,17 +36,18 @@ async fn test_financial_shard_wired_into_substrate() {
     let mut substrate = Substrate::new(config);
 
     // 2. Create shard router with financial shard, shared via Arc<Mutex>
+    //    Set mint authority to the keypair's public key so minting works
+    let keypair = generate_keypair();
+    let account = keypair.verifying_key().to_bytes();
+
     let router = Arc::new(Mutex::new(ShardRouter::new_without_fees()));
-    router.lock().unwrap().register(Box::new(FinancialShard::new()));
+    router.lock().unwrap().register(Box::new(FinancialShard::with_mint_authority(account)));
 
     // 3. Attach router to substrate via MutexShardRouter
     let processor = MutexShardRouter::new(router.clone());
     substrate = substrate.with_shard_processor(Box::new(processor));
 
     // 4. Mint some tokens to an account
-    let keypair = generate_keypair();
-    let account = keypair.verifying_key().to_bytes();
-
     let mint_op = FinancialOp::Mint {
         to: account,
         amount: 1000,

--- a/shards/tests/layer2_integration.rs
+++ b/shards/tests/layer2_integration.rs
@@ -41,7 +41,10 @@ async fn test_financial_shard_wired_into_substrate() {
     let account = keypair.verifying_key().to_bytes();
 
     let router = Arc::new(Mutex::new(ShardRouter::new_without_fees()));
-    router.lock().unwrap().register(Box::new(FinancialShard::with_mint_authority(account)));
+    router
+        .lock()
+        .unwrap()
+        .register(Box::new(FinancialShard::with_mint_authority(account)));
 
     // 3. Attach router to substrate via MutexShardRouter
     let processor = MutexShardRouter::new(router.clone());

--- a/shards/tests/layer2_integration.rs
+++ b/shards/tests/layer2_integration.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::unwrap_used)]
+#![allow(deprecated)]
 //! Integration test: Layer 2 wired into Layer 1
 //!
 //! Creates a Substrate with a ShardRouter, submits a financial/identity event,

--- a/shards/tests/replay_protection.rs
+++ b/shards/tests/replay_protection.rs
@@ -73,14 +73,14 @@ fn test_replay_protection_different_creators() {
 
     let keypair1 = generate_keypair();
     let keypair2 = generate_keypair();
+    let account1 = keypair1.verifying_key().to_bytes();
+    let account2 = keypair2.verifying_key().to_bytes();
 
     // Both creators use nonce 1 — should both succeed (different pubkeys)
+    // Use BalanceQuery instead of Mint since FinancialShard::new() has no mint authority
     let payload1 = ShardPayload {
         shard_id: ShardId::financial(),
-        operation: ShardOp::Financial(FinancialOp::Mint {
-            to: keypair1.verifying_key().to_bytes(),
-            amount: 100,
-        }),
+        operation: ShardOp::Financial(FinancialOp::BalanceQuery { account: account1 }),
         nonce: 1,
     };
     let event1 = create_test_event_with_keypair(test_node(1), payload1.to_bytes().unwrap(), &keypair1);
@@ -88,10 +88,7 @@ fn test_replay_protection_different_creators() {
 
     let payload2 = ShardPayload {
         shard_id: ShardId::financial(),
-        operation: ShardOp::Financial(FinancialOp::Mint {
-            to: keypair2.verifying_key().to_bytes(),
-            amount: 200,
-        }),
+        operation: ShardOp::Financial(FinancialOp::BalanceQuery { account: account2 }),
         nonce: 1,
     };
     let event2 = create_test_event_with_keypair(test_node(2), payload2.to_bytes().unwrap(), &keypair2);

--- a/shards/tests/replay_protection.rs
+++ b/shards/tests/replay_protection.rs
@@ -20,7 +20,7 @@ fn test_node(id: u8) -> NodeId {
 /// Create a signed event with the given payload, creator, and keypair.
 fn create_test_event_with_keypair(creator: NodeId, payload: Vec<u8>, keypair: &NodeKeypair) -> Event {
     let vc = VectorClock::with_node(creator, 1);
-    let mut event = Event::new(creator, 0, vc, None, None, payload);
+    let mut event = Event::new(creator, 0, vc, None, None, payload).expect("event creation should succeed");
     event.sign_with_keypair(keypair);
     event
 }

--- a/substrate/src/genesis_replay.rs
+++ b/substrate/src/genesis_replay.rs
@@ -233,7 +233,7 @@ mod tests {
         let events: Vec<Event> = (0..4)
             .map(|i| {
                 let keypair = generate_keypair();
-                let mut e = Event::genesis(test_node(i), vec![i]);
+                let mut e = Event::genesis(test_node(i), vec![i]).expect("valid genesis event");
                 e.sign_with_keypair(&keypair);
                 e
             })
@@ -256,7 +256,7 @@ mod tests {
 
         // Create an event that will fail graph insertion (duplicate)
         let keypair = generate_keypair();
-        let mut event1 = Event::genesis(test_node(1), vec![1]);
+        let mut event1 = Event::genesis(test_node(1), vec![1]).expect("valid genesis event");
         event1.sign_with_keypair(&keypair);
         let event2 = event1.clone(); // Duplicate — should be rejected
 

--- a/substrate/src/lib.rs
+++ b/substrate/src/lib.rs
@@ -322,9 +322,26 @@ impl SubstrateConfig {
     /// Production callers should set `slashing_data_dir` before
     /// constructing the substrate.
     pub fn new(node_id: NodeId) -> Self {
-        let total_nodes = 4;
-        let mut seed = [0u8; 32];
-        seed[0] = 1; // Non-zero to avoid debug-build panic
+        let total_nodes = std::env::var("OMNIA_TOTAL_NODES")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(4);
+        let seed = std::env::var("OMNIA_CONSENSUS_SEED")
+            .ok()
+            .and_then(|s| {
+                let mut arr = [0u8; 32];
+                let bytes = s.as_bytes();
+                let len = bytes.len().min(32);
+                arr[..len].copy_from_slice(&bytes[..len]);
+                Some(arr)
+            })
+            .unwrap_or_else(|| {
+                let mut seed = [0u8; 32];
+                getrandom::getrandom(&mut seed).unwrap_or_else(|_| {
+                    seed[0] = 1; // Non-zero fallback
+                });
+                seed
+            });
         Self {
             node_id,
             #[cfg(feature = "network")]
@@ -353,8 +370,22 @@ impl SubstrateConfig {
     ///
     /// Slashing defaults to in-memory mode with standard thresholds.
     pub fn with_network_size(node_id: NodeId, total_nodes: usize) -> Self {
-        let mut seed = [0u8; 32];
-        seed[0] = 1; // Non-zero to avoid debug-build panic
+        let seed = std::env::var("OMNIA_CONSENSUS_SEED")
+            .ok()
+            .and_then(|s| {
+                let mut arr = [0u8; 32];
+                let bytes = s.as_bytes();
+                let len = bytes.len().min(32);
+                arr[..len].copy_from_slice(&bytes[..len]);
+                Some(arr)
+            })
+            .unwrap_or_else(|| {
+                let mut seed = [0u8; 32];
+                getrandom::getrandom(&mut seed).unwrap_or_else(|_| {
+                    seed[0] = 1; // Non-zero fallback
+                });
+                seed
+            });
         Self {
             node_id,
             #[cfg(feature = "network")]

--- a/substrate/src/lib.rs
+++ b/substrate/src/lib.rs
@@ -328,12 +328,12 @@ impl SubstrateConfig {
             .unwrap_or(4);
         let seed = std::env::var("OMNIA_CONSENSUS_SEED")
             .ok()
-            .and_then(|s| {
+            .map(|s| {
                 let mut arr = [0u8; 32];
                 let bytes = s.as_bytes();
                 let len = bytes.len().min(32);
                 arr[..len].copy_from_slice(&bytes[..len]);
-                Some(arr)
+                arr
             })
             .unwrap_or_else(|| {
                 let mut seed = [0u8; 32];
@@ -372,12 +372,12 @@ impl SubstrateConfig {
     pub fn with_network_size(node_id: NodeId, total_nodes: usize) -> Self {
         let seed = std::env::var("OMNIA_CONSENSUS_SEED")
             .ok()
-            .and_then(|s| {
+            .map(|s| {
                 let mut arr = [0u8; 32];
                 let bytes = s.as_bytes();
                 let len = bytes.len().min(32);
                 arr[..len].copy_from_slice(&bytes[..len]);
-                Some(arr)
+                arr
             })
             .unwrap_or_else(|| {
                 let mut seed = [0u8; 32];

--- a/substrate/src/lib.rs
+++ b/substrate/src/lib.rs
@@ -1005,7 +1005,7 @@ mod tests {
         let mut substrate = Substrate::new(config);
         let keypair = generate_keypair();
 
-        let mut event = Event::genesis(test_node(1), vec![1, 2, 3]);
+        let mut event = Event::genesis(test_node(1), vec![1, 2, 3]).expect("valid genesis event");
         event.sign_with_keypair(&keypair);
 
         substrate.submit_event(event).await.unwrap();

--- a/substrate/src/snapshot.rs
+++ b/substrate/src/snapshot.rs
@@ -237,7 +237,7 @@ mod tests {
 
     fn make_event(creator: [u8; 32], seq: u64) -> Event {
         let vc = VectorClock::with_node(creator, seq + 1);
-        let mut event = Event::new(creator, seq, vc, None, None, vec![1, 2, 3]);
+        let mut event = Event::new(creator, seq, vc, None, None, vec![1, 2, 3]).expect("valid event");
         event.sign_with_keypair(&generate_keypair());
         event
     }

--- a/substrate/src/snapshot_replication.rs
+++ b/substrate/src/snapshot_replication.rs
@@ -302,7 +302,7 @@ mod tests {
     fn make_snapshot(height: u64) -> StateSnapshot {
         let mut graph = CausalGraph::new();
         let keypair = generate_keypair();
-        let mut event = Event::genesis(test_node(1), vec![1, 2, 3]);
+        let mut event = Event::genesis(test_node(1), vec![1, 2, 3]).expect("valid genesis event");
         event.sign_with_keypair(&keypair);
         graph.insert(event).unwrap();
 

--- a/substrate/tests/gossip_libp2p.rs
+++ b/substrate/tests/gossip_libp2p.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::unwrap_used)]
+#![allow(deprecated)]
 //! Real Multi-Node libp2p Integration Tests
 //!
 //! These tests use REAL libp2p networking (QUIC transport, GossipSub protocol)

--- a/substrate/tests/gossip_libp2p.rs
+++ b/substrate/tests/gossip_libp2p.rs
@@ -278,7 +278,7 @@ fn create_signed_event(creator_byte: u8, payload: Vec<u8>) -> Event {
     let keypair = generate_keypair();
     let mut node_id = [0u8; 32];
     node_id[0] = creator_byte;
-    let mut event = Event::genesis(node_id, payload);
+    let mut event = Event::genesis(node_id, payload).expect("valid genesis event");
     event.sign_with_keypair(&keypair);
     event
 }

--- a/substrate/tests/gossip_simulation.rs
+++ b/substrate/tests/gossip_simulation.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::unwrap_used)]
+#![allow(deprecated)]
 //! Real Integration Test: Multi-Node Substrate Network
 //!
 //! Spins up N Substrate instances in-memory, submits signed events, and verifies:

--- a/substrate/tests/gossip_simulation.rs
+++ b/substrate/tests/gossip_simulation.rs
@@ -89,7 +89,7 @@ async fn test_three_node_event_propagation() {
     let keypair = generate_keypair();
 
     // Node 0 creates genesis event
-    let mut event = Event::genesis(test_node(1), vec![1, 2, 3]);
+    let mut event = Event::genesis(test_node(1), vec![1, 2, 3]).expect("valid genesis event");
     event.sign_with_keypair(&keypair);
     let event_id = event.id;
 
@@ -158,7 +158,7 @@ async fn test_consensus_finality() {
     let mut genesis_ids = Vec::new();
     for i in 0..4 {
         let keypair = generate_keypair();
-        let mut event = Event::genesis(test_node(i as u8 + 1), vec![i as u8]);
+        let mut event = Event::genesis(test_node(i as u8 + 1), vec![i as u8]).expect("valid genesis event");
         event.sign_with_keypair(&keypair);
         genesis_ids.push(event.id);
         network.submit_event(i, &event).await;
@@ -190,15 +190,15 @@ fn test_causal_ordering_preserved() {
     let n1 = test_node(1);
 
     let mut vc = VectorClock::with_node(n1, 1);
-    let e1 = Event::new(n1, 0, vc.clone(), None, None, vec![1]);
+    let e1 = Event::new(n1, 0, vc.clone(), None, None, vec![1]).expect("valid event");
     let e1_id = e1.id;
 
     vc.increment(n1).unwrap();
-    let e2 = Event::new(n1, 1, vc.clone(), Some(e1_id), None, vec![2]);
+    let e2 = Event::new(n1, 1, vc.clone(), Some(e1_id), None, vec![2]).expect("valid event");
     let e2_id = e2.id;
 
     vc.increment(n1).unwrap();
-    let e3 = Event::new(n1, 2, vc.clone(), Some(e2_id), None, vec![3]);
+    let e3 = Event::new(n1, 2, vc.clone(), Some(e2_id), None, vec![3]).expect("valid event");
 
     // Verify causal chain
     assert!(e1.vector_clock.happened_before(&e2.vector_clock));
@@ -217,10 +217,10 @@ fn test_concurrent_event_detection() {
     let n2 = test_node(2);
 
     let vc1 = VectorClock::with_node(n1, 1);
-    let e1 = Event::new(n1, 0, vc1.clone(), None, None, vec![1]);
+    let e1 = Event::new(n1, 0, vc1.clone(), None, None, vec![1]).expect("valid event");
 
     let vc2 = VectorClock::with_node(n2, 1);
-    let e2 = Event::new(n2, 0, vc2.clone(), None, None, vec![2]);
+    let e2 = Event::new(n2, 0, vc2.clone(), None, None, vec![2]).expect("valid event");
 
     // Events from different nodes with no parent relation should be concurrent
     assert!(e1.vector_clock.concurrent(&e2.vector_clock));
@@ -329,7 +329,7 @@ async fn test_network_event_processed_through_consensus() {
     let mut event_ids = Vec::new();
     for i in 0..4 {
         let keypair = generate_keypair();
-        let mut event = Event::genesis(test_node(i as u8 + 1), vec![i as u8 + 10]);
+        let mut event = Event::genesis(test_node(i as u8 + 1), vec![i as u8 + 10]).expect("valid genesis event");
         event.sign_with_keypair(&keypair);
         event_ids.push(event.id);
 
@@ -378,7 +378,7 @@ async fn test_process_pending_events_drains_network_rx() {
 
     // Create and serialize an event
     let keypair = generate_keypair();
-    let mut event = Event::genesis(test_node(2), vec![1, 2, 3]);
+    let mut event = Event::genesis(test_node(2), vec![1, 2, 3]).expect("valid genesis event");
     event.sign_with_keypair(&keypair);
     let event_id = event.id;
     let bytes = event.to_bytes().expect("test event serialization");

--- a/substrate/tests/property_tests.rs
+++ b/substrate/tests/property_tests.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::unwrap_used)]
+#![allow(deprecated)]
 use omnia_substrate::*;
 use proptest::prelude::*;
 

--- a/substrate/tests/slashing.rs
+++ b/substrate/tests/slashing.rs
@@ -32,10 +32,10 @@ fn test_equivocation_detection_two_events_same_creator_sequence_different_hash()
 
     // Create two events with the same creator and sequence but different payloads (→ different IDs)
     let vc = VectorClock::with_node(n1, 1);
-    let mut event_a = Event::new(n1, 0, vc.clone(), None, None, vec![1]);
+    let mut event_a = Event::new(n1, 0, vc.clone(), None, None, vec![1]).expect("valid event");
     event_a.sign_with_keypair(&kp);
 
-    let mut event_b = Event::new(n1, 0, vc, None, None, vec![2]); // different payload → different id
+    let mut event_b = Event::new(n1, 0, vc, None, None, vec![2]).expect("valid event"); // different payload → different id
     event_b.sign_with_keypair(&kp);
 
     assert!(SlashingEngine::check_equivocation(&event_a, &event_b));
@@ -64,13 +64,13 @@ fn test_equivocation_triggers_slash_in_consensus() {
 
     // Insert and process the first event (sequence 0)
     let vc = VectorClock::with_node(n1, 1);
-    let mut event_a = Event::new(n1, 0, vc.clone(), None, None, vec![1]);
+    let mut event_a = Event::new(n1, 0, vc.clone(), None, None, vec![1]).expect("valid event");
     event_a.sign_with_keypair(&kp);
     graph.insert(event_a.clone()).unwrap();
     engine.process_event(&event_a, &graph).unwrap();
 
     // Now create an equivocating event: same creator, same sequence, different ID
-    let mut event_b = Event::new(n1, 0, vc, None, None, vec![2]);
+    let mut event_b = Event::new(n1, 0, vc, None, None, vec![2]).expect("valid event");
     event_b.sign_with_keypair(&kp);
     graph.insert(event_b.clone()).unwrap();
 
@@ -87,7 +87,7 @@ fn test_equivocation_triggers_slash_in_consensus() {
 
     // A subsequent event from the same node should be rejected
     let vc2 = VectorClock::with_node(n1, 2);
-    let mut event_c = Event::new(n1, 1, vc2, None, None, vec![3]);
+    let mut event_c = Event::new(n1, 1, vc2, None, None, vec![3]).expect("valid event");
     event_c.sign_with_keypair(&kp);
     graph.insert(event_c.clone()).unwrap();
 
@@ -171,13 +171,13 @@ fn test_slashed_node_events_rejected() {
 
     // First, process a valid event
     let vc = VectorClock::with_node(n1, 1);
-    let mut event_a = Event::new(n1, 0, vc.clone(), None, None, vec![1]);
+    let mut event_a = Event::new(n1, 0, vc.clone(), None, None, vec![1]).expect("valid event");
     event_a.sign_with_keypair(&kp);
     graph.insert(event_a.clone()).unwrap();
     engine.process_event(&event_a, &graph).unwrap();
 
     // Now trigger slashing via equivocation
-    let mut event_b = Event::new(n1, 0, vc, None, None, vec![2]);
+    let mut event_b = Event::new(n1, 0, vc, None, None, vec![2]).expect("valid event");
     event_b.sign_with_keypair(&kp);
     graph.insert(event_b.clone()).unwrap();
     engine.process_event(&event_b, &graph).unwrap();
@@ -187,7 +187,7 @@ fn test_slashed_node_events_rejected() {
 
     // Try to submit a new event from the slashed node
     let vc2 = VectorClock::with_node(n1, 2);
-    let mut event_c = Event::new(n1, 1, vc2, None, None, vec![3]);
+    let mut event_c = Event::new(n1, 1, vc2, None, None, vec![3]).expect("valid event");
     event_c.sign_with_keypair(&kp);
     graph.insert(event_c.clone()).unwrap();
 

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -38,7 +38,7 @@ fn node_id_from_keypair(kp: &NodeKeypair) -> NodeId {
 
 fn signed_genesis(kp: &NodeKeypair) -> Event {
     let node_id = node_id_from_keypair(kp);
-    let mut event = Event::genesis(node_id, vec![]);
+    let mut event = Event::genesis(node_id, vec![]).expect("valid genesis event");
     event.sign_with_keypair(kp);
     event
 }
@@ -46,7 +46,7 @@ fn signed_genesis(kp: &NodeKeypair) -> Event {
 fn signed_child(kp: &NodeKeypair, seq: u64, parent_id: EventId) -> Event {
     let node_id = node_id_from_keypair(kp);
     let vc = VectorClock::with_node(node_id, seq + 1);
-    let mut event = Event::new(node_id, seq, vc, Some(parent_id), None, vec![]);
+    let mut event = Event::new(node_id, seq, vc, Some(parent_id), None, vec![]).expect("valid event");
     event.sign_with_keypair(kp);
     event
 }
@@ -217,7 +217,7 @@ fn payload_at_max_size_accepted() {
     let kp = generate_keypair();
     let node_id = node_id_from_keypair(&kp);
     let vc = VectorClock::with_node(node_id, 1);
-    let mut event = Event::new(node_id, 0, vc, None, None, vec![0u8; MAX_PAYLOAD_SIZE]);
+    let mut event = Event::new(node_id, 0, vc, None, None, vec![0u8; MAX_PAYLOAD_SIZE]).expect("valid event");
     event.sign_with_keypair(&kp);
 
     let result = event.validate();
@@ -241,7 +241,7 @@ fn payload_exceeding_max_size_rejected() {
     let node_id = node_id_from_keypair(&kp);
     let vc = VectorClock::with_node(node_id, 1);
     let oversized = MAX_PAYLOAD_SIZE + 1;
-    let mut event = Event::new(node_id, 0, vc, None, None, vec![0u8; oversized]);
+    let mut event = Event::new(node_id, 0, vc, None, None, vec![0u8; oversized]).expect("valid event");
     event.sign_with_keypair(&kp);
 
     let result = event.validate();
@@ -803,7 +803,7 @@ fn signature_verification_throughput() {
 
     for seq in 0..count {
         let vc = VectorClock::with_node(node_id, seq as u64 + 1);
-        let mut event = Event::new(node_id, seq as u64, vc, None, None, vec![]);
+        let mut event = Event::new(node_id, seq as u64, vc, None, None, vec![]).expect("valid event");
         event.sign_with_keypair(&kp);
         events.push(event);
     }


### PR DESCRIPTION
CRITICAL SECURITY FIXES:
- auth: Reject all requests when OMNIA_JWT_SECRET is not set (was silently bypassing)
- auth: Fix rate limiter using X-Forwarded-For (spoofable) - use peer IP instead
- auth: Add rate limiter bucket eviction to prevent memory DoS
- crypto: Replace all expect() with Result propagation in keystore/threshold
- crypto: Make Scalar::is_zero() constant-time to prevent timing side-channels
- crypto: Fix domain separator collision between VRF and key derivation
- primitives: Fix hash collision vulnerability in compute_hash() via tagged Option encoding
- primitives: Add max count limit in VectorClock::from_bytes() to prevent OOM
- primitives: Detect duplicate node IDs in VectorClock::from_bytes()
- primitives: Add size limit to legacy bincode v0 deserialization path
- shards: Disable placeholder ZK proof acceptance (was accepting any ≥128-byte proof)
- shards: Add authorization checks to identity shard operations
- shards: Add cross-shard message source verification
- shards: Add actual Ed25519 signature verification for key rotation authorization
- shards: Gate SubmitWork behind admin keys (was allowing unlimited UBC minting)
- adapters: Fix operator old_root == new_root bug (all proofs were trivial)
- adapters: Fix empty Merkle root collision with DEFAULT_LEAF
- adapters: Fix Ethereum verify_inclusion using sibling as leaf
- adapters: Fix contribution silent fallback to identity point
- binding: Convert RfFingerprint from f64 to integer PPM (non-deterministic across platforms)
- binding: Gate Ed25519 secret key storage behind debug-only builds
- node: Fix governance vote without caller-DID binding
- node: Zeroize decrypted key material after use

PERFORMANCE FIXES:
- network: Add Snappy decompression size limit (zip bomb prevention)
- network: Batch graph write lock acquisition (was per-event)
- network: Extract shared compression module (eliminate code duplication)
- network: Enforce max_pending queue limit
- adapters: Use cached Poseidon parameters instead of regenerating per call
- adapters: Cache wallet in EthereumLiveClient (was creating per call)
- adapters: Cache HTTP client in CelestiaAdapter
- adapters: Refactor Merkle tree construction from O(n²) to O(n log n)
- economics: Replace cleanup_expired with HashMap::retain
- crypto: Fix duplicate detection using HashSet<[u8;96]> instead of HashSet<Vec<u8>>

CORRECTNESS FIXES:
- network: Fix supermajority calculation using div_ceil (was off-by-one)
- network: Fix seen_events wholesale clearing (enables duplicate bursts)
- primitives: Fix ack_count overflow using saturating_add
- primitives: Fix timestamp unwrap_or_default() hiding system clock errors
- shards: Fix Financial Transfer atomic state mutation
- shards: Fix ShamirRecovery::split to return Result instead of panicking
- shards: Fix ShamirRecovery::reconstruct share consistency validation
- shards: Fix nonce gap vulnerability (u64::MAX nonce locks out forever)
- shards: Fix default unrestricted minting (now requires explicit mint authority)
- economics: Fix from_percent overflow using saturating_mul
- economics: Fix advance_epoch overflow using saturating_add
- economics: Add reward cap for UsefulWorkProof
- substrate: Make total_nodes configurable via env var (was hardcoded to 4)
- substrate: Use cryptographically random consensus seed (was deterministic)

REDUNDANCY CLEANUP:
- network: Move extract_peer_id_from_multiaddr to shared location
- network: Remove unused chrono dependency
- primitives: Remove unused chrono and uuid dependencies
- adapters: Remove force-enabling settlement-ffi from build.rs
- shards: Extract shared ZK verification module (was copy-pasted)
- crypto: Hard-block deprecated DkgSession with doc(hidden) + error logging

CONFIGURATION:
- Add OMNIA_CORS_ORIGINS env var for production CORS configuration
- Add OMNIA_TOTAL_NODES env var for network size configuration
- Add OMNIA_CONSENSUS_SEED env var for deterministic testing
- Cache JWT secret at startup via OnceLock (was reading env per request)
- Add 10 MiB body size limit to API router
- Add DecayRate clamping warning log