### PR TITLE
Fix self-slashing event API, ephemeral peer identity, unformable testnet

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -28,6 +28,13 @@ services:
       retries: 10
       start_period: 30s
 
+  # Worker nodes dial the bootstrap by DNS name. The address may be given
+  # with or without a trailing `/p2p/<PeerId>` component:
+  #   - without: the peer identity is learned during the QUIC handshake
+  #   - with:    the identity is verified against the pinned PeerId; since
+  #              the node derives its libp2p identity from the persistent
+  #              keypair in its data volume, the PeerId is stable across
+  #              restarts and safe to pin
   omnia-node-1:
     build:
       context: ../

--- a/node/src/api/events.rs
+++ b/node/src/api/events.rs
@@ -9,6 +9,7 @@
 use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::Json;
+use omnia_primitives::blake3_hash_domain;
 use omnia_substrate::Event;
 use serde::Deserialize;
 use serde_json::{json, Value};
@@ -100,8 +101,6 @@ pub async fn submit_event(
         ));
     }
 
-    let node_id = state.config.node_id_bytes();
-
     // Use the node's persistent keypair for signing — events must be
     // verifiable as originating from this node. Ephemeral keypairs would
     // make signature verification meaningless.
@@ -111,28 +110,78 @@ pub async fn submit_event(
             Json(json!({"error": "No persistent keypair configured"})),
         )
     })?;
-    let mut event = Event::genesis(node_id, payload_bytes.clone()).map_err(|e| {
-        (
-            StatusCode::BAD_REQUEST,
-            Json(json!({"error": format!("Invalid event: {e}")})),
-        )
-    })?;
-    event.sign_with_keypair(&keypair).map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({"error": format!("Signing failed: {e}")})),
-        )
-    })?;
 
-    let event_id_hex = hex::encode(event.id);
-    let creator_hex = hex::encode(&event.creator[..4]);
-    let timestamp = event.timestamp;
+    // The on-chain creator identity is derived from the signing key by
+    // `sign_with_keypair` (creator = blake3("omnia-creator", pubkey)), not
+    // the configured node ID. Chain lookups must use the same identity.
+    let creator = blake3_hash_domain(b"omnia-creator", &keypair.verifying_key().to_bytes());
 
-    // Attempt to submit to the substrate
-    let submit_result = {
+    // Build and submit under a single substrate write lock so that two
+    // concurrent submissions cannot mint the same sequence number.
+    //
+    // Every event must extend this creator's previous event: re-using a
+    // (creator, sequence) pair is equivocation and the consensus layer
+    // slashes the validator for it. The previous implementation created
+    // every API event via `Event::genesis()` — creator + sequence 0 each
+    // time — so the *second* submission was indistinguishable from a
+    // Byzantine fork and permanently slashed the node's own validator.
+    let (submit_result, event_id_hex, event_sequence, timestamp) = {
         let mut substrate = state.substrate.write().await;
-        substrate.submit_event(event).await
+
+        let mut event = {
+            let graph = substrate.graph().await;
+            let own_events = graph.by_creator(&creator);
+            match own_events.into_iter().max_by_key(|e| e.sequence) {
+                // First event from this validator — a genuine genesis.
+                None => Event::genesis(creator, payload_bytes.clone()),
+                Some(latest) => {
+                    let sequence = latest.sequence + 1;
+                    let self_parent = latest.id;
+                    // Advance our own clock entry on top of everything
+                    // observed (convention: own entry = sequence + 1, so
+                    // genesis is seq 0 / clock 1).
+                    let mut vector_clock = graph.frontier().clone();
+                    vector_clock.set(creator, sequence + 1);
+                    // Two-parent, Hashgraph-style: reference the newest
+                    // tip from another creator when one exists.
+                    let other_parent = graph
+                        .tips()
+                        .filter_map(|id| graph.get(id))
+                        .filter(|e| e.creator != creator)
+                        .max_by_key(|e| e.timestamp)
+                        .map(|e| e.id);
+                    Event::new(
+                        creator,
+                        sequence,
+                        vector_clock,
+                        Some(self_parent),
+                        other_parent,
+                        payload_bytes.clone(),
+                    )
+                }
+            }
+            .map_err(|e| {
+                (
+                    StatusCode::BAD_REQUEST,
+                    Json(json!({"error": format!("Invalid event: {e}")})),
+                )
+            })?
+        };
+
+        event.sign_with_keypair(&keypair).map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": format!("Signing failed: {e}")})),
+            )
+        })?;
+
+        let event_id_hex = hex::encode(event.id);
+        let event_sequence = event.sequence;
+        let timestamp = event.timestamp;
+        let result = substrate.submit_event(event).await;
+        (result, event_id_hex, event_sequence, timestamp)
     };
+    let creator_hex = hex::encode(&creator[..4]);
 
     match submit_result {
         Ok(()) => {
@@ -140,7 +189,7 @@ pub async fn submit_event(
             let stored = StoredEvent {
                 id: event_id_hex.clone(),
                 creator: creator_hex,
-                sequence: 0,
+                sequence: event_sequence,
                 timestamp,
                 payload: body.payload.clone(),
                 event_type: body.event_type.clone(),
@@ -170,7 +219,7 @@ pub async fn submit_event(
             let stored = StoredEvent {
                 id: event_id_hex.clone(),
                 creator: creator_hex,
-                sequence: 0,
+                sequence: event_sequence,
                 timestamp,
                 payload: body.payload.clone(),
                 event_type: body.event_type.clone(),

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -560,7 +560,14 @@ async fn spawn_background_tasks(
 
             // A2: Build a NetworkConfig that includes the bootstrap peers
             // from CLI/TOML, so the Kademlia DHT is seeded correctly.
+            //
+            // The swarm identity is derived from the node's persistent
+            // keypair, so the libp2p PeerId survives restarts and pinned
+            // `/p2p/<PeerId>` bootstrap addresses stay valid. Previously
+            // the identity was regenerated on every start, which broke
+            // any pinned address as soon as the node restarted.
             let network_config = NetworkConfig {
+                identity: Some(load_or_generate_node_keypair(&config.data_dir).to_bytes()),
                 bootstrap_peers: config
                     .bootstrap_nodes
                     .iter()

--- a/node/tests/api_integration.rs
+++ b/node/tests/api_integration.rs
@@ -1470,3 +1470,40 @@ async fn test_transfer_insufficient_balance_returns_400() {
         "Error should mention transfer failure"
     );
 }
+
+// ---- Regression: repeated submissions must chain, not equivocate ----
+
+/// The submit handler used to create every API event via `Event::genesis()`
+/// — creator + sequence 0 each time — so the second submission was
+/// indistinguishable from a Byzantine fork (same creator + sequence,
+/// different event ID) and the consensus layer slashed the node's own
+/// validator. All subsequent submissions then failed with `NodeSlashed`.
+///
+/// After the chaining fix each submission extends the previous event
+/// (sequence + 1, self-parent link), so any number of submissions succeeds.
+#[tokio::test]
+async fn test_repeated_submissions_chain_and_do_not_self_slash() {
+    let server = setup_server(None).await;
+    let client = reqwest::Client::new();
+    let token = make_valid_token(REGULAR_CALLER);
+
+    for i in 0..5 {
+        let body = json!({
+            "payload": hex::encode(format!("event {i}").as_bytes()),
+            "event_type": "test"
+        });
+        let resp = client
+            .post(format!("{}/api/v1/events", server.base_url))
+            .bearer_auth(&token)
+            .json(&body)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            201,
+            "submission {i} must succeed — before the chaining fix the second \
+             submission self-slashed the validator and every later one failed"
+        );
+    }
+}

--- a/omnia-network/src/gossip.rs
+++ b/omnia-network/src/gossip.rs
@@ -401,11 +401,20 @@ impl GossipProtocol {
                                     warn!("Failed to send Dial command for bootstrap peer: {}", e);
                                 }
                             }
-                            (None, _) => {
-                                warn!(
-                                    addr = %addr_str,
-                                    "Bootstrap address missing /p2p peer ID, skipping"
-                                );
+                            (None, dial_addr) => {
+                                // No /p2p component — dial the raw address and
+                                // learn the peer's identity during the handshake.
+                                // Previously these addresses were silently
+                                // skipped, which meant the stock docker-compose
+                                // testnet (whose bootstrap address has no peer
+                                // ID) could never form a network.
+                                info!(addr = %addr_str, "Dialing bootstrap peer (identity learned on handshake)");
+                                if let Err(e) = cmd_tx
+                                    .send(NetworkCommand::DialAddress { addr: dial_addr })
+                                    .await
+                                {
+                                    warn!("Failed to send DialAddress command for bootstrap peer: {}", e);
+                                }
                             }
                         }
                     }

--- a/omnia-network/src/network.rs
+++ b/omnia-network/src/network.rs
@@ -52,6 +52,14 @@ use tokio::sync::mpsc;
 /// traversal, and transport fallback options.
 #[derive(Debug, Clone)]
 pub struct NetworkConfig {
+    /// Ed25519 secret-key bytes for a persistent swarm identity.
+    ///
+    /// When `Some`, the node's libp2p `PeerId` is derived from this key and
+    /// survives restarts, so bootstrap multiaddrs pinned with `/p2p/<PeerId>`
+    /// stay valid. When `None` a fresh identity is generated on every start
+    /// (the previous behaviour), which invalidates pinned addresses on each
+    /// restart.
+    pub identity: Option<[u8; 32]>,
     /// Multiaddresses of bootstrap/seed peers for initial DHT population.
     pub bootstrap_peers: Vec<Multiaddr>,
     /// Relay server multiaddresses for NAT traversal.
@@ -73,6 +81,7 @@ pub struct NetworkConfig {
 impl Default for NetworkConfig {
     fn default() -> Self {
         Self {
+            identity: None,
             bootstrap_peers: Vec::new(),
             relay_servers: Vec::new(),
             dht_protocol: "/omnia/kad/1.0.0".to_string(),
@@ -421,6 +430,13 @@ pub enum NetworkCommand {
         /// Topic to subscribe to
         topic: String,
     },
+    /// Dial an address without a known peer ID (e.g. a bootstrap
+    /// multiaddr lacking a `/p2p` component). The remote identity is
+    /// learned during the connection handshake.
+    DialAddress {
+        /// Multiaddress to dial
+        addr: Multiaddr,
+    },
     /// Dial a specific peer at the given address.
     Dial {
         /// Peer to dial
@@ -462,7 +478,11 @@ impl OmniaNetwork {
         listen_addr: Multiaddr,
         config: NetworkConfig,
     ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
-        let local_key = identity::Keypair::generate_ed25519();
+        let local_key = match config.identity {
+            Some(secret) => identity::Keypair::ed25519_from_bytes(secret)
+                .map_err(|e| format!("invalid persistent identity key: {e}"))?,
+            None => identity::Keypair::generate_ed25519(),
+        };
         let local_peer_id = PeerId::from(local_key.public());
 
         // ── GossipSub config ─────────────────────────────────────────
@@ -575,6 +595,14 @@ impl OmniaNetwork {
         self.local_peer_id
     }
 
+    /// Dial an address whose peer ID is not yet known. The remote
+    /// identity is verified during the transport handshake and learned
+    /// via the identify/kademlia behaviours.
+    pub fn dial_addr(&mut self, addr: Multiaddr) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        self.swarm.dial(addr)?;
+        Ok(())
+    }
+
     /// Dial a peer at the given address
     pub fn dial(&mut self, peer_id: PeerId, addr: Multiaddr) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let p2p_addr = addr.with(libp2p::multiaddr::Protocol::P2p(peer_id));
@@ -651,6 +679,11 @@ impl OmniaNetwork {
                         Some(NetworkCommand::Subscribe { topic }) => {
                             if let Err(e) = self.subscribe(&topic) {
                                 tracing::warn!("Subscribe failed: {:?}", e);
+                            }
+                        }
+                        Some(NetworkCommand::DialAddress { addr }) => {
+                            if let Err(e) = self.dial_addr(addr) {
+                                tracing::warn!("Dial (no peer ID) failed: {:?}", e);
                             }
                         }
                         Some(NetworkCommand::Dial { peer_id, addr }) => {
@@ -890,6 +923,42 @@ mod tests {
         assert!(config.enable_dcutr);
         assert!(config.enable_tcp_fallback);
         assert!(!config.listen_addresses.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_persistent_identity_yields_stable_peer_id() {
+        // Two networks built from the same secret must present the same
+        // PeerId — this is what lets operators pin `/p2p/<PeerId>` in
+        // bootstrap multiaddrs across restarts. A `None` identity must
+        // still produce a fresh (random) PeerId.
+        let secret = [7u8; 32];
+        let expected = PeerId::from(
+            identity::Keypair::ed25519_from_bytes(secret)
+                .expect("valid secret")
+                .public(),
+        );
+
+        for _ in 0..2 {
+            let config = NetworkConfig {
+                identity: Some(secret),
+                ..Default::default()
+            };
+            let net = OmniaNetwork::with_config(
+                "/ip4/127.0.0.1/udp/0/quic-v1".parse().expect("valid multiaddr"),
+                config,
+            )
+            .await
+            .expect("network construction");
+            assert_eq!(net.local_peer_id(), expected, "PeerId must be derived from the persistent key");
+        }
+
+        let ephemeral = OmniaNetwork::with_config(
+            "/ip4/127.0.0.1/udp/0/quic-v1".parse().expect("valid multiaddr"),
+            NetworkConfig::default(),
+        )
+        .await
+        .expect("network construction");
+        assert_ne!(ephemeral.local_peer_id(), expected, "no identity configured → random PeerId");
     }
 
     #[test]


### PR DESCRIPTION
Three defects found while bringing up the first public testnet
(Hetzner, 2026-07-02), each independently fatal to a running network:

1. POST /api/v1/events created every event via Event::genesis() —
   creator + sequence 0 every time — so a node's second submission was
   indistinguishable from a Byzantine fork (same creator+sequence,
   different id) and the consensus layer slashed the node's own
   validator. Persistently. The handler now extends the creator's chain
   under a single substrate write lock: sequence + 1, self-parent link,
   frontier-merged vector clock, and a second parent from another
   creator's newest tip. Regression test submits five events in a row.

2. The libp2p swarm identity was regenerated on every start
   (identity::Keypair::generate_ed25519), so a bootstrap node's PeerId
   died with each restart and pinned /p2p/<PeerId> multiaddrs went
   stale. The identity is now derived from the node's persistent
   keypair (node_key.bin) via NetworkConfig::identity; test asserts the
   PeerId is stable across constructions.

3. dial_bootstrap_peers() silently skipped any bootstrap address
   lacking a /p2p component — and docker-compose.yml ships exactly such
   an address, so the stock five-node testnet could never form. A new
   NetworkCommand::DialAddress dials raw multiaddrs with the identity
   learned during the QUIC handshake. The compose file now documents
   both address forms; with (2) the pinned form is also safe.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JgAknFkgPe5nQpHAXDR6th