### PR TITLE
style(node): rustfmt wallet-auth integration tests (fix CI fmt check)

### DIFF
--- a/node/tests/api_integration.rs
+++ b/node/tests/api_integration.rs
@@ -1593,7 +1593,11 @@ async fn test_wallet_challenge_login_flow() {
         .unwrap();
 
     let nonce = chal["nonce"].as_str().unwrap().to_string();
-    assert_eq!(chal["did"].as_str().unwrap(), expected_did, "server DID must match client-derived DID");
+    assert_eq!(
+        chal["did"].as_str().unwrap(),
+        expected_did,
+        "server DID must match client-derived DID"
+    );
     assert_eq!(chal["message"].as_str().unwrap(), format!("omnia-auth:{nonce}"));
 
     // Step 2: sign the challenge message and log in.
@@ -1622,7 +1626,10 @@ async fn test_wallet_challenge_login_flow() {
     assert_eq!(bal_resp.status(), 200, "balance lookup with wallet JWT should succeed");
     let bal: Value = bal_resp.json().await.unwrap();
     assert_eq!(bal["did"].as_str().unwrap(), expected_did);
-    assert!(bal["is_registered"].as_bool().unwrap(), "login should have registered the DID");
+    assert!(
+        bal["is_registered"].as_bool().unwrap(),
+        "login should have registered the DID"
+    );
 }
 
 /// A reused nonce must be rejected (single-use replay protection).


### PR DESCRIPTION
## What
The wallet challenge/login integration tests added in #264 had a couple of `assert_eq!`/`assert!` lines that exceeded the repository's `max_width = 120` (rustfmt.toml). This failed the **Check & Lint** job's `cargo fmt --all -- --check` step, which is why the #264 CI run went red.

This PR reformats those lines exactly as rustfmt wants. **No behavior change** — only whitespace/line-wrapping in `node/tests/api_integration.rs`.

## Verification
- `cargo fmt --all -- --check` — clean
- `cargo test -p omnia-node --test api_integration wallet -- --test-threads=1` — 3/3 pass
- `cargo test -p omnia-node --lib wallet_auth` — 5/5 pass