### PR TITLE
Reject UBC self-transfers with a clear 400 error

### DIFF
--- a/node/src/api/economics.rs
+++ b/node/src/api/economics.rs
@@ -119,6 +119,20 @@ pub async fn transfer_ubc(
         );
     }
 
+    // Reject self-transfers. UBC is soulbound: a "transfer" spends (burns)
+    // the sender's tokens without crediting the recipient, so sending to
+    // yourself can only destroy your own balance. Fail loudly instead of
+    // letting callers burn tokens by accident.
+    if body.to_did == from_did {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(json!({
+                "error": "Cannot transfer to yourself: UBC is soulbound, so a transfer burns the sender's tokens without crediting the recipient. A self-transfer would only destroy your balance.",
+                "from_did": from_did,
+            })),
+        ));
+    }
+
     let mut economics = state.economics.lock().await;
 
     // Ensure the sender (authenticated caller) is registered

--- a/node/tests/api_integration.rs
+++ b/node/tests/api_integration.rs
@@ -1436,6 +1436,57 @@ async fn test_transfer_success_returns_200() {
     );
 }
 
+// ---- economics: transfer 400 self-transfer ----
+
+#[tokio::test]
+async fn test_transfer_to_self_returns_400() {
+    let server = setup_server_with_economics(|econ| {
+        register_and_mint(econ, REGULAR_CALLER, 10_000);
+    })
+    .await;
+
+    let client = reqwest::Client::new();
+    let token = make_valid_token(REGULAR_CALLER);
+
+    let body = json!({
+        "from_did": REGULAR_CALLER,
+        "to_did": REGULAR_CALLER,
+        "amount": 500
+    });
+
+    let resp = client
+        .post(format!("{}/api/v1/economics/transfer", server.base_url))
+        .bearer_auth(&token)
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), 400, "Self-transfer should return 400");
+    let body: Value = resp.json().await.unwrap();
+    assert!(
+        body["error"].as_str().unwrap().contains("soulbound"),
+        "Error should explain that UBC is soulbound"
+    );
+
+    // The balance must be untouched — nothing was burned.
+    let resp = client
+        .get(format!(
+            "{}/api/v1/economics/balance/{}",
+            server.base_url, REGULAR_CALLER
+        ))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let body: Value = resp.json().await.unwrap();
+    assert!(
+        body["balance"].as_u64().unwrap() >= 10_000,
+        "Rejected self-transfer must not burn any UBC"
+    );
+}
+
 // ---- economics: transfer 400 insufficient balance ----
 
 #[tokio::test]


### PR DESCRIPTION
UBC is soulbound: POST /api/v1/economics/transfer spends (burns) the
sender's tokens without crediting the recipient. Transferring to your
own DID therefore silently destroyed the caller's balance while
looking like a normal transfer.

Reject from_did == to_did (using the authenticated caller identity)
with a 400 that explains the soulbound semantics, before any tokens
are spent. Adds an integration test asserting the 400 and that the
balance is untouched.

