### PR TITLE
ops: multi-node Lane 0 validator testnet setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,9 @@ scripts/__pycache__/
 
 # Per-deployment secrets for docker compose (never commit)
 docker/.env
+
+# Generated validator keypairs for the local testnet (secrets — never commit)
+ops/testnet-keys/
+
+# Local benchmark reports
+bench-results/

--- a/docker/docker-compose.testnet.yml
+++ b/docker/docker-compose.testnet.yml
@@ -36,12 +36,18 @@ services:
       - OMNIA_AUTHORIZED_CALLERS=admin-caller
       - OMNIA_RATE_LIMIT_RPS=${OMNIA_RATE_LIMIT_RPS:-10}
       - OMNIA_LANE0_VALIDATORS=${OMNIA_LANE0_VALIDATORS:-}
+      # Persistent validator keypair (raw 32-byte Ed25519 secret) so this
+      # node's pubkey is fixed and known ahead of time — see
+      # scripts/setup-validators.sh, which generates the keys and the
+      # matching OMNIA_LANE0_VALIDATORS set.
+      - OMNIA_NODE_KEY_FILE=/keys/validator_key.bin
     ports:
       - "9090:8080/tcp"
     networks:
       - omnia-testnet
     volumes:
       - bootstrap-data:/app/data
+      - ../ops/testnet-keys/node0:/keys:ro
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
       interval: 10s
@@ -67,12 +73,14 @@ services:
       - OMNIA_AUTHORIZED_CALLERS=admin-caller
       - OMNIA_RATE_LIMIT_RPS=${OMNIA_RATE_LIMIT_RPS:-10}
       - OMNIA_LANE0_VALIDATORS=${OMNIA_LANE0_VALIDATORS:-}
+      - OMNIA_NODE_KEY_FILE=/keys/validator_key.bin
     ports:
       - "9091:8080/tcp"
     networks:
       - omnia-testnet
     volumes:
       - node1-data:/app/data
+      - ../ops/testnet-keys/node1:/keys:ro
     depends_on:
       omnia-bootstrap:
         condition: service_healthy
@@ -95,12 +103,14 @@ services:
       - OMNIA_AUTHORIZED_CALLERS=admin-caller
       - OMNIA_RATE_LIMIT_RPS=${OMNIA_RATE_LIMIT_RPS:-10}
       - OMNIA_LANE0_VALIDATORS=${OMNIA_LANE0_VALIDATORS:-}
+      - OMNIA_NODE_KEY_FILE=/keys/validator_key.bin
     ports:
       - "9092:8080/tcp"
     networks:
       - omnia-testnet
     volumes:
       - node2-data:/app/data
+      - ../ops/testnet-keys/node2:/keys:ro
     depends_on:
       omnia-bootstrap:
         condition: service_healthy

--- a/docs/operations/validator-setup.md
+++ b/docs/operations/validator-setup.md
@@ -169,5 +169,69 @@ omnia-node --node-id 1 --http-port 8080
 
 ---
 
-🔙 **Back**: [operations/](./) | 🔄 **Related**: [runbook.md](./runbook.md)
+## Multi-Node Lane 0 Validator Testnet
+
+To run a multi-node testnet where transfers reach **Lane 0 fast-path
+finality** (ADR-025), every node must share the *same* validator set, keyed
+by each node's Ed25519 public key. Because a node's pubkey is derived from
+its keypair, the set has to be known before boot — a chicken-and-egg the
+setup script resolves by pre-generating the keys.
+
+### One-command setup
+
+```sh
+# Generates a persistent keypair per node, assembles OMNIA_LANE0_VALIDATORS
+# from their public keys, and writes docker/.env (with a fresh
+# OMNIA_JWT_SECRET if none exists, and OMNIA_RATE_LIMIT_RPS=1000).
+./scripts/setup-validators.sh            # 3 nodes, stake 1 each
+# NODES=5 STAKE=1 ./scripts/setup-validators.sh   # to scale
+```
+
+This writes `ops/testnet-keys/nodeK/` (git-ignored secrets):
+`validator_key.bin` (the raw 32-byte secret each node loads via
+`OMNIA_NODE_KEY_FILE`) and `validator_pubkey.txt`. `docker-compose.testnet.yml`
+mounts each into its node, so pubkeys — and therefore the validator set —
+stay stable across restarts.
+
+### Bring the testnet up
+
+```sh
+docker compose -f docker/docker-compose.testnet.yml up -d --build
+# add --profile monitoring for Prometheus (:9095) + Grafana (:3000)
+```
+
+Compose reads `docker/.env` automatically, so `OMNIA_LANE0_VALIDATORS`,
+`OMNIA_JWT_SECRET`, and `OMNIA_RATE_LIMIT_RPS` flow to all three nodes.
+
+### Verify
+
+```sh
+# Each node should report a `lane0` stats object (not null) and its own pubkey.
+for p in 9090 9091 9092; do
+  curl -s http://localhost:$p/api/v1/node/info \
+    | python3 -c 'import json,sys;d=json.load(sys.stdin);print(d["node_id"], d["lane0"], d["validator_pubkey"][:8])'
+done
+```
+
+Once the nodes have meshed (`/api/v1/node/peers` shows peers), a UBC
+transfer's provenance event is acked by the stake-weighted quorum and
+`GET /api/v1/events/:id` reports `lane0_final: true`. Capture multi-node
+throughput/finality with `scripts/testnet-bench.sh` — see the
+[testnet benchmark runbook](./testnet-benchmark.md).
+
+### Rotating keys
+
+Delete `ops/testnet-keys/` and re-run `setup-validators.sh` to regenerate
+all validator keypairs and the matching set. (Re-running without deleting
+reuses existing keys, keeping the set stable.)
+
+### Security note
+
+`setup-validators.sh` writes **unencrypted** raw keys for a local/dev
+testnet. Production validators should use the encrypted keygen path
+(`--passphrase`, Step 1 above) and a secrets manager, not committed files.
+
+---
+
+🔙 **Back**: [operations/](./) | 🔄 **Related**: [runbook.md](./runbook.md), [testnet-benchmark.md](./testnet-benchmark.md)
 🚀 **Next**: [monitoring.md](./monitoring.md) | 📜 **Source of Truth**: [Restructuring Blueprint](../reference/blueprint-reference.md)

--- a/scripts/setup-validators.sh
+++ b/scripts/setup-validators.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Omnia Protocol — Multi-Node Validator Setup (ADR-025 Lane 0)
+#
+# Prepares a reproducible N-node validator testnet:
+#   1. Generates a persistent Ed25519 keypair per node (via `omnia-node
+#      keygen`) into ops/testnet-keys/nodeK/ — validator_key.bin (raw
+#      32-byte secret the node loads via OMNIA_NODE_KEY_FILE) plus
+#      validator_pubkey.txt (hex public key).
+#   2. Assembles OMNIA_LANE0_VALIDATORS = pk0:stake,pk1:stake,… from those
+#      public keys, so every node's Lane 0 validator set is identical and
+#      known before first boot (no chicken-and-egg).
+#   3. Writes docker/.env with OMNIA_LANE0_VALIDATORS (and, if absent, a
+#      fresh OMNIA_JWT_SECRET and a benchmark-friendly OMNIA_RATE_LIMIT_RPS),
+#      preserving any other variables already there.
+#
+# docker/docker-compose.testnet.yml mounts ops/testnet-keys/nodeK into each
+# node and points OMNIA_NODE_KEY_FILE at it, so pubkeys stay stable across
+# restarts and match the validator set.
+#
+# Usage:
+#   ./scripts/setup-validators.sh                 # 3 nodes, stake 1 each
+#   NODES=3 STAKE=1 ./scripts/setup-validators.sh
+#
+# Then bring the testnet up:
+#   OMNIA_JWT_SECRET=$(grep '^OMNIA_JWT_SECRET=' docker/.env | cut -d= -f2-) \
+#   OMNIA_LANE0_VALIDATORS=$(grep '^OMNIA_LANE0_VALIDATORS=' docker/.env | cut -d= -f2-) \
+#     docker compose -f docker/docker-compose.testnet.yml up -d --build
+#   # (compose reads docker/.env automatically; the explicit vars above are
+#   #  only needed if you invoke compose from another directory.)
+#
+# Re-running is safe: existing node keys are reused (not regenerated), so
+# the validator set is stable. Delete ops/testnet-keys/ to rotate all keys.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$ROOT"
+
+NODES="${NODES:-3}"
+STAKE="${STAKE:-1}"
+KEYS_DIR="ops/testnet-keys"
+ENV_FILE="docker/.env"
+BIN="target/release/omnia-node"
+
+# ── 1. Ensure the node binary (for `keygen`) ────────────────────────────────
+
+if [[ ! -x "$BIN" ]]; then
+  echo "🔨 Building omnia-node (release) for keygen…"
+  cargo build --release -p omnia-node
+fi
+
+# ── 2. Generate / reuse a keypair per node ──────────────────────────────────
+
+mkdir -p "$KEYS_DIR"
+declare -a ENTRIES=()
+
+for ((i = 0; i < NODES; i++)); do
+  dir="$KEYS_DIR/node$i"
+  key="$dir/validator_key.bin"
+  pub="$dir/validator_pubkey.txt"
+
+  if [[ -f "$key" && -f "$pub" ]]; then
+    echo "♻️  node$i — reusing existing key"
+  else
+    mkdir -p "$dir"
+    # Unencrypted raw key: the node loads it directly via OMNIA_NODE_KEY_FILE.
+    # (Production validators should use an encrypted key + the decrypt path;
+    #  this is a local/dev testnet.)
+    "$BIN" keygen --output-dir "$dir" >/dev/null
+    echo "🔑 node$i — generated new key"
+  fi
+
+  pk="$(tr -d '[:space:]' < "$pub")"
+  if [[ ${#pk} -ne 64 ]]; then
+    echo "❌ node$i pubkey is not 64 hex chars: '$pk'" >&2
+    exit 1
+  fi
+  ENTRIES+=("$pk:$STAKE")
+done
+
+# Keys are secrets — never commit them.
+chmod -R go-rwx "$KEYS_DIR" 2>/dev/null || true
+
+VALIDATORS="$(IFS=,; echo "${ENTRIES[*]}")"
+
+# ── 3. Write docker/.env (preserve existing, update our keys) ───────────────
+
+touch "$ENV_FILE"
+tmp="$(mktemp)"
+grep -v -E '^(OMNIA_LANE0_VALIDATORS|OMNIA_RATE_LIMIT_RPS)=' "$ENV_FILE" > "$tmp" || true
+mv "$tmp" "$ENV_FILE"
+
+# Generate a JWT secret only if one isn't already set (don't clobber a live one).
+if ! grep -q '^OMNIA_JWT_SECRET=' "$ENV_FILE"; then
+  echo "OMNIA_JWT_SECRET=$(openssl rand -hex 32)" >> "$ENV_FILE"
+  echo "🔐 Generated a fresh OMNIA_JWT_SECRET in $ENV_FILE"
+fi
+
+{
+  echo "OMNIA_LANE0_VALIDATORS=$VALIDATORS"
+  # Benchmarks need headroom over the default 10 rps per-client limit.
+  echo "OMNIA_RATE_LIMIT_RPS=${OMNIA_RATE_LIMIT_RPS:-1000}"
+} >> "$ENV_FILE"
+chmod 600 "$ENV_FILE"
+
+# ── 4. Summary ──────────────────────────────────────────────────────────────
+
+echo ""
+echo "✅ Validator set ready for $NODES nodes (stake $STAKE each):"
+for ((i = 0; i < NODES; i++)); do
+  printf '   node%d  %s\n' "$i" "$(tr -d '[:space:]' < "$KEYS_DIR/node$i/validator_pubkey.txt")"
+done
+echo ""
+echo "   Wrote OMNIA_LANE0_VALIDATORS + OMNIA_RATE_LIMIT_RPS to $ENV_FILE"
+echo "   Keys in $KEYS_DIR/ (git-ignored — do not commit)."
+echo ""
+echo "🚀 Bring the testnet up (compose reads docker/.env automatically):"
+echo "   docker compose -f docker/docker-compose.testnet.yml up -d --build"
+echo ""
+echo "🔍 Verify Lane 0 is live on each node:"
+echo "   for p in 9090 9091 9092; do curl -s http://localhost:\$p/api/v1/node/info | \\"
+echo "     python3 -c 'import json,sys;d=json.load(sys.stdin);print(d[\"node_id\"], d[\"lane0\"])'; done"
+echo ""
+echo "📈 Benchmark once all three are healthy and meshed:"
+echo "   OMNIA_JWT_SECRET=\$(grep ^OMNIA_JWT_SECRET= $ENV_FILE | cut -d= -f2-) \\"
+echo "     ./scripts/testnet-bench.sh --events 1000 --concurrency 16"


### PR DESCRIPTION
## What

Everything needed to stand up a reproducible **multi-node validator testnet** where UBC transfers reach **Lane 0 fast-path finality** (ADR-025).

Lane 0 needs every node to share the same validator set, keyed by each node's Ed25519 pubkey — but a pubkey only exists after a node has a keypair, which is a chicken-and-egg for configuring the set before boot. This resolves it by pre-generating the keys.

- **`scripts/setup-validators.sh`** (new) — generates a persistent keypair per node via `omnia-node keygen`, assembles `OMNIA_LANE0_VALIDATORS` from the pubkeys, and writes `docker/.env` (a fresh `OMNIA_JWT_SECRET` if none exists, `OMNIA_RATE_LIMIT_RPS=1000`). Re-runnable (reuses existing keys so the set stays stable); `NODES` / `STAKE` overridable.
- **`docker/docker-compose.testnet.yml`** — each of the 3 nodes now mounts its `ops/testnet-keys/nodeK/validator_key.bin` read-only and sets `OMNIA_NODE_KEY_FILE`, so pubkeys are stable across restarts and match the set. (`:ro` is safe — the node loads the existing key and never writes it.)
- **`.gitignore`** — `ops/testnet-keys/` (secret keys) and `bench-results/`.
- **`docs/operations/validator-setup.md`** — a "Multi-Node Lane 0 Validator Testnet" section: one-command setup → `docker compose up` → verify `lane0` non-null on all three → benchmark.

## The flow

```sh
./scripts/setup-validators.sh
docker compose -f docker/docker-compose.testnet.yml up -d --build
for p in 9090 9091 9092; do curl -s localhost:$p/api/v1/node/info \
  | python3 -c 'import json,sys;d=json.load(sys.stdin);print(d["node_id"], d["lane0"])'; done
```

## Verified

Ran `setup-validators.sh` end-to-end: built the release node, generated 3 keypairs (`validator_key.bin` = 32-byte raw secret the node loads via `OMNIA_NODE_KEY_FILE`; `validator_pubkey.txt` = 64-hex pubkey), assembled a correct 3-entry `OMNIA_LANE0_VALIDATORS`, and wrote `docker/.env`. Confirmed `docker/.env` and `ops/testnet-keys/` are git-ignored (never staged). `bash -n` clean.

## Security note

The script writes **unencrypted** raw keys for a local/dev testnet. Production validators should use the encrypted keygen path (`--passphrase`) and a secrets manager, not committed files — called out in the doc.