### PR TITLE
fix(iai): strip ANSI escape codes — root cause of 9/9 missing

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -407,15 +407,6 @@ jobs:
       - name: IAI regression gate
         if: always()
         run: |
-          echo "=== iai_output.txt size ==="
-          wc -c iai_output.txt 2>/dev/null || echo "FILE NOT FOUND"
-          echo "=== iai_output.txt first 20 lines ==="
-          head -20 iai_output.txt 2>/dev/null || echo "CANNOT READ FILE"
-          echo "=== iai_output.txt last 20 lines ==="
-          tail -20 iai_output.txt 2>/dev/null || echo "CANNOT READ FILE"
-          echo "=== iai_stderr.txt size ==="
-          wc -c iai_stderr.txt 2>/dev/null || echo "NO STDERR FILE"
-          echo "=== Running IAI gate ==="
           if [ ! -s iai_output.txt ]; then
             echo "::warning::IAI output is empty — iai-callgrind may have failed. Skipping IAI gate."
             exit 0

--- a/scripts/check_benchmark_regression.py
+++ b/scripts/check_benchmark_regression.py
@@ -17,6 +17,16 @@ import os
 from pathlib import Path
 
 
+# ANSI escape code pattern. Both criterion and iai-callgrind output
+# color codes even when piped. These must be stripped before parsing.
+ANSI_ESCAPE = re.compile(r"\x1b\[[0-9;]*m|\x1b")
+
+
+def strip_ansi(text: str) -> str:
+    """Remove ANSI escape codes from text."""
+    return ANSI_ESCAPE.sub("", text)
+
+
 def parse_time_value(s: str) -> float:
     """Parse a time string like '17.610 µs' or '1.73 ms' or '389.30 ns' into nanoseconds."""
     s = s.strip()
@@ -47,7 +57,7 @@ def parse_criterion_output(text: str) -> dict[str, float]:
     current_bench = None
 
     for line in text.splitlines():
-        line_stripped = line.strip()
+        line_stripped = strip_ansi(line).strip()
         if not line_stripped:
             continue
 

--- a/scripts/check_iai_regression.py
+++ b/scripts/check_iai_regression.py
@@ -25,6 +25,17 @@ import sys
 from pathlib import Path
 
 
+# ANSI escape code pattern. iai-callgrind 0.13 outputs color codes
+# (ESC [ ... m) even when stdout is piped. These must be stripped
+# before parsing or the regex won't match metric values.
+ANSI_ESCAPE = re.compile(r"\x1b\[[0-9;]*m|\x1b")
+
+
+def strip_ansi(text: str) -> str:
+    """Remove ANSI escape codes from text."""
+    return ANSI_ESCAPE.sub("", text)
+
+
 def parse_iai_output(text: str) -> dict[str, dict[str, int]]:
     """Parse iai-callgrind text output.
 
@@ -43,7 +54,11 @@ def parse_iai_output(text: str) -> dict[str, dict[str, int]]:
     current_bench = None
 
     for line in text.splitlines():
-        stripped = line.strip()
+        # Strip ANSI escape codes — iai-callgrind 0.13 outputs color
+        # codes (ESC[0m etc.) even when piped. Without this, the regex
+        # won't match because ESC characters are embedded between the
+        # metric name, the number, and the pipe.
+        stripped = strip_ansi(line).strip()
         if not stripped:
             continue
 

--- a/scripts/multi_sample_bench.py
+++ b/scripts/multi_sample_bench.py
@@ -40,6 +40,16 @@ import statistics
 from pathlib import Path
 
 
+# ANSI escape code pattern. Both criterion and iai-callgrind output
+# color codes even when piped. These must be stripped before parsing.
+ANSI_ESCAPE = re.compile(r"\x1b\[[0-9;]*m|\x1b")
+
+
+def strip_ansi(text: str) -> str:
+    """Remove ANSI escape codes from text."""
+    return ANSI_ESCAPE.sub("", text)
+
+
 def parse_time_value(s: str) -> float:
     """Parse a time string like '17.610 µs' into nanoseconds."""
     s = s.strip().replace("µs", "us").replace("μs", "us")
@@ -62,7 +72,7 @@ def parse_criterion_run(text: str) -> dict[str, float]:
     current_bench = None
 
     for line in text.splitlines():
-        stripped = line.strip()
+        stripped = strip_ansi(line).strip()
         if not stripped:
             continue
 


### PR DESCRIPTION
ROOT CAUSE FOUND: iai-callgrind 0.13 outputs ANSI color codes (ESC
sequences) even when stdout is piped. The file iai_output.txt
contained lines like:

  \x1bhot_path_iai::...bench_vector_clock_merge_100\x1b
  Instructions:     \x1b         186112\x1b|N/A  (\x1b*********\x1b)

The ESC characters (\x1b) were embedded BETWEEN the metric name,
the number, and the pipe character. The regex
  ^(Instructions|...):\s+(\d+)\|
could not match because of the ESC between the number and |.

FIX: Added strip_ansi() function to all three Python gate scripts
(check_iai_regression.py, check_benchmark_regression.py,
multi_sample_bench.py). The function uses regex
  \x1b\[[0-9;]*m|\x1b
to remove all ANSI escape codes before parsing each line.

VERIFIED with the actual CI artifact (iai_output.txt from the
2026-06-23 CI run, downloaded as iai-callgrind-results.zip):

  Before fix: 0 passed, 0 regressions, 9 missing (FAILED)
  After fix:  54 passed, 0 regressions, 0 missing (PASSED)

All 9 benchmarks × 6 metrics = 54 checks pass with deterministic
instruction counts.

Also applied the same ANSI stripping to check_benchmark_regression.py
and multi_sample_bench.py — criterion output also contains ANSI codes
that could cause similar parsing failures.

Removed the debug file-dump step added in the previous commit (no
longer needed — root cause is identified and fixed).