### PR TITLE
feat(api): add list endpoints for events, proposals, transfers, validators

### DIFF
--- a/node/src/api/economics.rs
+++ b/node/src/api/economics.rs
@@ -4,8 +4,9 @@
 //! (spending) UBC tokens:
 //! - `GET /api/v1/economics/balance/:did` — check UBC balance
 //! - `POST /api/v1/economics/transfer` — spend/transfer UBC
+//! - `GET /api/v1/economics/transfers` — list recent transfer records
 
-use axum::extract::{Path, State};
+use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::Extension;
 use axum::Json;
@@ -14,7 +15,7 @@ use serde_json::{json, Value};
 use utoipa::ToSchema;
 
 use crate::api::auth::CallerIdentity;
-use crate::state::AppState;
+use crate::state::{AppState, TransferRecord};
 
 /// Request body for a UBC transfer (spend) operation.
 ///
@@ -146,17 +147,47 @@ pub async fn transfer_ubc(
     match result {
         Ok(()) => {
             let new_balance = economics.balance_of(&from_did).unwrap_or(0);
+            let now_ms = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_millis() as u64)
+                .unwrap_or(0);
+
+            // Derive a stable transfer ID: BLAKE3 of (from_did, to_did, amount, timestamp).
+            // Using BLAKE3 (rather than a UUID) keeps IDs deterministic and
+            // auditable — anyone with the same inputs can recompute the ID.
+            let id_input = format!("{from_did}|{}|{}|{now_ms}", body.to_did, body.amount);
+            let id = blake3::hash(id_input.as_bytes())
+                .to_hex()
+                .to_string();
+
+            let record = TransferRecord {
+                id: id.clone(),
+                from_did: from_did.clone(),
+                to_did: body.to_did.clone(),
+                amount: body.amount,
+                timestamp: now_ms,
+                status: "completed".to_string(),
+                new_balance,
+            };
+
+            // Release the economics lock before acquiring the history lock
+            // to avoid lock-ordering surprises across endpoints.
+            drop(economics);
+            crate::state::record_transfer(&state.transfer_history, record).await;
+
             tracing::info!(
                 from_did = %from_did,
                 to_did = %body.to_did,
                 amount = body.amount,
                 new_balance = new_balance,
+                transfer_id = %id,
                 "UBC spend operation completed"
             );
             Ok((
                 StatusCode::OK,
                 Json(json!({
                     "status": "completed",
+                    "id": id,
                     "from_did": from_did,
                     "to_did": body.to_did,
                     "amount": body.amount,
@@ -182,6 +213,53 @@ pub async fn transfer_ubc(
             ))
         }
     }
+}
+
+/// Query parameters for `GET /api/v1/economics/transfers`.
+#[derive(Debug, Clone, Deserialize, ToSchema)]
+pub struct ListTransfersQuery {
+    /// Maximum number of records to return (default: 50, max: 1000).
+    #[serde(default = "default_transfer_limit")]
+    pub limit: usize,
+}
+
+fn default_transfer_limit() -> usize {
+    50
+}
+
+/// Maximum number of transfer records to return per request.
+const MAX_TRANSFER_LIST_LIMIT: usize = 1000;
+
+/// Handler for `GET /api/v1/economics/transfers`.
+///
+/// Returns the most recent UBC spend operations, newest first.
+/// Failed transfers are not recorded in the history — only successful
+/// spends appear here.
+#[utoipa::path(
+    get,
+    path = "/api/v1/economics/transfers",
+    params(
+        ("limit" = Option<usize>, Query, description = "Maximum number of records to return (default 50, max 1000)")
+    ),
+    responses(
+        (status = 200, description = "List of transfer records"),
+    )
+)]
+pub async fn list_transfers(
+    State(state): State<AppState>,
+    Query(query): Query<ListTransfersQuery>,
+) -> Json<Value> {
+    let limit = query.limit.min(MAX_TRANSFER_LIST_LIMIT);
+    let history = state.transfer_history.read().await;
+
+    // Newest first — Vec's natural order is oldest first.
+    let transfers: Vec<&TransferRecord> = history.iter().rev().take(limit).collect();
+
+    Json(json!({
+        "transfers": transfers,
+        "count": transfers.len(),
+        "total_in_history": history.len(),
+    }))
 }
 
 #[cfg(test)]

--- a/node/src/api/economics.rs
+++ b/node/src/api/economics.rs
@@ -156,9 +156,7 @@ pub async fn transfer_ubc(
             // Using BLAKE3 (rather than a UUID) keeps IDs deterministic and
             // auditable — anyone with the same inputs can recompute the ID.
             let id_input = format!("{from_did}|{}|{}|{now_ms}", body.to_did, body.amount);
-            let id = blake3::hash(id_input.as_bytes())
-                .to_hex()
-                .to_string();
+            let id = blake3::hash(id_input.as_bytes()).to_hex().to_string();
 
             let record = TransferRecord {
                 id: id.clone(),
@@ -245,10 +243,7 @@ const MAX_TRANSFER_LIST_LIMIT: usize = 1000;
         (status = 200, description = "List of transfer records"),
     )
 )]
-pub async fn list_transfers(
-    State(state): State<AppState>,
-    Query(query): Query<ListTransfersQuery>,
-) -> Json<Value> {
+pub async fn list_transfers(State(state): State<AppState>, Query(query): Query<ListTransfersQuery>) -> Json<Value> {
     let limit = query.limit.min(MAX_TRANSFER_LIST_LIMIT);
     let history = state.transfer_history.read().await;
 

--- a/node/src/api/events.rs
+++ b/node/src/api/events.rs
@@ -257,10 +257,7 @@ const MAX_LIST_LIMIT: usize = 1000;
         (status = 200, description = "List of events", body = [StoredEvent]),
     )
 )]
-pub async fn list_events(
-    State(state): State<AppState>,
-    Query(query): Query<ListEventsQuery>,
-) -> Json<Value> {
+pub async fn list_events(State(state): State<AppState>, Query(query): Query<ListEventsQuery>) -> Json<Value> {
     let limit = query.limit.min(MAX_LIST_LIMIT);
     let store = state.event_store.read().await;
 

--- a/node/src/api/events.rs
+++ b/node/src/api/events.rs
@@ -265,8 +265,9 @@ pub async fn list_events(
     let store = state.event_store.read().await;
 
     // IndexMap preserves insertion order. Iterate in reverse so the
-    // newest events come first.
-    let events: Vec<&StoredEvent> = store.iter().rev().take(limit).collect();
+    // newest events come first. `.values().rev()` gives us only the
+    // StoredEvent references (not the keys).
+    let events: Vec<&StoredEvent> = store.values().rev().take(limit).collect();
 
     Json(json!({
         "events": events,

--- a/node/src/api/events.rs
+++ b/node/src/api/events.rs
@@ -3,9 +3,10 @@
 //! Provides endpoints for submitting new events to the substrate
 //! and retrieving events by their identifier:
 //! - `POST /api/v1/events` — submit a new event
+//! - `GET /api/v1/events` — list recently submitted events
 //! - `GET /api/v1/events/:id` — retrieve an event by ID
 
-use axum::extract::{Path, State};
+use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::Json;
 use omnia_substrate::Event;
@@ -218,4 +219,58 @@ pub async fn get_event(
             Json(json!({"error": format!("Event not found: {id}")})),
         )),
     }
+}
+
+/// Query parameters for `GET /api/v1/events`.
+#[derive(Debug, Clone, Deserialize, ToSchema)]
+pub struct ListEventsQuery {
+    /// Maximum number of events to return (default: 100, max: 1000).
+    ///
+    /// The most recently submitted events are returned first.
+    #[serde(default = "default_limit")]
+    pub limit: usize,
+}
+
+fn default_limit() -> usize {
+    100
+}
+
+/// Maximum number of events the API will return in a single request.
+const MAX_LIST_LIMIT: usize = 1000;
+
+/// Handler for `GET /api/v1/events`.
+///
+/// Returns the most recently submitted events from the in-memory event
+/// store, newest first. The store preserves insertion order via
+/// `IndexMap`, so "newest" is well-defined.
+///
+/// # Query parameters
+///
+/// - `limit` — maximum number of events to return (default 100, max 1000)
+#[utoipa::path(
+    get,
+    path = "/api/v1/events",
+    params(
+        ("limit" = Option<usize>, Query, description = "Maximum number of events to return (default 100, max 1000)")
+    ),
+    responses(
+        (status = 200, description = "List of events", body = [StoredEvent]),
+    )
+)]
+pub async fn list_events(
+    State(state): State<AppState>,
+    Query(query): Query<ListEventsQuery>,
+) -> Json<Value> {
+    let limit = query.limit.min(MAX_LIST_LIMIT);
+    let store = state.event_store.read().await;
+
+    // IndexMap preserves insertion order. Iterate in reverse so the
+    // newest events come first.
+    let events: Vec<&StoredEvent> = store.iter().rev().take(limit).collect();
+
+    Json(json!({
+        "events": events,
+        "count": events.len(),
+        "total_in_store": store.len(),
+    }))
 }

--- a/node/src/api/governance.rs
+++ b/node/src/api/governance.rs
@@ -222,9 +222,7 @@ pub async fn cast_vote(
         (status = 200, description = "List of proposals"),
     )
 )]
-pub async fn list_proposals(
-    State(state): State<AppState>,
-) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+pub async fn list_proposals(State(state): State<AppState>) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
     let economics = state.economics.lock().await;
     // Clone the proposals to avoid holding the lock while serializing —
     // also lets us add a derived `status` field per proposal without
@@ -245,7 +243,10 @@ pub async fn list_proposals(
             let mut obj = base.as_object().cloned().unwrap_or_default();
             obj.insert("status".to_string(), json!(status));
             // Compute participation totals for convenience
-            let total = p.votes_for.saturating_add(p.votes_against).saturating_add(p.votes_abstain);
+            let total = p
+                .votes_for
+                .saturating_add(p.votes_against)
+                .saturating_add(p.votes_abstain);
             obj.insert("total_participation".to_string(), json!(total));
             Value::Object(obj)
         })

--- a/node/src/api/governance.rs
+++ b/node/src/api/governance.rs
@@ -2,6 +2,7 @@
 //!
 //! Provides endpoints for creating governance proposals and casting votes:
 //! - `POST /api/v1/governance/proposals` — submit a new proposal
+//! - `GET /api/v1/governance/proposals` — list all proposals
 //! - `POST /api/v1/governance/vote` — cast a vote on a proposal
 
 use axum::extract::State;
@@ -206,6 +207,53 @@ pub async fn cast_vote(
             ))
         }
     }
+}
+
+/// Handler for `GET /api/v1/governance/proposals`.
+///
+/// Returns all proposals currently tracked by the governance state.
+/// Proposals are returned in insertion order (which approximates creation
+/// order, since `HashMap` does not preserve it; for true chronological
+/// ordering, sort by `created_at_epoch` client-side).
+#[utoipa::path(
+    get,
+    path = "/api/v1/governance/proposals",
+    responses(
+        (status = 200, description = "List of proposals"),
+    )
+)]
+pub async fn list_proposals(
+    State(state): State<AppState>,
+) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+    let economics = state.economics.lock().await;
+    // Clone the proposals to avoid holding the lock while serializing —
+    // also lets us add a derived `status` field per proposal without
+    // mutating the underlying governance state.
+    let proposals: Vec<Value> = economics
+        .governance
+        .proposals
+        .values()
+        .map(|p| {
+            let status = if p.execution_time.is_some() {
+                "passed"
+            } else if p.is_expired(economics.current_epoch()) {
+                "expired"
+            } else {
+                "voting"
+            };
+            let base = serde_json::to_value(p).unwrap_or_else(|_| json!({}));
+            let mut obj = base.as_object().cloned().unwrap_or_default();
+            obj.insert("status".to_string(), json!(status));
+            // Compute participation totals for convenience
+            let total = p.votes_for.saturating_add(p.votes_against).saturating_add(p.votes_abstain);
+            obj.insert("total_participation".to_string(), json!(total));
+            Value::Object(obj)
+        })
+        .collect();
+    Ok(Json(json!({
+        "proposals": proposals,
+        "count": proposals.len(),
+    })))
 }
 
 /// Parse a vote choice string into a `VoteChoice` enum.

--- a/node/src/api/mod.rs
+++ b/node/src/api/mod.rs
@@ -40,14 +40,18 @@ use crate::state::AppState;
 #[openapi(
     paths(
         crate::api::events::submit_event,
+        crate::api::events::list_events,
         crate::api::events::get_event,
         crate::api::shards::submit_shard_operation,
         crate::api::governance::create_proposal,
+        crate::api::governance::list_proposals,
         crate::api::governance::cast_vote,
         crate::api::economics::get_balance,
         crate::api::economics::transfer_ubc,
+        crate::api::economics::list_transfers,
         crate::api::node::node_info,
         crate::api::node::node_peers,
+        crate::api::node::list_validators,
         crate::api::errors::error_codes,
     ),
     components(schemas(
@@ -72,22 +76,27 @@ pub struct ApiDoc;
 /// |--------|-------------------------------------------|------------------------|--------|
 /// | GET    | `/api/v1/node/info`                       | `node::node_info`      | Public |
 /// | GET    | `/api/v1/node/peers`                      | `node::node_peers`     | Public |
+/// | GET    | `/api/v1/validators`                      | `node::list_validators`| Public |
 /// | POST   | `/api/v1/events`                          | `events::submit_event` | JWT    |
+/// | GET    | `/api/v1/events`                          | `events::list_events`  | JWT    |
 /// | GET    | `/api/v1/events/:id`                      | `events::get_event`    | JWT    |
 /// | POST   | `/api/v1/shards/:shard_id/operations`     | `shards::submit_shard_operation` | JWT |
 /// | POST   | `/api/v1/governance/proposals`            | `governance::create_proposal` | JWT |
+/// | GET    | `/api/v1/governance/proposals`            | `governance::list_proposals`  | JWT  |
 /// | POST   | `/api/v1/governance/vote`                 | `governance::cast_vote` | JWT   |
 /// | GET    | `/api/v1/economics/balance/:did`          | `economics::get_balance` | JWT  |
 /// | POST   | `/api/v1/economics/transfer`              | `economics::transfer_ubc` | JWT |
+/// | GET    | `/api/v1/economics/transfers`             | `economics::list_transfers` | JWT |
 /// | GET    | `/api/v1/errors`                          | `errors::error_codes`  | Public |
 /// | GET    | `/api/v1/ceremony/state`                  | `ceremony::ceremony_state` | Public |
 /// | POST   | `/api/v1/ceremony/contribute`             | `ceremony::ceremony_contribute` | JWT |
 /// | GET    | `/api/v1/ceremony/transcript`             | `ceremony::ceremony_transcript` | Public |
 /// | POST   | `/api/v1/ceremony/finalize`               | `ceremony::ceremony_finalize` | JWT |
 ///
-/// Node info, peers, errors, and ceremony read endpoints are public (no JWT required)
-/// so that dashboards and monitoring tools can display live network status without
-/// requiring authentication tokens. All write endpoints require JWT authentication.
+/// Node info, peers, validators, errors, and ceremony read endpoints are public
+/// (no JWT required) so that dashboards and monitoring tools can display live
+/// network status without requiring authentication tokens. All write endpoints
+/// and sensitive reads (events list, governance list, economics list) require JWT.
 ///
 /// Reads `OMNIA_AUTHORIZED_CALLERS` from the environment to configure
 /// the authorization registry for privileged shard operations.
@@ -112,6 +121,7 @@ pub fn build_api_router_with(authorized: Arc<AuthorizedCallers>) -> Router<AppSt
     let public_routes = Router::new()
         .route("/node/info", get(node::node_info))
         .route("/node/peers", get(node::node_peers))
+        .route("/validators", get(node::list_validators))
         .route("/errors", get(errors::error_codes))
         .route("/ceremony/state", get(ceremony::ceremony_state))
         .route("/ceremony/transcript", get(ceremony::ceremony_transcript));
@@ -119,16 +129,20 @@ pub fn build_api_router_with(authorized: Arc<AuthorizedCallers>) -> Router<AppSt
     // Authenticated routes — JWT required (write endpoints + sensitive reads)
     let authenticated_routes = Router::new()
         // Events
-        .route("/events", post(events::submit_event))
+        .route("/events", post(events::submit_event).get(events::list_events))
         .route("/events/:id", get(events::get_event))
         // Shard operations
         .route("/shards/:shard_id/operations", post(shards::submit_shard_operation))
         // Governance
-        .route("/governance/proposals", post(governance::create_proposal))
+        .route(
+            "/governance/proposals",
+            post(governance::create_proposal).get(governance::list_proposals),
+        )
         .route("/governance/vote", post(governance::cast_vote))
         // Economics
         .route("/economics/balance/:did", get(economics::get_balance))
         .route("/economics/transfer", post(economics::transfer_ubc))
+        .route("/economics/transfers", get(economics::list_transfers))
         // Ceremony write operations
         .route("/ceremony/contribute", post(ceremony::ceremony_contribute))
         .route("/ceremony/finalize", post(ceremony::ceremony_finalize))

--- a/node/src/api/node.rs
+++ b/node/src/api/node.rs
@@ -117,9 +117,7 @@ pub struct PeerInfo {
         (status = 200, description = "Validator list"),
     )
 )]
-pub async fn list_validators(
-    State(state): State<AppState>,
-) -> Json<Value> {
+pub async fn list_validators(State(state): State<AppState>) -> Json<Value> {
     // Read consensus round and validator candidates from the substrate.
     let (validators_with_stake, current_round) = {
         let substrate = state.substrate.read().await;

--- a/node/src/api/node.rs
+++ b/node/src/api/node.rs
@@ -1,8 +1,10 @@
-//! Node info and peers API handlers
+//! Node info, peers, and validators API handlers
 //!
-//! Provides endpoints for querying node metadata and the peer list:
+//! Provides endpoints for querying node metadata, the peer list, and the
+//! validator set:
 //! - `GET /api/v1/node/info` — node identity, version, uptime, consensus state
 //! - `GET /api/v1/node/peers` — connected peer addresses
+//! - `GET /api/v1/validators` — registered validators with slash points and jail status
 
 use axum::extract::State;
 use axum::Json;
@@ -97,4 +99,96 @@ pub struct PeerInfo {
     pub address: String,
     /// Unix timestamp when the peer was discovered.
     pub connected_at: u64,
+}
+
+/// Handler for `GET /api/v1/validators`.
+///
+/// Returns the list of validator candidates registered with this node,
+/// along with each validator's stake, slash points, and jail status.
+///
+/// Slash points and jail status are sourced from the slashing engine
+/// (persistent redb store). Stake comes from the substrate's
+/// `validator_candidates` registry. The keypair itself is intentionally
+/// NOT exposed — only the public NodeId (hex-encoded) is returned.
+#[utoipa::path(
+    get,
+    path = "/api/v1/validators",
+    responses(
+        (status = 200, description = "Validator list"),
+    )
+)]
+pub async fn list_validators(
+    State(state): State<AppState>,
+) -> Json<Value> {
+    // Read consensus round and validator candidates from the substrate.
+    let (validators_with_stake, current_round) = {
+        let substrate = state.substrate.read().await;
+        let round = substrate.current_round();
+        let entries: Vec<(String, u64)> = substrate
+            .validator_candidates_iter()
+            .map(|(node_id, stake)| (hex::encode(node_id), stake))
+            .collect();
+        (entries, round)
+    };
+
+    // Read slash points and jail status from the slashing engine.
+    let slashing = state.slashing.lock().await;
+    let mut validators: Vec<Value> = Vec::with_capacity(validators_with_stake.len());
+
+    for (node_id_hex, stake) in validators_with_stake {
+        // Decode the hex back to NodeId for slashing-engine lookups.
+        // If decoding fails (shouldn't happen since we just encoded it),
+        // report zero slash points rather than failing the whole request.
+        let node_id_bytes = hex::decode(&node_id_hex).unwrap_or_default();
+        let node_id_array: [u8; 32] = if node_id_bytes.len() == 32 {
+            let mut arr = [0u8; 32];
+            arr.copy_from_slice(&node_id_bytes);
+            arr
+        } else {
+            // Skip malformed entries rather than panicking.
+            continue;
+        };
+
+        let slash_points = slashing.slash_points_of(&node_id_array);
+        let is_jailed = slashing.is_jailed(node_id_array, current_round);
+
+        let status = if is_jailed {
+            "jailed"
+        } else if slash_points > 0 {
+            "slashed"
+        } else {
+            "active"
+        };
+
+        validators.push(json!({
+            "node_id": node_id_hex,
+            "stake": stake,
+            "slash_points": slash_points,
+            "is_jailed": is_jailed,
+            "status": status,
+            "current_round": current_round,
+        }));
+    }
+
+    let total_stake: u64 = validators
+        .iter()
+        .filter_map(|v| v.get("stake").and_then(|s| s.as_u64()))
+        .sum();
+    let active_count = validators
+        .iter()
+        .filter(|v| v.get("status").and_then(|s| s.as_str()) == Some("active"))
+        .count();
+    let jailed_count = validators
+        .iter()
+        .filter(|v| v.get("status").and_then(|s| s.as_str()) == Some("jailed"))
+        .count();
+
+    Json(json!({
+        "validators": validators,
+        "count": validators.len(),
+        "active_count": active_count,
+        "jailed_count": jailed_count,
+        "total_stake": total_stake,
+        "current_round": current_round,
+    }))
 }

--- a/node/src/http.rs
+++ b/node/src/http.rs
@@ -285,6 +285,7 @@ mod tests {
             shard_router: Arc::new(std::sync::Mutex::new(shard_router)),
             economics: Arc::new(Mutex::new(EconomicsState::new())),
             event_store: Arc::new(RwLock::new(event_store)),
+            transfer_history: Arc::new(RwLock::new(Vec::new())),
             peers: Arc::new(RwLock::new(peers)),
             #[cfg(feature = "metrics")]
             metrics: Arc::new(metrics),

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -358,6 +358,7 @@ async fn main() -> Result<()> {
         shard_router: shared_shard_router,
         economics: Arc::new(Mutex::new(economics)),
         event_store: Arc::new(RwLock::new(indexmap::IndexMap::new())),
+        transfer_history: Arc::new(RwLock::new(Vec::new())),
         peers: Arc::new(RwLock::new(Vec::new())),
         #[cfg(feature = "metrics")]
         metrics: Arc::new(metrics),

--- a/node/src/state.rs
+++ b/node/src/state.rs
@@ -42,6 +42,54 @@ use crate::config::NodeConfig;
 /// When this limit is reached, the oldest 10% of events are evicted.
 const MAX_STORED_EVENTS: usize = 100_000;
 
+/// Maximum number of transfer records to keep in memory.
+///
+/// Transfer history is bounded to prevent unbounded memory growth on
+/// long-running nodes. When this limit is reached, the oldest 10% of
+/// records are evicted (mirroring the event store eviction policy).
+const MAX_TRANSFER_HISTORY: usize = 10_000;
+
+/// A recorded UBC spend/transfer operation, retained in memory for
+/// the `GET /api/v1/economics/transfers` endpoint.
+///
+/// UBC is soulbound — the "transfer" actually spends (burns) tokens
+/// from the sender's balance. The `to_did` field is recorded for
+/// informational/provenance purposes only.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct TransferRecord {
+    /// Hex-encoded unique transfer ID (BLAKE3 of the transfer fields).
+    pub id: String,
+    /// Sender DID (the authenticated caller at the time of the transfer).
+    pub from_did: String,
+    /// Recipient DID (informational — UBC is soulbound).
+    pub to_did: String,
+    /// Amount spent.
+    pub amount: u64,
+    /// Unix-millisecond timestamp when the transfer was recorded.
+    pub timestamp: u64,
+    /// Status of the transfer — always `"completed"` on success,
+    /// since failed transfers are not appended to the history.
+    pub status: String,
+    /// Resulting balance of the sender after the spend.
+    pub new_balance: u64,
+}
+
+/// Append a transfer record to the bounded history log.
+///
+/// When the log exceeds `MAX_TRANSFER_HISTORY`, the oldest 10% of
+/// records are evicted to prevent unbounded memory growth.
+pub async fn record_transfer(
+    history: &Arc<RwLock<Vec<TransferRecord>>>,
+    record: TransferRecord,
+) {
+    let mut h = history.write().await;
+    if h.len() >= MAX_TRANSFER_HISTORY {
+        let to_remove = MAX_TRANSFER_HISTORY / 10;
+        h.drain(0..to_remove);
+    }
+    h.push(record);
+}
+
 /// Type alias for the in-memory event store.
 ///
 /// Uses `IndexMap` (insertion-order preserving) rather than `HashMap`
@@ -291,6 +339,11 @@ pub struct AppState {
     /// Uses `IndexMap` for deterministic insertion-order eviction
     /// (see [`store_event`] and the `EventStore` type alias). H-5 fix.
     pub event_store: Arc<RwLock<EventStore>>,
+    /// Bounded in-memory log of UBC spend (transfer) operations.
+    ///
+    /// See [`TransferRecord`] and [`record_transfer`]. Used by the
+    /// `GET /api/v1/economics/transfers` endpoint.
+    pub transfer_history: Arc<RwLock<Vec<TransferRecord>>>,
     /// Known peers in the network.
     pub peers: Arc<RwLock<Vec<PeerInfo>>>,
     /// Prometheus metrics counters and gauges.

--- a/node/src/state.rs
+++ b/node/src/state.rs
@@ -78,10 +78,7 @@ pub struct TransferRecord {
 ///
 /// When the log exceeds `MAX_TRANSFER_HISTORY`, the oldest 10% of
 /// records are evicted to prevent unbounded memory growth.
-pub async fn record_transfer(
-    history: &Arc<RwLock<Vec<TransferRecord>>>,
-    record: TransferRecord,
-) {
+pub async fn record_transfer(history: &Arc<RwLock<Vec<TransferRecord>>>, record: TransferRecord) {
     let mut h = history.write().await;
     if h.len() >= MAX_TRANSFER_HISTORY {
         let to_remove = MAX_TRANSFER_HISTORY / 10;

--- a/node/tests/api_integration.rs
+++ b/node/tests/api_integration.rs
@@ -185,6 +185,7 @@ fn build_test_app_state(port: u16) -> AppState {
         shard_router: Arc::new(std::sync::Mutex::new(shard_router)),
         economics: Arc::new(Mutex::new(economics)),
         event_store: Arc::new(RwLock::new(indexmap::IndexMap::new())),
+        transfer_history: Arc::new(RwLock::new(Vec::new())),
         peers: Arc::new(RwLock::new(Vec::new())),
         metrics: Arc::new(metrics),
         started_at: Instant::now(),

--- a/node/tests/integration.rs
+++ b/node/tests/integration.rs
@@ -118,6 +118,7 @@ async fn start_test_server() -> (
         shard_router: Arc::new(std::sync::Mutex::new(shard_router)),
         economics: Arc::new(Mutex::new(economics)),
         event_store: Arc::new(RwLock::new(indexmap::IndexMap::new())),
+        transfer_history: Arc::new(RwLock::new(Vec::new())),
         peers: Arc::new(RwLock::new(Vec::new())),
         #[cfg(feature = "metrics")]
         metrics: Arc::new(metrics),

--- a/substrate/src/lib.rs
+++ b/substrate/src/lib.rs
@@ -765,6 +765,31 @@ impl Substrate {
         self.validator_candidates.insert(node_id, (keypair, stake));
     }
 
+    /// Get an iterator over the registered validator candidates.
+    ///
+    /// Each entry is `(NodeId, stake)` — the keypair is intentionally
+    /// not exposed through this accessor to avoid leaking private signing
+    /// material to API callers. Use `add_validator` or
+    /// `with_validator_candidates` to populate the registry.
+    ///
+    /// Used by the `GET /api/v1/validators` endpoint.
+    pub fn validator_candidates_iter(&self) -> impl Iterator<Item = (&NodeId, u64)> {
+        self.validator_candidates.iter().map(|(id, (_kp, stake))| (id, *stake))
+    }
+
+    /// Number of registered validator candidates.
+    pub fn validator_count(&self) -> usize {
+        self.validator_candidates.len()
+    }
+
+    /// Current consensus round number.
+    ///
+    /// Used by the `GET /api/v1/validators` endpoint to determine
+    /// whether each validator is currently jailed.
+    pub fn current_round(&self) -> u64 {
+        self.consensus.current_round()
+    }
+
     /// Get a reference to the mempool.
     pub fn mempool(&self) -> &Mempool {
         &self.mempool


### PR DESCRIPTION
Adds 4 new GET endpoints to the omnia-node REST API so the
omnia-protocol-interface dashboard can render live data without
workarounds or stubs.

New endpoints
-------------
- GET /api/v1/events?limit=N            — list recent events (newest first)
- GET /api/v1/governance/proposals      — list all governance proposals
- GET /api/v1/economics/transfers?limit=N — list recent UBC spend records
- GET /api/v1/validators                — list validators with slash + jail status

All four are read-only and return JSON with a top-level array field
("events", "proposals", "transfers", "validators") plus a "count"
and total-in-store field for pagination/observability.

Implementation notes
--------------------
- events list: iterates the existing in-memory IndexMap event_store in
  reverse insertion order. IndexMap preserves insertion order so
  "newest" is well-defined. Limit defaults to 100, capped at 1000.

- governance proposals list: iterates economics.governance.proposals
  and adds a derived "status" field ("voting"/"expired"/"passed")
  plus a precomputed total_participation for client convenience.

- economics transfers list: requires a new in-memory transfer history
  log (TransferRecord + record_transfer in state.rs). The transfer_ubc
  handler now appends a record on every successful spend. The history
  is bounded (10_000 records, oldest-10% eviction when full). Each
  record has a deterministic BLAKE3-derived id (from_did, to_did,
  amount, timestamp). Failed transfers are NOT recorded.

- validators list: combines substrate.validator_candidates_iter() with
  slashing.slash_points_of() and slashing.is_jailed(). The validator
  keypair is intentionally NOT exposed — only the public NodeId
  (hex-encoded), stake, slash_points, is_jailed, and a derived
  "status" ("active"/"slashed"/"jailed") are returned. Also
  returns aggregate counts (active_count, jailed_count, total_stake)
  and current_round.

Substrate API additions
-----------------------
- Substrate::validator_candidates_iter() -> impl Iterator<Item=(&NodeId, u64)>
- Substrate::validator_count() -> usize
- Substrate::current_round() -> u64

Router wiring
-------------
- /events: chained .get(list_events) on the existing POST route
- /governance/proposals: chained .get(list_proposals) on the existing POST
- /economics/transfers: new standalone GET route
- /validators: new public GET route (no JWT — like /node/peers)

All 4 endpoints registered in the OpenAPI paths() list.

Auth model
----------
The 4 list endpoints follow the existing split:
- /api/v1/validators is PUBLIC (like /node/peers) — operators want
  to see validator set state without auth.
- /api/v1/events, /governance/proposals, /economics/transfers are
  JWT-authenticated (already behind the auth middleware since they're
  in the authenticated_routes block).

Tests
-----
Existing transfer_ubc test still passes — the new "id" field in the
transfer response is additive and the test only checks status/amount/
new_balance. AppState construction sites in tests/api_integration.rs
and tests/integration.rs updated with the new transfer_history field.