### PR TITLE
ops: parameterize OMNIA_JWT_SECRET + one-command rotation script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ target/
 target/
 substrate/target/
 scripts/__pycache__/
+
+# Per-deployment secrets for docker compose (never commit)
+docker/.env

--- a/docker/docker-compose.testnet.yml
+++ b/docker/docker-compose.testnet.yml
@@ -32,7 +32,7 @@ services:
       - OMNIA_HTTP_PORT=8080
       - OMNIA_DATA_DIR=/app/data
       - OMNIA_TOTAL_NODES=3
-      - OMNIA_JWT_SECRET=omnia-testnet-jwt-secret-CHANGE-ME
+      - OMNIA_JWT_SECRET=${OMNIA_JWT_SECRET:-omnia-testnet-jwt-secret-CHANGE-ME}
       - OMNIA_AUTHORIZED_CALLERS=admin-caller
     ports:
       - "9090:8080/tcp"
@@ -61,7 +61,7 @@ services:
       - OMNIA_HTTP_PORT=8080
       - OMNIA_DATA_DIR=/app/data
       - OMNIA_TOTAL_NODES=3
-      - OMNIA_JWT_SECRET=omnia-testnet-jwt-secret-CHANGE-ME
+      - OMNIA_JWT_SECRET=${OMNIA_JWT_SECRET:-omnia-testnet-jwt-secret-CHANGE-ME}
       - OMNIA_AUTHORIZED_CALLERS=admin-caller
     ports:
       - "9091:8080/tcp"
@@ -87,7 +87,7 @@ services:
       - OMNIA_HTTP_PORT=8080
       - OMNIA_DATA_DIR=/app/data
       - OMNIA_TOTAL_NODES=3
-      - OMNIA_JWT_SECRET=omnia-testnet-jwt-secret-CHANGE-ME
+      - OMNIA_JWT_SECRET=${OMNIA_JWT_SECRET:-omnia-testnet-jwt-secret-CHANGE-ME}
       - OMNIA_AUTHORIZED_CALLERS=admin-caller
     ports:
       - "9092:8080/tcp"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - OMNIA_DATA_DIR=/app/data
       - OMNIA_TOTAL_NODES=5
       - OMNIA_CORS_ORIGINS=*
-      - OMNIA_JWT_SECRET=omnia-testnet-jwt-secret-CHANGE-ME
+      - OMNIA_JWT_SECRET=${OMNIA_JWT_SECRET:-omnia-testnet-jwt-secret-CHANGE-ME}
       - OMNIA_AUTHORIZED_CALLERS=admin-caller
     ports:
       - "9090:8080/tcp"
@@ -49,7 +49,7 @@ services:
       - OMNIA_DATA_DIR=/app/data
       - OMNIA_TOTAL_NODES=5
       - OMNIA_CORS_ORIGINS=*
-      - OMNIA_JWT_SECRET=omnia-testnet-jwt-secret-CHANGE-ME
+      - OMNIA_JWT_SECRET=${OMNIA_JWT_SECRET:-omnia-testnet-jwt-secret-CHANGE-ME}
       - OMNIA_AUTHORIZED_CALLERS=admin-caller
     ports:
       - "9091:8080/tcp"
@@ -75,7 +75,7 @@ services:
       - OMNIA_DATA_DIR=/app/data
       - OMNIA_TOTAL_NODES=5
       - OMNIA_CORS_ORIGINS=*
-      - OMNIA_JWT_SECRET=omnia-testnet-jwt-secret-CHANGE-ME
+      - OMNIA_JWT_SECRET=${OMNIA_JWT_SECRET:-omnia-testnet-jwt-secret-CHANGE-ME}
       - OMNIA_AUTHORIZED_CALLERS=admin-caller
     ports:
       - "9092:8080/tcp"
@@ -101,7 +101,7 @@ services:
       - OMNIA_DATA_DIR=/app/data
       - OMNIA_TOTAL_NODES=5
       - OMNIA_CORS_ORIGINS=*
-      - OMNIA_JWT_SECRET=omnia-testnet-jwt-secret-CHANGE-ME
+      - OMNIA_JWT_SECRET=${OMNIA_JWT_SECRET:-omnia-testnet-jwt-secret-CHANGE-ME}
       - OMNIA_AUTHORIZED_CALLERS=admin-caller
     ports:
       - "9093:8080/tcp"
@@ -127,7 +127,7 @@ services:
       - OMNIA_DATA_DIR=/app/data
       - OMNIA_TOTAL_NODES=5
       - OMNIA_CORS_ORIGINS=*
-      - OMNIA_JWT_SECRET=omnia-testnet-jwt-secret-CHANGE-ME
+      - OMNIA_JWT_SECRET=${OMNIA_JWT_SECRET:-omnia-testnet-jwt-secret-CHANGE-ME}
       - OMNIA_AUTHORIZED_CALLERS=admin-caller
     ports:
       - "9094:8080/tcp"

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -81,6 +81,8 @@
 | `OMNIA_TOTAL_NODES`        | `5`                     | Expected number of nodes in the network          |
 | `OMNIA_DATA_DIR`           | `/app/data`             | Data directory for persistent storage            |
 | `OMNIA_JWT_SECRET`         | (none)                  | HMAC secret for JWT auth                         |
+
+> **Rotation:** the node reads `OMNIA_JWT_SECRET` once at startup and caches it, so rotating requires recreating the container. Use `scripts/rotate-jwt-secret.sh` — it generates a fresh secret into `docker/.env` (git-ignored; compose substitutes it), recreates the containers, and prints the value to mirror into Supabase's edge-function secrets. All outstanding JWTs are invalidated on rotation; the wallet re-authenticates transparently on the next 401. Rotate on a schedule (e.g. monthly) or immediately on suspected leak — the compose default (`omnia-testnet-jwt-secret-CHANGE-ME`) is public and must never run in production.
 | `OMNIA_AUTHORIZED_CALLERS` | (none)                  | Comma-separated authorized caller IDs            |
 | `OMNIA_RATE_LIMIT_RPS`     | (none)                  | Max requests per second per IP                   |
 

--- a/scripts/rotate-jwt-secret.sh
+++ b/scripts/rotate-jwt-secret.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Rotate OMNIA_JWT_SECRET for a docker-compose deployment.
+#
+# What it does:
+#   1. Generates a fresh 256-bit secret.
+#   2. Writes it to docker/.env (compose substitutes it into every node).
+#   3. Recreates the containers (the node caches the secret at startup,
+#      so a recreate is required — `restart` is not enough).
+#   4. Prints the new secret ONCE so you can mirror it to Supabase
+#      (Dashboard -> Edge Functions -> Secrets -> OMNIA_JWT_SECRET).
+#
+# Effects of rotation: every outstanding JWT (wallet sessions, web
+# sessions) becomes invalid. Clients recover automatically — the wallet
+# re-runs challenge/login (self-custody) or re-mints via the edge
+# function (Supabase mode) on the next 401. The Supabase secret MUST be
+# updated in the same sitting or Supabase-mode sign-ins will 401 until
+# it is.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+COMPOSE_FILE="${1:-docker/docker-compose.yml}"
+NEW_SECRET=$(openssl rand -hex 32)
+
+touch docker/.env
+grep -v '^OMNIA_JWT_SECRET=' docker/.env > docker/.env.tmp || true
+mv docker/.env.tmp docker/.env
+echo "OMNIA_JWT_SECRET=${NEW_SECRET}" >> docker/.env
+chmod 600 docker/.env
+
+docker compose -f "${COMPOSE_FILE}" up -d
+
+echo
+echo "Rotated. New OMNIA_JWT_SECRET (set the SAME value on Supabase now):"
+echo
+echo "  ${NEW_SECRET}"
+echo
+echo "Supabase: Dashboard -> Edge Functions -> Secrets -> OMNIA_JWT_SECRET"
+echo "(or: supabase secrets set OMNIA_JWT_SECRET=${NEW_SECRET} --project-ref <ref>)"


### PR DESCRIPTION
## What

Makes JWT-secret rotation a one-command operation:

- **Compose files** now substitute `OMNIA_JWT_SECRET` from the environment / `docker/.env` (`${OMNIA_JWT_SECRET:-omnia-testnet-jwt-secret-CHANGE-ME}`) instead of hardcoding the public default in 8 places. Local dev behavior is unchanged (fallback keeps the old default).
- **`scripts/rotate-jwt-secret.sh`**: generates a fresh 256-bit secret, writes it to `docker/.env` (git-ignored, `chmod 600`), recreates the containers (required — the node caches the secret at startup), and prints the value once so the operator can mirror it into Supabase's edge-function secrets.
- **`deployment.md`**: documents the rotation procedure, the client impact (all JWTs invalidated; the wallet re-authenticates transparently on 401), and a warning that the public compose default must never run in production.

## Why

The live node's HS256 secret is shared with Supabase's `mint-node-jwt` function. If it's still the repo default, anyone can mint valid node JWTs for any DID. Rotation needs to be trivial or it won't happen.

## Verification

`bash -n` clean on the script; compose changes are pure variable substitution with unchanged defaults, so all Docker-based CI paths behave identically.