### PR TITLE
feat(node): POST /api/v1/auth/register — register the authenticated caller's DID (#271)

* feat(node): POST /api/v1/auth/register — register the caller's DID


* chore: bump crossbeam-epoch 0.9.18 -> 0.9.20 (RUSTSEC-2026-0204)



### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2035,9 +2035,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/node/src/api/mod.rs
+++ b/node/src/api/mod.rs
@@ -56,6 +56,7 @@ use crate::state::AppState;
         crate::api::errors::error_codes,
         crate::api::wallet_auth::request_challenge,
         crate::api::wallet_auth::login,
+        crate::api::wallet_auth::register,
     ),
     components(schemas(
         crate::api::events::SubmitEventRequest,
@@ -97,6 +98,7 @@ pub struct ApiDoc;
 /// | GET    | `/api/v1/errors`                          | `errors::error_codes`  | Public |
 /// | POST   | `/api/v1/auth/challenge`                  | `wallet_auth::request_challenge` | Public |
 /// | POST   | `/api/v1/auth/login`                      | `wallet_auth::login`   | Public |
+/// | POST   | `/api/v1/auth/register`                   | `wallet_auth::register` | JWT   |
 /// | GET    | `/api/v1/ceremony/state`                  | `ceremony::ceremony_state` | Public |
 /// | POST   | `/api/v1/ceremony/contribute`             | `ceremony::ceremony_contribute` | JWT |
 /// | GET    | `/api/v1/ceremony/transcript`             | `ceremony::ceremony_transcript` | Public |
@@ -140,6 +142,9 @@ pub fn build_api_router_with(authorized: Arc<AuthorizedCallers>) -> Router<AppSt
 
     // Authenticated routes — JWT required (write endpoints + sensitive reads)
     let authenticated_routes = Router::new()
+        // Register the caller's DID (for externally-minted JWTs, e.g. the
+        // wallet's Supabase sign-in; challenge/signature login self-registers)
+        .route("/auth/register", post(wallet_auth::register))
         // Events
         .route("/events", post(events::submit_event).get(events::list_events))
         .route("/events/:id", get(events::get_event))

--- a/node/src/api/wallet_auth.rs
+++ b/node/src/api/wallet_auth.rs
@@ -325,6 +325,60 @@ pub async fn login(
     ))
 }
 
+/// Handler for `POST /api/v1/auth/register` (authenticated).
+///
+/// Registers the **authenticated caller's** DID in the economics quota
+/// system if it is not registered yet. Idempotent: calling it for an
+/// already-registered DID is a no-op that reports the current state.
+///
+/// This exists for clients whose JWTs are minted *outside* the
+/// challenge/signature flow — e.g. the mobile wallet's Supabase sign-in,
+/// where a server-assisted JWT carries a DID the node has never seen.
+/// Challenge/signature logins never need it (login already registers).
+///
+/// The DID comes from the verified JWT `sub` claim, never the request body,
+/// so a caller can only ever register itself.
+#[utoipa::path(
+    post,
+    path = "/api/v1/auth/register",
+    responses(
+        (status = 200, description = "DID registered (or already was)"),
+        (status = 401, description = "Missing/invalid JWT"),
+    ),
+    security(("bearer_auth" = []))
+)]
+pub async fn register(
+    State(state): State<AppState>,
+    axum::Extension(caller): axum::Extension<crate::api::auth::CallerIdentity>,
+) -> (StatusCode, Json<Value>) {
+    let did = caller.caller_id;
+
+    let mut economics = state.economics.lock().await;
+    let newly_registered = if economics.quota.is_registered(&did) {
+        false
+    } else {
+        economics.quota.register_did(&did);
+        tracing::info!(did = %did, "Registered DID via /auth/register");
+        true
+    };
+
+    let balance = economics.balance_of(&did).unwrap_or(0);
+    let quota = economics.quota.quota_of(&did).unwrap_or(0);
+    let epoch = economics.current_epoch();
+
+    (
+        StatusCode::OK,
+        Json(json!({
+            "did": did,
+            "newly_registered": newly_registered,
+            "balance": balance,
+            "monthly_quota": quota,
+            "current_epoch": epoch,
+            "is_registered": true,
+        })),
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/node/tests/api_integration.rs
+++ b/node/tests/api_integration.rs
@@ -1632,6 +1632,70 @@ async fn test_wallet_challenge_login_flow() {
     );
 }
 
+/// `POST /auth/register` registers the authenticated caller's DID —
+/// the path used by wallets whose JWT was minted outside the node
+/// (e.g. Supabase-account sign-in), where no challenge/login ever ran.
+#[tokio::test]
+async fn test_auth_register_registers_external_did() {
+    let server = setup_server(None).await;
+    let client = reqwest::Client::new();
+
+    // A DID the node has never seen, with a JWT minted directly (as the
+    // Supabase edge function does — same secret, sub = did).
+    let did = "did:omnia:9f1e2d3c";
+    let token = make_valid_token(did);
+
+    // Before registration, balance is a 404.
+    let before = client
+        .get(format!("{}/api/v1/economics/balance/{}", server.base_url, did))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(before.status(), 404, "unregistered DID should 404");
+
+    // Register.
+    let reg = client
+        .post(format!("{}/api/v1/auth/register", server.base_url))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(reg.status(), 200);
+    let reg_body: Value = reg.json().await.unwrap();
+    assert_eq!(reg_body["did"].as_str().unwrap(), did);
+    assert!(reg_body["newly_registered"].as_bool().unwrap());
+    assert!(reg_body["is_registered"].as_bool().unwrap());
+
+    // Idempotent: second call succeeds and reports it already existed.
+    let again = client
+        .post(format!("{}/api/v1/auth/register", server.base_url))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(again.status(), 200);
+    let again_body: Value = again.json().await.unwrap();
+    assert!(!again_body["newly_registered"].as_bool().unwrap());
+
+    // Balance now resolves.
+    let after = client
+        .get(format!("{}/api/v1/economics/balance/{}", server.base_url, did))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(after.status(), 200, "registered DID should have a balance");
+
+    // No JWT -> 401.
+    let anon = client
+        .post(format!("{}/api/v1/auth/register", server.base_url))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(anon.status(), 401, "register requires a JWT");
+}
+
 /// A reused nonce must be rejected (single-use replay protection).
 #[tokio::test]
 async fn test_wallet_login_nonce_is_single_use() {


### PR DESCRIPTION
Wallets whose JWT is minted outside the node (the mobile wallet's
Supabase-account sign-in) carry a DID the node has never seen, so
economics endpoints 404 forever. This authenticated, idempotent endpoint
registers the JWT's sub DID in the quota system (the DID always comes
from the verified token, never the body). Challenge/signature logins are
unaffected — login already self-registers.
