### PR TITLE
fix(ci): pin iai-callgrind-runner to 0.13.4 to match library version

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -128,10 +128,15 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y valgrind
 
       # iai-callgrind requires the iai-callgrind-runner binary to be installed
-      # separately from the library crate. The runner version must match the
-      # library version used in benches/Cargo.toml.
+      # separately from the library crate. The runner version MUST match the
+      # library version in benches/Cargo.toml (currently 0.13.4). Pinning the
+      # version here prevents CI breakage when a newer runner is published to
+      # crates.io (e.g., the 0.16.1 runner is incompatible with the 0.13
+      # library and produces: "iai-callgrind-runner (0.16.1) is newer than
+      # iai-callgrind (0.13.4)"). When bumping the library version in
+      # benches/Cargo.toml, update this pin to match.
       - name: Install iai-callgrind runner
-        run: cargo install iai-callgrind-runner
+        run: cargo install iai-callgrind-runner --version 0.13.4 --locked
 
       # iai-callgrind requires the benchmark binary to be built first
       - name: Build iai-callgrind benchmarks

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -18,6 +18,11 @@ omnia-node = { path = "../node" }
 omnia-substrate = { path = "../substrate" }
 
 criterion = { version = "0.5", features = ["html_reports"] }
+# iai-callgrind library version must match the iai-callgrind-runner binary
+# installed in CI. The CI workflow (bench.yml) pins the runner to 0.13.4
+# via `cargo install iai-callgrind-runner --version 0.13.4` to match this
+# library version. If you bump this version, also update the CI install
+# command AND regenerate Cargo.lock (cargo update -p iai-callgrind).
 iai-callgrind = "0.13"
 tokio = { version = "1.38", features = ["full"] }
 rand = "0.8"


### PR DESCRIPTION
Error from CI:
  iai_callgrind_runner: Error: iai-callgrind-runner (0.16.1) is newer
  than iai-callgrind (0.13.4). Please update iai-callgrind to '0.16.1'
  in your Cargo.toml file

Root cause: the CI workflow installed iai-callgrind-runner with
`cargo install iai-callgrind-runner` (no version pin), which fetches
the latest published version (0.16.1 as of 2026-06-19). The library
crate in benches/Cargo.toml is pinned at 0.13. The runner and library
versions must match exactly, and 0.16.1 is incompatible with the 0.13
library.

Two options:
  (A) Bump the library to 0.16 to match the latest runner.
  (B) Pin the runner to 0.13.4 to match the existing library.

Chose (B) because:
  - Option (A) would require regenerating Cargo.lock to pull in
    iai-callgrind 0.16.1's significantly expanded dependency tree
    (anyhow, clap, colored, env_logger, glob, inferno, itertools,
    lazy_static, log, polonius-the-crab, regex, sanitize-filename,
    schemars, shlex, strum, tempfile, version-compare, which,
    cargo_metadata, indexmap — ~20 new transitive deps). Manually
    adding these to Cargo.lock with correct checksums is error-prone
    without a local cargo update, and a wrong checksum would cause a
    different CI failure.
  - Option (B) is a one-line CI change with no lock file impact. The
    0.13 library API (`library_benchmark`, `library_benchmark_group`,
    `main!`, `black_box`) is stable and sufficient for the current
    hot_path_iai.rs benchmark.

Changes:
  - bench.yml: pin runner install to `--version 0.13.4 --locked` with
    a comment explaining the version-match requirement and how to bump.
  - benches/Cargo.toml: added a comment on the iai-callgrind dependency
    noting the CI pin and the steps to bump both together.