### PR TITLE
fix(audit): resolve 6 findings from third-pass audit (NEW-C1 through NEW-L1)

### DIFF
--- a/docs/adr/ADR-024-third-audit-remediation.md
+++ b/docs/adr/ADR-024-third-audit-remediation.md
@@ -1,0 +1,117 @@
+# ADR-024: Third-Pass Audit Remediation (NEW-C1 through NEW-L2)
+
+**Date:** 2026-06-30
+**Status:** Proposed
+**Audit:** Omnia Protocol Architecture Audit Report, Third Pass (Super Z · Z.ai, 30 June 2026)
+**Audited commit:** v0.1.79 (post-ADR-023)
+
+## Context
+
+A third independent audit identified 18 new findings (2 Critical, 7 High, 7 Medium, 2 Low) that the prior audits did not surface. Two of the new Critical findings invalidate claimed security fixes in ADR-023.
+
+## Verification Summary
+
+All 18 new findings were verified against the live code. All are CONFIRMED TRUE.
+
+### Critical (2 findings)
+
+| ID | Claim | Status |
+|----|-------|--------|
+| NEW-C1 | F-13 fix is security theater — verify_source_signature never called | **CONFIRMED + FIXED** |
+| NEW-C2 | ZK VerifyingKey deserialized from attacker-supplied proof bytes | CONFIRMED — deferred (needs VK registry) |
+
+### High (7 findings)
+
+| ID | Claim | Status |
+|----|-------|--------|
+| NEW-H1 | production feature off by default — all fail-closed gates bypassed | **CONFIRMED + FIXED** |
+| NEW-H2 | node_key.bin written unencrypted | Deferred |
+| NEW-H3 | SlashingEngine Clone race causes lost updates | Deferred (same root as F-10) |
+| NEW-H4 | thread_pool skips signature verification | **CONFIRMED + FIXED** |
+| NEW-H5 | Silent event drops under burst load | Deferred |
+| NEW-H6 | Fast-sync Sybil-vulnerable | Deferred |
+| NEW-H7 | PeerScoreTracker + VersionHandshake dead code | Deferred |
+
+### Medium (7 findings)
+
+| ID | Claim | Status |
+|----|-------|--------|
+| NEW-M1 | parse_consensus_seed silent fallback in default constructors | **CONFIRMED + FIXED** |
+| NEW-M2 | Quadratic voting Sybil attack | Deferred |
+| NEW-M3 | Biological consent expiry disabled | Deferred |
+| NEW-M4 | TimeLockVoting dead code | Deferred |
+| NEW-M5 | JWT secret + AuthorizedCallers no rotation | Deferred |
+| NEW-M6 | QuantumCommitment phase caller-controlled | Deferred (latent — binding dead code) |
+| NEW-M7 | Replay protection diverges on save_incremental failure | **CONFIRMED + FIXED** |
+
+### Low (2 findings)
+
+| ID | Claim | Status |
+|----|-------|--------|
+| NEW-L1 | Stale omnia-zk audit entry | **CONFIRMED + FIXED** |
+| NEW-L2 | O(epochs) decay loop | Deferred |
+
+## Fixes Applied
+
+### NEW-C1: F-13 Fix Is Security Theater
+
+**Problem:** The F-13 fix checked `source_signature.is_none()` (presence) but never called `verify_source_signature()` (validity). Any `Some(random_64_bytes)` passed. Additionally, `verify_source_signature` itself only signed `self.payload`, omitting `causal_proof` from the signed digest.
+
+**Fix:**
+1. `route_cross_shard` now calls `msg.verify_source_signature(&event.creator_pubkey)` after the presence check
+2. Rejects on verification failure (all builds, not just `#[cfg(feature = "production")]`)
+3. `verify_source_signature` now includes `causal_proof.to_bytes()` in the signed data
+
+### NEW-H1: Production Feature Off By Default
+
+**Problem:** The F-6 (PoUW) and F-13 (cross-shard) fail-closed gates used `#[cfg(feature = "production")]`, but `production` was not in the default feature set. The default binary build bypassed all fail-closed behavior.
+
+**Fix:** Made PoUW verification fail-closed unconditionally — empty `verifier_signature` always returns `false`, regardless of feature flags. Cross-shard signature verification (NEW-C1) is also unconditional.
+
+### NEW-H4: Thread Pool Skips Signature Verification
+
+**Problem:** `validate_and_insert` only called `verify_hash()` — no `verify_signature()`. The module docstring claimed signature verification was performed.
+
+**Fix:** Added `event.verify_signature()` check after the hash check, before inserting into sharded state.
+
+### NEW-M1: parse_consensus_seed Silent Fallback
+
+**Problem:** `SubstrateConfig::new()` and `with_network_size()` used the unsafe legacy `parse_consensus_seed()` that silently fell back to a random seed on invalid input. `try_new()` also used `.unwrap_or(4)` for `OMNIA_TOTAL_NODES`, silently falling back on a typo.
+
+**Fix:**
+1. Deprecated `new()` and `with_network_size()` — they now delegate to `try_new()` / `try_with_network_size()` and panic on error
+2. `try_new()` now validates `OMNIA_TOTAL_NODES` and returns `Err` on parse failure instead of silently falling back to 4
+
+### NEW-M7: Replay Protection Diverges on save_incremental Failure
+
+**Problem:** On `save_incremental` failure, the in-memory nonce map had the new nonce but the persistent store didn't. The code only logged a warning and continued. On restart, the stale persisted nonce allowed replay.
+
+**Fix:** On `save_incremental` failure, the node now panics with a clear error message. This is fail-closed — silent divergence is worse than downtime.
+
+### NEW-L1: Stale omnia-zk Audit Entry
+
+**Problem:** `supply-chain/audits.toml` had `[[audits.omnia-zk]]` but the crate was renamed to `omnia-adapters`.
+
+**Fix:** Renamed the audit entry to `[[audits.omnia-adapters]]`.
+
+## Deferred (13 findings)
+
+The following require architectural work and are tracked for future sprints:
+
+- **NEW-C2** (VK registry): 1-2 weeks — needs `VkRegistry` mapping `CircuitId → VerifyingKey`
+- **NEW-H2** (encrypted node key): 2-3 days — needs `EncryptedKeyStore` integration
+- **NEW-H3** (slashing clone race): 2-3 days — needs write lock held across persist
+- **NEW-H5** (event drops): 3-5 days — needs backpressure or unbounded channel + fast-sync trigger
+- **NEW-H6** (fast-sync Sybil): 1-2 weeks — needs stake-weighted threshold + checkpoint signatures
+- **NEW-H7** (dead code peer scoring): 3-5 days — needs wiring into gossip validation
+- **NEW-M2** (voting Sybil): 1-2 weeks — needs proof-of-personhood or DID clustering
+- **NEW-M3** (consent expiry): 2-3 days — needs epoch threading
+- **NEW-M4** (TimeLockVoting): 3-5 days — needs wiring into governance
+- **NEW-M5** (JWT rotation): 3-5 days — needs admin endpoint + file-watching
+- **NEW-M6** (quantum phase): 3-5 days — latent (binding dead code)
+- **NEW-L2** (decay loop): 2 hours — needs exponentiation by squaring
+- Plus 15 deferred findings from prior audits (F-1, F-2, F-3, F-4, F-7, F-8, F-9, F-10, F-11, F-12, F-18, F-19, F-24, F-25, H1)
+
+## Decision
+
+Apply the 6 immediate fixes (NEW-C1, NEW-H1, NEW-H4, NEW-M1, NEW-M7, NEW-L1). Document the 13 deferred findings. The fixes address Sprint 1 of the audit's recommended 6-sprint roadmap.

--- a/economics/src/useful_work.rs
+++ b/economics/src/useful_work.rs
@@ -136,21 +136,20 @@ impl UsefulWorkProof {
     /// warning is logged and the proof is accepted (testing mode). If
     /// the signature is non-empty, it is verified cryptographically.
     pub fn verify(&self, verifier_pubkey: &[u8; 32]) -> bool {
-        // F-6 fix: in production, require explicit opt-in for PoUW rewards
-        // since real work verification is not yet implemented.
-        #[cfg(feature = "production")]
-        {
-            let allow_unverified = std::env::var("OMNIA_ALLOW_UNVERIFIED_POUW")
-                .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-                .unwrap_or(false);
-            if !allow_unverified {
-                tracing::error!(
-                    "PoUW proof rejected — set OMNIA_ALLOW_UNVERIFIED_POUW=1 to accept \
-                     attested-but-unverified work proofs in production. Real PoUW verification \
-                     (zkML/folding) is not yet implemented."
-                );
-                return false;
-            }
+        // NEW-H1 fix: the previous F-6 fix gated on #[cfg(feature = "production")]
+        // but the production feature is NOT in the default feature set. The default
+        // binary build accepted unverified PoUW proofs. Now fail-closed is
+        // unconditional — there is no legitimate reason to accept unverified work
+        // proofs in any build. Tests that need relaxed verification should use
+        // a separate test-relaxed feature scoped to [dev-dependencies].
+        if self.verifier_signature.is_empty() {
+            tracing::error!(
+                "Work proof rejected — no verifier signature. \
+                 Real PoUW verification (zkML/folding) is not yet implemented. \
+                 The verifier signature proves a trusted verifier ATTESTED to \
+                 the work, not that the work was actually done (F-6 caveat)."
+            );
+            return false;
         }
 
         // Construct the message that the verifier should have signed:
@@ -158,20 +157,6 @@ impl UsefulWorkProof {
         let mut message = Vec::with_capacity(40);
         message.extend_from_slice(&self.result_hash);
         message.extend_from_slice(&self.compute_units_consumed.to_le_bytes());
-
-        if self.verifier_signature.is_empty() {
-            // No signature provided
-            #[cfg(feature = "production")]
-            {
-                tracing::error!("Production mode: work proof rejected — no verifier signature");
-                return false;
-            }
-            #[cfg(not(feature = "production"))]
-            {
-                tracing::warn!("Work proof accepted without verifier signature — testing mode only");
-                return self.result_hash.iter().any(|&b| b != 0) && self.compute_units_consumed > 0;
-            }
-        }
 
         // Verify the Ed25519 signature against the verifier's public key
         use ed25519_dalek::{Signature, Verifier, VerifyingKey};

--- a/economics/tests/ubc_lifecycle.rs
+++ b/economics/tests/ubc_lifecycle.rs
@@ -10,11 +10,11 @@
 //! 6. Quadratic voting weight calculation
 //! 7. Reputation decay for inactive voters
 
+use ed25519_dalek::{Signature, Signer, SigningKey};
 use omnia_economics::{
     DecayRate, EconomicsError, EconomicsOp, EconomicsState, QuotaSystem, UbcToken, UsefulWorkProof, UsefulWorkType,
     VoteChoice, DEFAULT_UBC_QUOTA,
 };
-use ed25519_dalek::{Signature, Signer, SigningKey};
 
 /// Helper: create a non-zero result hash.
 fn nonzero_hash() -> [u8; 32] {

--- a/economics/tests/ubc_lifecycle.rs
+++ b/economics/tests/ubc_lifecycle.rs
@@ -261,13 +261,11 @@ fn test_governance_inactive_voter() {
 #[cfg(not(feature = "production"))]
 fn test_economics_state_full_lifecycle() {
     let mut state = EconomicsState::new();
-    // Set a verifier pubkey so SubmitWork is accepted. In non-production
-    // mode the proof's signature is empty (testing-only path), so any
-    // well-formed 32-byte public key works.
-    let verifier_pubkey = {
-        let kp = omnia_substrate::crypto::generate_keypair();
-        kp.verifying_key().to_bytes()
-    };
+    // Set a verifier pubkey so SubmitWork is accepted. NEW-H1 fix: the
+    // verifier signature is now verified unconditionally, so we need a
+    // real keypair that we can also use to sign the proof.
+    let verifier_keypair = SigningKey::from_bytes(&[1u8; 32]);
+    let verifier_pubkey = verifier_keypair.verifying_key().to_bytes();
     state.set_verifier_pubkey(verifier_pubkey);
     let epoch = state.current_epoch();
 
@@ -310,12 +308,10 @@ fn test_economics_state_full_lifecycle() {
     // Step 3: Alice submits useful work for a reward.
     //
     // NEW-H1 fix: PoUW verification is now fail-closed unconditionally —
-    // empty verifier_signature is always rejected. We generate a real
-    // Ed25519 signature over result_hash || compute_units_consumed.
+    // empty verifier_signature is always rejected. We use the same
+    // verifier_keypair that was set on the state to sign the proof.
     let result_hash = nonzero_hash();
     let compute_units: u64 = 500;
-    let verifier_keypair = SigningKey::from_bytes(&[1u8; 32]);
-    let verifier_pubkey = verifier_keypair.verifying_key().to_bytes();
 
     // Sign result_hash (32 bytes) || compute_units_consumed (8 bytes LE)
     let mut message = Vec::with_capacity(40);
@@ -341,7 +337,7 @@ fn test_economics_state_full_lifecycle() {
                 proof,
             },
             epoch,
-            Some(&verifier_pubkey),
+            None,
         )
         .unwrap();
     assert_eq!(state.balance_of("did:omnia:alice"), Some(DEFAULT_UBC_QUOTA - 300 + 500));

--- a/economics/tests/ubc_lifecycle.rs
+++ b/economics/tests/ubc_lifecycle.rs
@@ -14,6 +14,7 @@ use omnia_economics::{
     DecayRate, EconomicsError, EconomicsOp, EconomicsState, QuotaSystem, UbcToken, UsefulWorkProof, UsefulWorkType,
     VoteChoice, DEFAULT_UBC_QUOTA,
 };
+use ed25519_dalek::{Signature, Signer, SigningKey};
 
 /// Helper: create a non-zero result hash.
 fn nonzero_hash() -> [u8; 32] {
@@ -308,22 +309,29 @@ fn test_economics_state_full_lifecycle() {
 
     // Step 3: Alice submits useful work for a reward.
     //
-    // The verifier_signature is empty because this test exercises the
-    // economics state machine's reward crediting logic, not the C-9
-    // Ed25519 signature verification. In non-production mode (which
-    // this test is gated on via #[cfg(not(feature = "production"))]
-    // above), an empty signature is accepted with a warning — see
-    // UsefulWorkProof::verify(). In production mode, a real 64-byte
-    // Ed25519 signature over `result_hash || compute_units_consumed`
-    // would be required.
+    // NEW-H1 fix: PoUW verification is now fail-closed unconditionally —
+    // empty verifier_signature is always rejected. We generate a real
+    // Ed25519 signature over result_hash || compute_units_consumed.
+    let result_hash = nonzero_hash();
+    let compute_units: u64 = 500;
+    let verifier_keypair = SigningKey::from_bytes(&[1u8; 32]);
+    let verifier_pubkey = verifier_keypair.verifying_key().to_bytes();
+
+    // Sign result_hash (32 bytes) || compute_units_consumed (8 bytes LE)
+    let mut message = Vec::with_capacity(40);
+    message.extend_from_slice(&result_hash);
+    message.extend_from_slice(&compute_units.to_le_bytes());
+    let signature: Signature = verifier_keypair.sign(&message);
+    let verifier_sig = signature.to_bytes().to_vec();
+
     let proof = UsefulWorkProof::new(
         UsefulWorkType::AiTraining {
             model_hash: nonzero_hash(),
             training_data_hash: nonzero_hash(),
         },
-        nonzero_hash(),
-        500,        // 500 compute units → 500 UBC reward
-        Vec::new(), // empty signature: testing-mode accepted path
+        result_hash,
+        compute_units, // 500 compute units → 500 UBC reward
+        verifier_sig,
     )
     .expect("valid proof should construct");
     state
@@ -333,7 +341,7 @@ fn test_economics_state_full_lifecycle() {
                 proof,
             },
             epoch,
-            None,
+            Some(&verifier_pubkey),
         )
         .unwrap();
     assert_eq!(state.balance_of("did:omnia:alice"), Some(DEFAULT_UBC_QUOTA - 300 + 500));

--- a/node/tests/api_integration.rs
+++ b/node/tests/api_integration.rs
@@ -135,7 +135,8 @@ fn build_test_app_state(port: u16) -> AppState {
         id
     };
 
-    let substrate_config = SubstrateConfig::new(node_id_bytes);
+    let substrate_config = SubstrateConfig::try_new(node_id_bytes)
+        .unwrap_or_else(|e| panic!("Failed to create SubstrateConfig: {e:?}"));
     let substrate = Substrate::new(substrate_config);
     let slashing = substrate.slashing.clone();
 

--- a/node/tests/api_integration.rs
+++ b/node/tests/api_integration.rs
@@ -135,8 +135,8 @@ fn build_test_app_state(port: u16) -> AppState {
         id
     };
 
-    let substrate_config = SubstrateConfig::try_new(node_id_bytes)
-        .unwrap_or_else(|e| panic!("Failed to create SubstrateConfig: {e:?}"));
+    let substrate_config =
+        SubstrateConfig::try_new(node_id_bytes).unwrap_or_else(|e| panic!("Failed to create SubstrateConfig: {e:?}"));
     let substrate = Substrate::new(substrate_config);
     let slashing = substrate.slashing.clone();
 

--- a/node/tests/integration.rs
+++ b/node/tests/integration.rs
@@ -74,8 +74,8 @@ async fn start_test_server() -> (
         id
     };
 
-    let substrate_config = SubstrateConfig::try_new(node_id_bytes)
-        .unwrap_or_else(|e| panic!("Failed to create SubstrateConfig: {e:?}"));
+    let substrate_config =
+        SubstrateConfig::try_new(node_id_bytes).unwrap_or_else(|e| panic!("Failed to create SubstrateConfig: {e:?}"));
     let substrate = Substrate::new(substrate_config);
     let slashing = substrate.slashing.clone();
 

--- a/node/tests/integration.rs
+++ b/node/tests/integration.rs
@@ -74,7 +74,8 @@ async fn start_test_server() -> (
         id
     };
 
-    let substrate_config = SubstrateConfig::new(node_id_bytes);
+    let substrate_config = SubstrateConfig::try_new(node_id_bytes)
+        .unwrap_or_else(|e| panic!("Failed to create SubstrateConfig: {e:?}"));
     let substrate = Substrate::new(substrate_config);
     let slashing = substrate.slashing.clone();
 

--- a/omnia-consensus/src/thread_pool.rs
+++ b/omnia-consensus/src/thread_pool.rs
@@ -159,7 +159,8 @@ impl ValidationPool {
     ///
     /// Performs:
     /// 1. Hash integrity check
-    /// 2. Event insertion into the sharded state (if not already present)
+    /// 2. Signature verification (NEW-H4 fix — defence-in-depth)
+    /// 3. Event insertion into the sharded state (if not already present)
     ///
     /// Returns a [`ValidationResult`] indicating success or failure.
     fn validate_and_insert(event: &Event, state: &ShardedConsensusState) -> ValidationResult {
@@ -171,6 +172,19 @@ impl ValidationPool {
                 event_id,
                 valid: false,
                 error: Some("hash integrity check failed".to_string()),
+            };
+        }
+
+        // NEW-H4 fix: verify signature in the thread pool for defence-in-depth.
+        // ConsensusEngine::process_event re-verifies at consensus.rs:413, but
+        // verifying here too prevents polluting the sharded state with
+        // attacker-chosen EventIds in Pending state. The module docstring
+        // claimed signature verification was performed — now it actually is.
+        if !event.verify_signature() {
+            return ValidationResult {
+                event_id,
+                valid: false,
+                error: Some("signature verification failed".to_string()),
             };
         }
 

--- a/shards/src/cross_shard.rs
+++ b/shards/src/cross_shard.rs
@@ -45,11 +45,30 @@ impl CrossShardMessage {
             payload,
             causal_proof,
             // P0-6 fix: default to unsigned. Production callers must call
-            // `with_signature` (or set this field directly) to attach an
+            // `sign` (or set this field directly) to attach an
             // Ed25519 signature over the payload before sending; otherwise
             // the receiving router will reject the message.
             source_signature: None,
         }
+    }
+
+    /// Sign this cross-shard message with the given Ed25519 keypair.
+    ///
+    /// Signs over `payload || causal_proof.to_bytes()` — the same data
+    /// that `verify_source_signature` checks. The signature is stored
+    /// in `source_signature`.
+    pub fn sign(&mut self, keypair: &omnia_substrate::crypto::NodeKeypair) {
+        use ed25519_dalek::{Signer, SigningKey};
+
+        let mut signed_data = Vec::new();
+        signed_data.extend_from_slice(&self.payload);
+        if let Ok(proof_bytes) = self.causal_proof.to_bytes() {
+            signed_data.extend_from_slice(&proof_bytes);
+        }
+
+        // NodeKeypair is ed25519_dalek::SigningKey
+        let sig: ed25519_dalek::Signature = keypair.sign(&signed_data);
+        self.source_signature = Some(sig.to_bytes().to_vec());
     }
 
     /// Verify that the source event causally precedes this message.

--- a/shards/src/cross_shard.rs
+++ b/shards/src/cross_shard.rs
@@ -77,10 +77,12 @@ impl CrossShardMessage {
             Ok(pk) => pk,
             Err(_) => return false,
         };
-        // Sign over the message payload + causal proof (excluding the signature itself)
+        // NEW-C1 fix: sign over BOTH payload AND causal_proof (not just payload).
+        // The previous code only signed self.payload, allowing an attacker to
+        // swap causal_proof without invalidating the signature.
         let mut signed_data = Vec::new();
         signed_data.extend_from_slice(&self.payload);
-        // Include causal proof bytes if serializable
+        signed_data.extend_from_slice(&self.causal_proof.to_bytes());
         pk.verify(&signed_data, &sig).is_ok()
     }
 }

--- a/shards/src/cross_shard.rs
+++ b/shards/src/cross_shard.rs
@@ -58,7 +58,7 @@ impl CrossShardMessage {
     /// that `verify_source_signature` checks. The signature is stored
     /// in `source_signature`.
     pub fn sign(&mut self, keypair: &omnia_substrate::crypto::NodeKeypair) {
-        use ed25519_dalek::{Signer, SigningKey};
+        use ed25519_dalek::Signer;
 
         let mut signed_data = Vec::new();
         signed_data.extend_from_slice(&self.payload);

--- a/shards/src/cross_shard.rs
+++ b/shards/src/cross_shard.rs
@@ -82,7 +82,9 @@ impl CrossShardMessage {
         // swap causal_proof without invalidating the signature.
         let mut signed_data = Vec::new();
         signed_data.extend_from_slice(&self.payload);
-        signed_data.extend_from_slice(&self.causal_proof.to_bytes());
+        if let Ok(proof_bytes) = self.causal_proof.to_bytes() {
+            signed_data.extend_from_slice(&proof_bytes);
+        }
         pk.verify(&signed_data, &sig).is_ok()
     }
 }

--- a/shards/src/router.rs
+++ b/shards/src/router.rs
@@ -428,7 +428,8 @@ impl ShardRouter {
                     "Nonce persistence failed for creator {:?}: {}. \
                      Halting to prevent replay protection bypass. \
                      Fix the disk issue and restart.",
-                    &creator[..4], e
+                    &creator[..4],
+                    e
                 );
             }
         }

--- a/shards/src/router.rs
+++ b/shards/src/router.rs
@@ -213,52 +213,45 @@ impl ShardRouter {
 
     /// Route a cross-shard message to its target shard.
     fn route_cross_shard(&mut self, event: &Event, msg: &CrossShardMessage) -> Result<(), ShardError> {
-        // P0-6 fix: cross-shard messages now carry an optional
-        // `source_signature` proving they were authorized by the source
-        // shard's signing key. Without this, any peer could fabricate a
-        // `CrossShardMessage` with an arbitrary `payload` and inject it
-        // into the target shard's state machine (subject only to the
-        // causal-proof check, which is not a cryptographic guarantee of
-        // origin).
+        // NEW-C1 fix: the previous F-13 fix checked signature PRESENCE
+        // (is_none()) but never called verify_source_signature(). Any
+        // Some(random_bytes) passed. Now we:
+        //   1. Reject if source_signature is None (all builds, not just
+        //      production — there is no legitimate reason to accept
+        //      unsigned cross-shard messages in any build)
+        //   2. Verify the signature against the event creator's public key
         //
-        // TODO(cross-shard-auth): once a per-shard signing-key registry
-        // exists (wired through `ShardRouter`), look up the source
-        // shard's Ed25519 pubkey by `msg.source_shard` and call
-        // `msg.verify_source_signature(&pubkey)`. Reject the message
-        // with `ShardError::ValidationFailed` when verification fails.
-        // In the interim, we log a warning when `source_signature` is
-        // absent so operators can monitor for unsigned messages in
-        // production. Test builds continue to accept unsigned messages
-        // for backward compatibility with existing test fixtures.
-        // F-13 fix: in production builds, reject cross-shard messages
-        // without a source_signature. The previous code only logged a
-        // warning — any peer could fabricate a CrossShardMessage with
-        // an arbitrary payload and inject it into the target shard's
-        // state machine. Now production builds fail-closed.
+        // The event creator's pubkey is the node that originated the
+        // cross-shard message. In a multi-node setup, a per-shard signing
+        // key registry would be more correct, but for now the event
+        // creator's key is the right authority to check.
         //
-        // Non-production builds still accept unsigned messages for
-        // backward compatibility with test fixtures.
+        // Tests that need to send unsigned cross-shard messages should
+        // sign them with a test keypair and embed the signature.
         if msg.source_signature.is_none() {
-            #[cfg(feature = "production")]
-            {
-                tracing::error!(
-                    source_shard = ?msg.source_shard,
-                    target_shard = ?msg.target_shard,
-                    "cross-shard message rejected — no source_signature (production mode)"
-                );
-                return Err(ShardError::ValidationFailed(
-                    "cross-shard message missing source_signature in production mode".into(),
-                ));
-            }
-            #[cfg(not(feature = "production"))]
-            {
-                tracing::warn!(
-                    source_shard = ?msg.source_shard,
-                    target_shard = ?msg.target_shard,
-                    "cross-shard message has no source_signature — accepting in \
-                     non-production mode. Production builds reject unsigned messages."
-                );
-            }
+            tracing::error!(
+                source_shard = ?msg.source_shard,
+                target_shard = ?msg.target_shard,
+                "cross-shard message rejected — no source_signature"
+            );
+            return Err(ShardError::ValidationFailed(
+                "cross-shard message missing source_signature".into(),
+            ));
+        }
+
+        // NEW-C1 fix: actually verify the signature, not just check presence.
+        // The event creator's public key is the authority that should have
+        // signed the cross-shard message.
+        if !msg.verify_source_signature(&event.creator_pubkey) {
+            tracing::error!(
+                source_shard = ?msg.source_shard,
+                target_shard = ?msg.target_shard,
+                creator = ?&event.creator_pubkey[..4],
+                "cross-shard message rejected — source_signature verification failed"
+            );
+            return Err(ShardError::ValidationFailed(
+                "cross-shard message source_signature verification failed".into(),
+            ));
         }
 
         // SECURITY: Verify cross-shard causal proof before processing.
@@ -414,8 +407,29 @@ impl ShardRouter {
         // Only persist nonce and insert into in-memory map if operation succeeded
         if result.is_ok() {
             self.last_nonces.insert(creator, payload.nonce);
+            // NEW-M7 fix: on save_incremental failure, halt the node instead
+            // of logging a warning. The previous code silently diverged — the
+            // in-memory nonce map had the new nonce but the persistent store
+            // didn't. On restart, the stale persisted nonce allowed replay of
+            // all post-failure events. Now we fail-closed: the node halts so
+            // the operator can fix the disk issue before more events are
+            // processed.
             if let Err(e) = self.nonce_store.save_incremental(&creator, payload.nonce) {
-                tracing::warn!("Failed to persist nonce for creator: {}", e);
+                tracing::error!(
+                    creator = ?&creator[..4],
+                    error = %e,
+                    "CRITICAL: Failed to persist nonce — halting to prevent \
+                     replay attacks. Fix the disk issue and restart."
+                );
+                // Panic is intentional — this is a consensus-safety issue.
+                // Silent continuation would allow replay of processed events
+                // after restart.
+                panic!(
+                    "Nonce persistence failed for creator {:?}: {}. \
+                     Halting to prevent replay protection bypass. \
+                     Fix the disk issue and restart.",
+                    &creator[..4], e
+                );
             }
         }
 

--- a/shards/tests/fee_enforcement.rs
+++ b/shards/tests/fee_enforcement.rs
@@ -198,7 +198,7 @@ fn test_cross_shard_fee_deduction() {
     router.register(Box::new(FinancialShard::new()));
     router.register(Box::new(IdentityShard::new()));
 
-    let msg = CrossShardMessage::new(
+    let mut msg = CrossShardMessage::new(
         ShardId::identity(),
         ShardId::identity(),
         postcard::to_allocvec(&ShardOp::Identity(omnia_shards::IdentityOp::CreateDid {
@@ -219,6 +219,10 @@ fn test_cross_shard_fee_deduction() {
         // and a target vc that has count >= 1 for that node.
         VectorClock::with_node(test_node(2), 1),
     );
+
+    // NEW-C1 fix: sign the cross-shard message with the event creator's
+    // keypair. The router now requires a valid source_signature.
+    msg.sign(&keypair);
 
     // The default test event uses VectorClock::with_node(creator, 1) which
     // doesn't include test_node(2). For happened_before to return true,
@@ -260,7 +264,7 @@ fn test_cross_shard_insufficient_balance() {
     router.register(Box::new(FinancialShard::new()));
     router.register(Box::new(IdentityShard::new()));
 
-    let msg = CrossShardMessage::new(
+    let mut msg = CrossShardMessage::new(
         ShardId::financial(),
         ShardId::identity(),
         vec![1, 2, 3],
@@ -268,6 +272,9 @@ fn test_cross_shard_insufficient_balance() {
         // rather than the (now-enforced) causality check.
         VectorClock::with_node(test_node(2), 1),
     );
+
+    // NEW-C1 fix: sign the cross-shard message.
+    msg.sign(&keypair);
 
     let payload = ShardPayload {
         shard_id: ShardId::financial(),

--- a/substrate/src/lib.rs
+++ b/substrate/src/lib.rs
@@ -467,23 +467,29 @@ impl SubstrateConfig {
     /// with standard thresholds (slash at 500, eject at 2000).
     /// Production callers should set `slashing_data_dir` before
     /// constructing the substrate.
+    ///
+    /// NEW-M1 fix: this method now delegates to try_new() and panics on
+    /// invalid OMNIA_CONSENSUS_SEED / OMNIA_TOTAL_NODES instead of
+    /// silently falling back. The silent fallback was the H-12 bug that
+    /// was supposed to be fixed — this closes the gap.
+    #[deprecated(note = "Use try_new() for proper error propagation. \
+                         This method panics on invalid env vars.")]
     pub fn new(node_id: NodeId) -> Self {
-        let total_nodes: usize = std::env::var("OMNIA_TOTAL_NODES")
-            .map(|v| v.parse().unwrap_or(4))
-            .unwrap_or_else(|_| {
-                tracing::warn!("OMNIA_TOTAL_NODES not set, defaulting to 4 — configure this for production");
-                4
-            });
-        let seed = parse_consensus_seed();
-        Self::build_config(node_id, total_nodes, seed)
+        Self::try_new(node_id).unwrap_or_else(|e| {
+            panic!("SubstrateConfig::new failed: {e:?}. Use try_new() for error propagation.")
+        })
     }
 
     /// Create a substrate configuration with a custom network size.
     ///
     /// Slashing defaults to in-memory mode with standard thresholds.
+    #[deprecated(note = "Use try_with_network_size() for proper error propagation. \
+                         This method panics on invalid env vars.")]
     pub fn with_network_size(node_id: NodeId, total_nodes: usize) -> Self {
-        let seed = parse_consensus_seed();
-        Self::build_config(node_id, total_nodes, seed)
+        Self::try_with_network_size(node_id, total_nodes).unwrap_or_else(|e| {
+            panic!("SubstrateConfig::with_network_size failed: {e:?}. \
+                    Use try_with_network_size() for error propagation.")
+        })
     }
 
     /// Like [`SubstrateConfig::new`] but propagates consensus-seed errors
@@ -494,12 +500,21 @@ impl SubstrateConfig {
     /// error message and exit instead of unknowingly forking off the
     /// network with a different seed.
     pub fn try_new(node_id: NodeId) -> ConsensusSeedResult<Self> {
-        let total_nodes: usize = std::env::var("OMNIA_TOTAL_NODES")
-            .map(|v| v.parse().unwrap_or(4))
-            .unwrap_or_else(|_| {
+        // NEW-M1 fix: also validate OMNIA_TOTAL_NODES — the previous code
+        // used .unwrap_or(4) which silently fell back on a typo, causing
+        // the node to compute wrong supermajority thresholds and silently
+        // fork from the network.
+        let total_nodes: usize = match std::env::var("OMNIA_TOTAL_NODES") {
+            Ok(v) => v.parse().map_err(|_| {
+                ConsensusSeedError::InvalidHex(format!(
+                    "OMNIA_TOTAL_NODES='{v}' is not a valid usize — refusing to silently fall back"
+                ))
+            })?,
+            Err(_) => {
                 tracing::warn!("OMNIA_TOTAL_NODES not set, defaulting to 4 — configure this for production");
                 4
-            });
+            }
+        };
         let seed = try_parse_consensus_seed()?;
         Ok(Self::build_config(node_id, total_nodes, seed))
     }

--- a/substrate/src/lib.rs
+++ b/substrate/src/lib.rs
@@ -183,6 +183,10 @@ pub const TARGET_FINALITY_MS: u64 = 5_000;
 /// — especially those that surface errors to the operator (e.g. `main()`) —
 /// should use [`try_parse_consensus_seed`] instead, which returns a `Result`
 /// rather than silently falling back to a random seed on invalid hex.
+///
+/// NEW-M1: this function is now unused since SubstrateConfig::new() delegates
+/// to try_new(). Kept for backward compat with any external callers.
+#[allow(dead_code)]
 fn parse_consensus_seed() -> [u8; 32] {
     if let Ok(hex_seed) = std::env::var("OMNIA_CONSENSUS_SEED") {
         if hex_seed.len() == 64 {
@@ -517,9 +521,9 @@ impl SubstrateConfig {
         // the node to compute wrong supermajority thresholds and silently
         // fork from the network.
         let total_nodes: usize = match std::env::var("OMNIA_TOTAL_NODES") {
-            Ok(v) => v.parse().map_err(|_| {
-                ConsensusSeedError::InvalidTotalNodes { raw: v }
-            })?,
+            Ok(v) => v
+                .parse()
+                .map_err(|_| ConsensusSeedError::InvalidTotalNodes { raw: v })?,
             Err(_) => {
                 tracing::warn!("OMNIA_TOTAL_NODES not set, defaulting to 4 — configure this for production");
                 4

--- a/substrate/src/lib.rs
+++ b/substrate/src/lib.rs
@@ -285,6 +285,17 @@ pub enum ConsensusSeedError {
         expected: usize,
     },
 
+    /// `OMNIA_TOTAL_NODES` was set but could not be parsed as a usize.
+    /// NEW-M1 fix: prevents silent fallback to 4 on a typo'd value.
+    #[error(
+        "OMNIA_TOTAL_NODES='{raw}' is not a valid usize. \
+         Fix the value or unset the variable to use the default (4)."
+    )]
+    InvalidTotalNodes {
+        /// The raw (invalid) string that was provided.
+        raw: String,
+    },
+
     /// The system RNG was unavailable and no seed was provided via the env var.
     #[error("System RNG unavailable — cannot generate random consensus seed. Set OMNIA_CONSENSUS_SEED manually.")]
     RngUnavailable(#[from] getrandom::Error),
@@ -475,9 +486,8 @@ impl SubstrateConfig {
     #[deprecated(note = "Use try_new() for proper error propagation. \
                          This method panics on invalid env vars.")]
     pub fn new(node_id: NodeId) -> Self {
-        Self::try_new(node_id).unwrap_or_else(|e| {
-            panic!("SubstrateConfig::new failed: {e:?}. Use try_new() for error propagation.")
-        })
+        Self::try_new(node_id)
+            .unwrap_or_else(|e| panic!("SubstrateConfig::new failed: {e:?}. Use try_new() for error propagation."))
     }
 
     /// Create a substrate configuration with a custom network size.
@@ -487,8 +497,10 @@ impl SubstrateConfig {
                          This method panics on invalid env vars.")]
     pub fn with_network_size(node_id: NodeId, total_nodes: usize) -> Self {
         Self::try_with_network_size(node_id, total_nodes).unwrap_or_else(|e| {
-            panic!("SubstrateConfig::with_network_size failed: {e:?}. \
-                    Use try_with_network_size() for error propagation.")
+            panic!(
+                "SubstrateConfig::with_network_size failed: {e:?}. \
+                    Use try_with_network_size() for error propagation."
+            )
         })
     }
 
@@ -506,9 +518,7 @@ impl SubstrateConfig {
         // fork from the network.
         let total_nodes: usize = match std::env::var("OMNIA_TOTAL_NODES") {
             Ok(v) => v.parse().map_err(|_| {
-                ConsensusSeedError::InvalidHex(format!(
-                    "OMNIA_TOTAL_NODES='{v}' is not a valid usize — refusing to silently fall back"
-                ))
+                ConsensusSeedError::InvalidTotalNodes { raw: v }
             })?,
             Err(_) => {
                 tracing::warn!("OMNIA_TOTAL_NODES not set, defaulting to 4 — configure this for production");

--- a/substrate/src/lib.rs
+++ b/substrate/src/lib.rs
@@ -1214,6 +1214,8 @@ mod tests {
 
     #[test]
     fn test_substrate_creation() {
+        let _lock = SEED_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::remove_var("OMNIA_CONSENSUS_SEED");
         let config = SubstrateConfig::new(test_node(1));
         let substrate = Substrate::new(config);
 
@@ -1225,6 +1227,8 @@ mod tests {
     #[cfg(feature = "network")]
     #[tokio::test]
     async fn test_substrate_start_stop() {
+        let _lock = SEED_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::remove_var("OMNIA_CONSENSUS_SEED");
         let config = SubstrateConfig::new(test_node(1));
         let mut substrate = Substrate::new(config);
 
@@ -1241,6 +1245,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_submit_event() {
+        let _lock = SEED_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::remove_var("OMNIA_CONSENSUS_SEED");
         let config = SubstrateConfig::new(test_node(1));
         let mut substrate = Substrate::new(config);
         let keypair = generate_keypair();
@@ -1256,6 +1262,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_substrate_stats() {
+        let _lock = SEED_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::remove_var("OMNIA_CONSENSUS_SEED");
         let config = SubstrateConfig::new(test_node(1));
         let substrate = Substrate::new(config);
 
@@ -1281,6 +1289,8 @@ mod tests {
 
     #[test]
     fn test_substrate_config_with_network_size() {
+        let _lock = SEED_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::remove_var("OMNIA_CONSENSUS_SEED");
         let config = SubstrateConfig::with_network_size(test_node(1), 10);
         assert_eq!(config.total_nodes, 10);
         assert_eq!(config.consensus.total_nodes, 10);

--- a/substrate/tests/gossip_libp2p.rs
+++ b/substrate/tests/gossip_libp2p.rs
@@ -254,7 +254,8 @@ async fn spawn_node(
         id[1] = ((port >> 8) & 0xFF) as u8;
         id
     };
-    let config = SubstrateConfig::with_network_size(node_id, 4);
+    let config = SubstrateConfig::try_with_network_size(node_id, 4)
+        .unwrap_or_else(|e| panic!("Failed to create SubstrateConfig: {e:?}"));
     let substrate = Substrate::new(config);
 
     Ok(TestNode {

--- a/substrate/tests/gossip_simulation.rs
+++ b/substrate/tests/gossip_simulation.rs
@@ -35,7 +35,8 @@ impl TestNetwork {
 
         for i in 0..node_count {
             let node_id = test_node(i as u8 + 1);
-            let config = SubstrateConfig::with_network_size(node_id, node_count);
+            let config = SubstrateConfig::try_with_network_size(node_id, node_count)
+                .unwrap_or_else(|e| panic!("Failed to create SubstrateConfig: {e:?}"));
             let substrate = Substrate::new(config);
             nodes.push(Arc::new(RwLock::new(substrate)));
         }

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -49,11 +49,14 @@ criteria = "safe-to-deploy"
 version = "0.1.0"
 notes = "Core substrate layer — our own code."
 
-[[audits.omnia-zk]]
+# NEW-L1 fix: renamed omnia-zk → omnia-adapters (the crate was renamed
+# in Phase 2 but this audit entry was never updated). The stale entry
+# would never match any actual crate version in cargo-vet.
+[[audits.omnia-adapters]]
 who = "Omnia Protocol Contributors"
 criteria = "safe-to-deploy"
 version = "0.1.0"
-notes = "ZK rollup module — our own code."
+notes = "ZK rollup + settlement adapters — our own code."
 
 # ── Phase 3/4 dependency audits ──────────────────────────────────────────────
 


### PR DESCRIPTION
Verified all 18 new findings from the third independent architecture
audit. All 18 are CONFIRMED TRUE. Applied 6 immediate fixes (Sprint 1
of the audit's recommended roadmap); 12 deferred for architectural work.

CRITICAL FIXES (1)

NEW-C1 — F-13 fix is security theater: verify_source_signature never called
  The F-13 fix checked source_signature.is_none() (presence) but never
  called verify_source_signature() (validity). Any Some(random_64_bytes)
  passed. Now route_cross_shard calls verify_source_signature against
  the event creator's public key and rejects on failure.

  Also fixed the signing-scope bug: verify_source_signature now includes
  causal_proof.to_bytes() in the signed digest (previously only payload
  was signed, allowing causal_proof swapping).

  Verification is unconditional (all builds, not just #[cfg(feature =
  "production")]) — there is no legitimate reason to accept unsigned
  cross-shard messages in any build.

HIGH FIXES (2)

NEW-H1 — production feature off by default: all fail-closed gates bypassed
  The F-6 (PoUW) and F-13 (cross-shard) fail-closed gates used
  #[cfg(feature = "production")] but production was not in the default
  feature set. The default binary build accepted unsigned work proofs
  and unsigned cross-shard messages.

  Fix: made PoUW verification fail-closed unconditionally — empty
  verifier_signature always returns false. Cross-shard verification
  (NEW-C1) is also unconditional.

NEW-H4 — thread_pool validate_and_insert skips signature verification
  The thread pool was documented as performing 'CPU-bound work (signature
  verification, hash computation)' but validate_and_insert only called
  verify_hash() — no verify_signature(). Added verify_signature() check
  after the hash check, before inserting into sharded state.

MEDIUM FIXES (2)

NEW-M1 — parse_consensus_seed silent fallback in default constructors
  SubstrateConfig::new() and with_network_size() used the unsafe legacy
  parse_consensus_seed() that silently fell back to random seed on
  invalid input. try_new() also used .unwrap_or(4) for OMNIA_TOTAL_NODES.

  Fix: deprecated new()/with_network_size() — they now delegate to
  try_new()/try_with_network_size() and panic on error. try_new() now
  validates OMNIA_TOTAL_NODES and returns Err on parse failure.

NEW-M7 — replay protection diverges on save_incremental failure
  On save_incremental failure, in-memory nonce map had the new nonce
  but persistent store didn't. Code only logged a warning. On restart,
  stale persisted nonce allowed replay.

  Fix: on save_incremental failure, the node now panics with a clear
  error message. Fail-closed — silent divergence is worse than downtime.

LOW FIXES (1)

NEW-L1 — stale omnia-zk audit entry in supply-chain/audits.toml
  Crate was renamed to omnia-adapters in Phase 2 but the audit entry
  was never updated. Renamed to [[audits.omnia-adapters]].

DEFERRED (12)
  NEW-C2 (VK registry), NEW-H2 (encrypted node key), NEW-H3 (slashing
  race), NEW-H5 (event drops), NEW-H6 (fast-sync Sybil), NEW-H7 (peer
  scoring dead code), NEW-M2 (voting Sybil), NEW-M3 (consent expiry),
  NEW-M4 (TimeLockVoting), NEW-M5 (JWT rotation), NEW-M6 (quantum phase),
  NEW-L2 (decay loop).

ADR-024 documents the full verification of all 18 findings.