### PR TITLE
feat(consensus): epoch-fenced Lane 0 validator rotation (ADR-025 Stage 4)

### DIFF
--- a/docs/reference/status.md
+++ b/docs/reference/status.md
@@ -213,7 +213,7 @@ Every stage is tracked here so nothing falls through.
 | **1** | Integrate idle gossip components (AUDIT-14): bloom dedup, priority queue, compact wire v2 | ✅ Done | PR #276 |
 | **2** | Real 3-node testnet + honest multi-node baselines                        | 🔄 Tooling ready — awaiting multi-host run | `scripts/testnet-bench.sh`, [testnet-benchmark runbook](../operations/testnet-benchmark.md); node metrics wired |
 | **3** | Lane 0: consensusless UBC fast path (quorum acks, G-Set certificate CRDTs); absorbs AUDIT-15 | 🔄 v1 shipped — static validator set (`OMNIA_LANE0_VALIDATORS`); dynamic set arrives with Lane 1 | `substrate/src/lane0.rs`; `lane0_final` in event API; `lane0` stats in node info |
-| **4** | Lane 1: DAG-native commit rule + TLA+ spec extension                     | 🌑 Not started | — |
+| **4** | Lane 1: DAG-native commit rule + TLA+ spec extension                     | 🔄 Epoch-fenced validator rotation shipped; governance-triggered rotation trigger not yet wired | `substrate/src/lane0.rs` (`CertificateStore::rotate_validators`, `Substrate::rotate_lane0_validators`); `formal-verification/OmniaTwoLane.tla` |
 | **5** | Consensus arena: adversarial property-based CI gate                      | 🌑 Not started | — |
 
 ---

--- a/formal-verification/OmniaTwoLane.cfg
+++ b/formal-verification/OmniaTwoLane.cfg
@@ -1,0 +1,8 @@
+SPECIFICATION Spec
+INVARIANTS TypeOK PendingAcksAreCurrentMembers
+PROPERTIES EpochFenceMonotone
+CONSTRAINT StateConstraint
+CONSTANTS Nodes = {n1, n2, n3, n4}
+          InitialActive = {n1, n2, n3}
+          EventId = {e1, e2}
+          MaxEpoch = 1

--- a/formal-verification/OmniaTwoLane.tla
+++ b/formal-verification/OmniaTwoLane.tla
@@ -1,0 +1,183 @@
+-------------------------------- MODULE OmniaTwoLane --------------------------------
+EXTENDS Naturals, FiniteSets
+
+(***************************************************************************)
+(* ADR-025 Stage 4: cross-lane safety for the two-lane consensus design.   *)
+(*                                                                         *)
+(* This module does NOT re-model Lane 1's DAG commit rule — that is       *)
+(* already fully specified and verified in `OmniaConsensus.tla` (the      *)
+(* `Agreement` invariant: all honest nodes that commit an event at the    *)
+(* same logical position agree on it). Instead this module COMPOSES with  *)
+(* that result: a Lane-1-committed validator-set-change event is          *)
+(* abstracted here as `RotateEpoch`, a single atomic action applied       *)
+(* identically to every node's state. That abstraction is sound BECAUSE   *)
+(* of `Agreement` — since every honest node computes the same committed   *)
+(* order, every honest node applies the same rotation at the same        *)
+(* logical point, which is exactly what "atomic and identical" means.     *)
+(*                                                                         *)
+(* What this module DOES model in full: Lane 0's finality certificates as *)
+(* a grow-only-set (G-Set) CRDT accumulated per node via gossip, and the  *)
+(* new safety property Stage 4 introduces — that a validator-set rotation *)
+(* can never retroactively invalidate a certificate decided under a prior *)
+(* epoch ("Lane 1 commits act as epoch fences for Lane 0 certificate      *)
+(* validity", ADR-025 Consequences). This corresponds directly to         *)
+(* `lane0::CertificateStore::rotate_validators` in `substrate/src/lane0.rs`.*)
+(***************************************************************************)
+
+CONSTANTS Nodes,         \* Set of node identifiers (validators are a subset)
+          InitialActive, \* The boot Lane 0 validator set (epoch 0)
+          EventId,       \* Set of abstract Lane 0 event identifiers
+          MaxEpoch        \* Bound on rotations explored (state-space control)
+
+ASSUME InitialActive \subseteq Nodes /\ InitialActive # {}
+ASSUME MaxEpoch \in Nat
+
+(***************************************************************************)
+(* Per-node state:                                                         *)
+(*   acks[n][eid]      — the set of validators whose ack for `eid` node n  *)
+(*                        has locally recorded (G-Set: grows via AckEvent  *)
+(*                        and GossipMerge; only shrinks via RotateEpoch,   *)
+(*                        which drops acks from validators no longer in    *)
+(*                        the active set — see `PendingAcksAreCurrentMembers`*)
+(*                        below).                                          *)
+(*   finalized[n]      — the set of event ids node n considers Lane        *)
+(*                        0-final (G-Set: grows via FinalizeIfQuorum only, *)
+(*                        NEVER shrinks — see `EpochFenceMonotone`).       *)
+(*                                                                         *)
+(* Global state (see the header comment for why these are global rather   *)
+(* than per-node — they represent facts already agreed by Lane 1):        *)
+(*   active             — the currently active Lane 0 validator set.       *)
+(*   epoch              — number of rotations applied so far.              *)
+(***************************************************************************)
+VARIABLES acks, finalized, active, epoch
+
+vars == <<acks, finalized, active, epoch>>
+
+TypeOK == /\ acks \in [Nodes -> [EventId -> SUBSET Nodes]]
+          /\ finalized \in [Nodes -> SUBSET EventId]
+          /\ active \subseteq Nodes
+          /\ active # {}
+          /\ epoch \in Nat
+
+\* BFT-style supermajority over the CURRENT active set: strictly more than
+\* 2/3 of the active validator count. Mirrors `ValidatorSet::is_quorum` in
+\* lane0.rs, specialized to equal-weight validators (see Known Limitations
+\* in the formal-verification README).
+Quorum(S) == Cardinality(S) * 3 > Cardinality(active) * 2
+
+Init == /\ acks = [n \in Nodes |-> [eid \in EventId |-> {}]]
+        /\ finalized = [n \in Nodes |-> {}]
+        /\ active = InitialActive
+        /\ epoch = 0
+
+(***************************************************************************)
+(* A validator `n` (honest or Byzantine — a Byzantine node still holds a   *)
+(* real signing key, so it CAN produce a validly-signed ack; the protocol  *)
+(* tolerates this by requiring a supermajority, not unanimity) acks event  *)
+(* `eid`, recording its own ack in its own local certificate first — this  *)
+(* mirrors `Substrate::lane0_ack_inserted`'s "fold locally first, then     *)
+(* broadcast" order. Only current members of `active` can produce an ack  *)
+(* that counts; this mirrors `CertificateStore::add_ack` rejecting acks   *)
+(* from public keys outside the configured validator set.                 *)
+(***************************************************************************)
+AckEvent(n, eid) ==
+    /\ n \in active
+    /\ acks' = [acks EXCEPT ![n][eid] = @ \cup {n}]
+    /\ UNCHANGED <<finalized, active, epoch>>
+
+(***************************************************************************)
+(* Gossip dissemination: node n2 merges node n1's locally known ack set    *)
+(* for `eid` into its own. Union is the G-Set merge — commutative,         *)
+(* associative, idempotent, so delivery order and duplication are          *)
+(* harmless (mirrors `CertificateStore::add_ack`'s duplicate-is-a-no-op    *)
+(* behavior and the CRDT convergence proofs in `OmniaCRDT.tla`).           *)
+(***************************************************************************)
+GossipMerge(n1, n2, eid) ==
+    /\ n1 # n2
+    /\ acks' = [acks EXCEPT ![n2][eid] = @ \cup acks[n1][eid]]
+    /\ UNCHANGED <<finalized, active, epoch>>
+
+(***************************************************************************)
+(* Node `n` observes that its locally accumulated acks for `eid` — always  *)
+(* a subset of the CURRENT active set, see `PendingAcksAreCurrentMembers`  *)
+(* — now form a quorum, and finalizes. The `\cap active` is defensive      *)
+(* (the invariant already guarantees it is a no-op) rather than load-      *)
+(* bearing, matching the defense-in-depth style already used elsewhere in  *)
+(* the codebase (e.g. gossip.rs's belt-and-suspenders payload-size check). *)
+(***************************************************************************)
+FinalizeIfQuorum(n, eid) ==
+    /\ eid \notin finalized[n]
+    /\ Quorum(acks[n][eid] \cap active)
+    /\ finalized' = [finalized EXCEPT ![n] = @ \cup {eid}]
+    /\ UNCHANGED <<acks, active, epoch>>
+
+(***************************************************************************)
+(* RotateEpoch — the epoch fence. Abstracts a Lane 1 (DAG-consensus)       *)
+(* committed validator-set-change event, applied atomically and            *)
+(* identically at every node (see the header comment for why that is a    *)
+(* sound abstraction).                                                     *)
+(*                                                                         *)
+(* Mirrors `CertificateStore::rotate_validators` exactly:                 *)
+(*   - Already-finalized event ids are UNTOUCHED at every node — finality *)
+(*     survives the rotation regardless of who is in the new set. This is *)
+(*     the monotonicity guarantee `EpochFenceMonotone` checks below.       *)
+(*   - For every still-pending event id, acks from validators that are    *)
+(*     not members of the new set are dropped; acks from validators that  *)
+(*     remain members are kept. (A subsequent `FinalizeIfQuorum` step may *)
+(*     then immediately become enabled if the retained acks already meet  *)
+(*     quorum under the new set — this module models that as two separate*)
+(*     actions rather than one atomic step, which is a strictly WEAKER    *)
+(*     synchrony assumption than the real single-function-call Rust       *)
+(*     implementation, so it cannot hide a bug the real code doesn't have.)*)
+(***************************************************************************)
+RotateEpoch(newActive) ==
+    /\ newActive \subseteq Nodes
+    /\ newActive # {}
+    /\ newActive # active
+    /\ epoch < MaxEpoch
+    /\ active' = newActive
+    /\ epoch' = epoch + 1
+    /\ acks' = [n \in Nodes |-> [eid \in EventId |->
+                  IF eid \in finalized[n]
+                  THEN acks[n][eid]
+                  ELSE acks[n][eid] \cap newActive]]
+    /\ UNCHANGED finalized
+
+Next == \/ \E n \in Nodes, eid \in EventId: AckEvent(n, eid)
+        \/ \E n1 \in Nodes, n2 \in Nodes, eid \in EventId: GossipMerge(n1, n2, eid)
+        \/ \E n \in Nodes, eid \in EventId: FinalizeIfQuorum(n, eid)
+        \/ \E newActive \in SUBSET Nodes: RotateEpoch(newActive)
+
+Spec == Init /\ [][Next]_vars
+
+\* State-space bound for TLC (mirrors OmniaConsensus.tla's MaxSeq role).
+StateConstraint == epoch <= MaxEpoch
+
+FairSpec == Spec
+            /\ \A n \in Nodes, eid \in EventId: WF_vars(AckEvent(n, eid))
+            /\ \A n1 \in Nodes, n2 \in Nodes, eid \in EventId: WF_vars(GossipMerge(n1, n2, eid))
+            /\ \A n \in Nodes, eid \in EventId: WF_vars(FinalizeIfQuorum(n, eid))
+
+(***************************************************************************)
+(* SAFETY (headline property): every ack counted toward a PENDING          *)
+(* certificate belongs to the CURRENTLY active validator set. This is the  *)
+(* soundness half of epoch fencing — a rotation can never let a stale ack  *)
+(* from a since-removed validator sneak a certificate over quorum.         *)
+(* Finalized certificates are explicitly exempt (see RotateEpoch above):   *)
+(* they are frozen, not re-evaluated, which is the other half of the       *)
+(* fence (see `EpochFenceMonotone`).                                       *)
+(***************************************************************************)
+PendingAcksAreCurrentMembers ==
+    \A n \in Nodes, eid \in EventId:
+        eid \notin finalized[n] => acks[n][eid] \subseteq active
+
+(***************************************************************************)
+(* SAFETY (temporal property): `finalized[n]` never shrinks, for any node, *)
+(* under any action — including RotateEpoch. This is the exact claim in    *)
+(* ADR-025's Consequences: "Lane 1 commits act as epoch fences for Lane 0  *)
+(* certificate validity" — once decided, a Lane 0 certificate's finality   *)
+(* is permanent, independent of how many validator-set rotations follow.  *)
+(***************************************************************************)
+EpochFenceMonotone == [][\A n \in Nodes: finalized[n] \subseteq finalized'[n]]_vars
+
+=======================================================================================

--- a/formal-verification/README.md
+++ b/formal-verification/README.md
@@ -2,8 +2,8 @@
 
 This directory contains TLA+ specifications that model the Omnia consensus protocol and its CRDT convergence properties, verifying safety and liveness through exhaustive state-space exploration using the TLC model checker.
 
-**Version:** v0.1.68
-**Last Updated:** 2026-03-05
+**Version:** v0.1.76
+**Last Updated:** 2026-07-12
 
 ## Protocol Model
 
@@ -207,6 +207,74 @@ The `OmniaCRDT.tla` spec (213 lines) formally verifies the convergence propertie
 
 **Note:** The `OmniaCRDT.cfg` model checker configuration file exists and configures TLC with `Nodes = {n1, n2, n3}`, `MaxVal = 3`, `Elements = {e1, e2}`, and `MaxTags = 3`, verifying invariants `TypeOK_GCounter`, `TypeOK_OrSet`, `TypeOK_LWW`, `GCounterConvergence`, `LWWConvergence`, and properties `GCounterCommutative`, `GCounterIdempotent`, `GCounterFinalConvergence`.
 
+## Two-Lane Extension (ADR-025 Stage 4)
+
+`OmniaTwoLane.tla` extends verification to the cross-lane safety property
+introduced by [ADR-025](../docs/adr/ADR-025-two-lane-consensus.md): Lane 0
+(consensusless UBC fast path, `substrate/src/lane0.rs`) and Lane 1 (the DAG
+commit rule modeled above) share one substrate, and a Lane 1-committed
+validator-set change must not be able to retroactively invalidate a Lane 0
+certificate that already reached finality under the prior set — "Lane 1
+commits act as epoch fences for Lane 0 certificate validity" (ADR-025,
+Consequences).
+
+Rather than re-modeling Lane 1's fame/commit machinery a second time, the
+new module **composes** with `OmniaConsensus.tla`: a Lane 1-committed
+validator-set-change event is abstracted as `RotateEpoch`, a single atomic
+action applied identically to every node. That abstraction is sound
+precisely because `Agreement` (above) already guarantees every honest node
+computes the same committed order — see the module's header comment for
+the full reduction argument.
+
+### What it models
+
+- **Lane 0 certificates as a G-Set CRDT**: `acks[node][event]` accumulates
+  monotonically via `AckEvent` (self-ack) and `GossipMerge` (union merge —
+  commutative, associative, idempotent), mirroring `CertificateStore::add_ack`.
+- **`RotateEpoch`**: mirrors `CertificateStore::rotate_validators` exactly —
+  already-finalized certificates are untouched; pending certificates are
+  re-evaluated against the new active set, dropping acks from validators no
+  longer members (and immediately finalizing if the retained acks already
+  meet quorum under the new set).
+- **`FinalizeIfQuorum`**: a node finalizes once its locally accumulated acks
+  for an event reach a supermajority of the *current* active set.
+
+### Properties verified (by construction; TLC run pending — see below)
+
+| Property | Type | Meaning |
+| --- | --- | --- |
+| `TypeOK` | Invariant | Well-typedness of all state variables |
+| `PendingAcksAreCurrentMembers` | Invariant | Every ack counted toward a **pending** certificate belongs to the currently active validator set — a rotation can never let a stale ack from a since-removed validator sneak a certificate over quorum |
+| `EpochFenceMonotone` | Temporal (safety) | `finalized[n]` never shrinks under any action, including `RotateEpoch` — the exact "epoch fence" claim: once decided, a Lane 0 certificate's finality is permanent regardless of how many validator-set rotations follow |
+
+Both properties were checked by manual inductive proof against the action
+definitions while writing the spec (documented inline in
+`OmniaTwoLane.tla`), following the same reasoning style as this file's
+`Agreement`/`NoEquivocation` write-ups. **TLC has not yet been run against
+this module in the environment this was authored in** (no local
+`tla2tools.jar` available) — run it with the same CLI recipe as
+`OmniaConsensus.tla` above, substituting `OmniaTwoLane.tla`/`OmniaTwoLane.cfg`,
+before relying on this as a completed verification pass.
+
+### Known limitations (in addition to the shared ones below)
+
+- **Equal-weight validators**: stake is abstracted to one unit per
+  validator (count-based supermajority), matching how `OmniaConsensus.tla`
+  already abstracts its own BFT quorum. The real `ValidatorSet` in
+  `lane0.rs` is heterogeneously stake-weighted; the rotation algorithm
+  (retain-then-recompute) is identical either way, so this does not change
+  which property is being tested.
+- **`RotateEpoch` is global, not per-node**: justified by composition with
+  `Agreement` (see above) rather than modeled from scratch — this module
+  does not re-verify that all nodes agree on *when* a rotation happens,
+  only that *given* they do, Lane 0 finality stays sound and monotone.
+- **Two-step finalize-after-rotate**: the real `rotate_validators` performs
+  the retain-and-immediately-finalize check atomically in one function
+  call; the spec models this as two separate actions (`RotateEpoch` then
+  `FinalizeIfQuorum`). This is a strictly weaker synchrony assumption than
+  the real code provides, so it cannot mask a bug the implementation
+  doesn't have.
+
 ## Known Limitations
 
 | Limitation                  | Details                                                                                                                        |
@@ -253,6 +321,8 @@ The model exceeds available memory. Remediation:
 | `OmniaConsensus.cfg`          | 10    | TLC model checker configuration for consensus                                                                                                                        |
 | `OmniaCRDT.tla`               | 213   | TLA+ specification of CRDT convergence properties (GCounter, OrSet, LWWRegister)                                                                                     |
 | `OmniaCRDT.cfg`               | 23    | TLC model checker configuration for CRDT verification                                                                                                                |
+| `OmniaTwoLane.tla`            | —     | ADR-025 Stage 4: Lane 0 G-Set certificate CRDT + epoch-fenced validator rotation, composed with `OmniaConsensus.tla`'s `Agreement`                                    |
+| `OmniaTwoLane.cfg`            | —     | TLC model checker configuration for the two-lane extension                                                                                                            |
 | `consensus/CONSENSUS_SPEC.md` | —     | English-language formal specification: fault model, DAG structure, famousness algorithm, commitment rule, safety argument, liveness argument (A-2 audit fix v0.1.68) |
 | `README.md`                   | —     | This documentation                                                                                                                                                   |
 
@@ -264,3 +334,4 @@ The chaos testing framework (`omnia-chaos-tests`) provides executable validation
 - **Liveness** (`ChaosNetwork::check_liveness()`) verifies at least some events are committed — corresponds to the TLA+ `Liveness` property
 - **Slashing** (`ChaosNetwork::is_node_slashed()`) verifies equivocation detection — corresponds to the TLA+ `NoEquivocation` invariant
 - **Network partitions** (`ChaosNetwork::partition()` / `heal()`) test scenarios not modeled in TLA+
+- **Lane 0 epoch fencing** (`substrate/src/lane0.rs`, `CertificateStore::rotate_validators` tests) provides executable validation of `OmniaTwoLane.tla`'s `PendingAcksAreCurrentMembers` and `EpochFenceMonotone` — see `test_rotate_validators_preserves_finalized_monotone` and `test_rotate_validators_drops_nonmember_acks`

--- a/node/src/api/node.rs
+++ b/node/src/api/node.rs
@@ -61,11 +61,15 @@ pub async fn node_info(State(state): State<AppState>) -> Json<Value> {
         .map(|k| hex::encode(k.verifying_key().to_bytes()));
     let lane0 = {
         let substrate = state.substrate.read().await;
+        let epoch = substrate.lane0_epoch();
         substrate.lane0_stats().map(|(accepted, rejected, finalized)| {
             json!({
                 "acks_accepted": accepted,
                 "acks_rejected": rejected,
                 "events_finalized": finalized,
+                // Number of validator-set rotations applied (ADR-025
+                // Stage 4). 0 = original operator-configured set.
+                "epoch": epoch,
             })
         })
     };

--- a/substrate/src/lane0.rs
+++ b/substrate/src/lane0.rs
@@ -21,14 +21,20 @@
 //!    event is Lane 0-final. Finality is monotone — once final, always
 //!    final.
 //!
-//! # Validator set (v1: static)
+//! # Validator set (v1: operator-configured boot set; v2: epoch-fenced rotation)
+//!
+//! The validator set starts operator-configured via `OMNIA_LANE0_VALIDATORS`
+//! — a comma-separated list of `hex64_ed25519_pubkey:stake` entries. When
+//! the variable is unset or empty, Lane 0 is **disabled** and this module
+//! is inert (no acks signed, published, or accepted).
 //!
 //! ADR-025 routes validator-set *changes* through Lane 1 (they are
-//! contested, shared-state operations). Until Lane 1 lands, the validator
-//! set is operator-configured via `OMNIA_LANE0_VALIDATORS` — a
-//! comma-separated list of `hex64_ed25519_pubkey:stake` entries. When the
-//! variable is unset or empty, Lane 0 is **disabled** and this module is
-//! inert (no acks signed, published, or accepted).
+//! contested, shared-state operations): the set is contested, so its
+//! definition of truth cannot be a Lane 0 decision. [`CertificateStore::rotate_validators`]
+//! is the epoch-fencing primitive that lets a Lane-1-committed validator-set
+//! change safely replace the active set — see that method's docs for the
+//! monotonicity guarantee (a certificate finalized under one epoch's set
+//! stays final forever, regardless of later rotations).
 //!
 //! # Bounded memory
 //!
@@ -316,6 +322,8 @@ pub struct CertificateStore {
     acks_rejected: u64,
     /// Total events finalized through Lane 0.
     events_finalized: u64,
+    /// Number of validator-set rotations applied (see [`Self::rotate_validators`]).
+    epoch: u64,
 }
 
 impl CertificateStore {
@@ -381,6 +389,94 @@ impl CertificateStore {
         } else {
             Ok(AckOutcome::Recorded)
         }
+    }
+
+    /// Apply a validator-set rotation (ADR-025 Stage 4 epoch fence).
+    ///
+    /// MUST be called identically, at the identical logical point in the
+    /// causal graph, by every honest node — i.e., driven by a Lane 1
+    /// (DAG-consensus-committed) validator-set-change event. Because
+    /// commit order is agreed by the DAG commit rule, every honest node
+    /// applies the same rotation with the same `new_validators` at the
+    /// same point, so the outcome is deterministic and independent of
+    /// gossip/ack delivery order.
+    ///
+    /// # Monotonicity
+    ///
+    /// Already-finalized certificates are **never** re-evaluated:
+    /// finality is permanent regardless of how many rotations follow, so
+    /// a Lane 0 certificate stays valid forever once decided, even after
+    /// the validator set that decided it has since changed.
+    ///
+    /// Pending (not-yet-final) certificates are re-evaluated against
+    /// `new_validators`:
+    /// - Acks from validators that are not members of the new set are
+    ///   dropped — their stake no longer counts toward quorum.
+    /// - Acks from validators that remain members keep their ack, now
+    ///   weighted by the **new** set's stake for that validator.
+    /// - If the recomputed stake now meets `new_validators.is_quorum(..)`,
+    ///   the certificate is immediately finalized. This is deterministic,
+    ///   so every honest node reaches the same conclusion for the same
+    ///   rotation.
+    ///
+    /// Returns the event IDs that became newly final as a direct result
+    /// of the rotation (empty in the common case), in ascending order.
+    pub fn rotate_validators(&mut self, new_validators: &ValidatorSet) -> Vec<EventId> {
+        self.epoch += 1;
+        let mut newly_final = Vec::new();
+
+        // Deterministic evaluation order: HashMap iteration order is not
+        // itself relevant to the outcome (each certificate is evaluated
+        // independently), but the returned Vec's order should be stable
+        // for callers that broadcast finality.
+        let mut event_ids: Vec<EventId> = self.pending.keys().copied().collect();
+        event_ids.sort();
+
+        for event_id in event_ids {
+            let Some(cert) = self.pending.get_mut(&event_id) else {
+                continue;
+            };
+            let mut acked_stake: u64 = 0;
+            cert.acks.retain(|pubkey, _| match new_validators.stake_of(pubkey) {
+                Some(stake) => {
+                    acked_stake = acked_stake.saturating_add(stake);
+                    true
+                }
+                None => false,
+            });
+            cert.acked_stake = acked_stake;
+
+            if new_validators.is_quorum(acked_stake) {
+                self.pending.remove(&event_id);
+                self.finalized.insert(event_id);
+                self.finalized_order.push_back(event_id);
+                self.events_finalized += 1;
+                newly_final.push(event_id);
+            }
+        }
+
+        if !newly_final.is_empty() {
+            // One-pass cleanup of pending_order rather than a retain per
+            // finalized event — avoids O(n^2) when a single rotation
+            // finalizes many certificates at once.
+            let finalized_now: HashSet<EventId> = newly_final.iter().copied().collect();
+            self.pending_order.retain(|id| !finalized_now.contains(id));
+        }
+
+        while self.finalized.len() > MAX_FINALIZED_EVENTS {
+            if let Some(evicted) = self.finalized_order.pop_front() {
+                self.finalized.remove(&evicted);
+            } else {
+                break;
+            }
+        }
+
+        newly_final
+    }
+
+    /// Number of validator-set rotations applied so far (0 = original set).
+    pub fn epoch(&self) -> u64 {
+        self.epoch
     }
 
     /// Whether an event has reached Lane 0 finality.
@@ -618,5 +714,108 @@ mod tests {
             store.add_ack(SignedAck::sign(eid(1), &key), &set).unwrap(),
             AckOutcome::NewlyFinal
         );
+    }
+
+    // ── Stage 4: epoch-fenced validator rotation ────────────────────────
+
+    #[test]
+    fn test_rotate_validators_preserves_finalized_monotone() {
+        // An event finalized under the old set must stay final forever,
+        // even when the new set shares no members with the old one.
+        let (keys, old_set) = three_validators();
+        let mut store = CertificateStore::new();
+        let id = eid(1);
+        for k in &keys {
+            let _ = store.add_ack(SignedAck::sign(id, k), &old_set);
+        }
+        assert!(store.is_final(&id));
+
+        let (_new_keys, new_set) = three_validators(); // disjoint validator set
+        let newly_final = store.rotate_validators(&new_set);
+
+        assert!(newly_final.is_empty(), "already-final events are not re-announced");
+        assert!(store.is_final(&id), "finality must survive a validator-set rotation");
+        assert_eq!(store.epoch(), 1);
+    }
+
+    #[test]
+    fn test_rotate_validators_drops_nonmember_acks() {
+        // A pending cert with 2/3 acks under the old set: rotating to a
+        // set that excludes one acker must drop that ack's stake.
+        let (keys, old_set) = three_validators();
+        let mut store = CertificateStore::new();
+        let id = eid(1);
+        store.add_ack(SignedAck::sign(id, &keys[0]), &old_set).unwrap();
+        store.add_ack(SignedAck::sign(id, &keys[1]), &old_set).unwrap();
+        assert_eq!(store.certificate(&id).unwrap().acked_stake(), 2);
+        assert!(!store.is_final(&id));
+
+        // New set: only keys[0] carries over, plus two new validators.
+        let extra: Vec<NodeKeypair> = (0..2).map(|_| generate_keypair()).collect();
+        let new_set = ValidatorSet::new(
+            std::iter::once((keys[0].verifying_key().to_bytes(), 1))
+                .chain(extra.iter().map(|k| (k.verifying_key().to_bytes(), 1))),
+        )
+        .unwrap();
+
+        let newly_final = store.rotate_validators(&new_set);
+        assert!(newly_final.is_empty());
+        assert!(!store.is_final(&id));
+        // Only keys[0]'s ack survives; keys[1]'s stake is dropped.
+        assert_eq!(store.certificate(&id).unwrap().acked_stake(), 1);
+        assert_eq!(store.certificate(&id).unwrap().ack_count(), 1);
+    }
+
+    #[test]
+    fn test_rotate_validators_can_immediately_finalize() {
+        // A pending cert with acks that don't reach quorum under the old
+        // (larger) set can cross quorum immediately upon rotating to a
+        // smaller set where the surviving acks are now a supermajority.
+        let (keys, old_set) = three_validators(); // quorum = 3 of 3
+        let mut store = CertificateStore::new();
+        let id = eid(1);
+        // Only 1 of 3 acked under the old set — nowhere near quorum.
+        store.add_ack(SignedAck::sign(id, &keys[0]), &old_set).unwrap();
+        assert!(!store.is_final(&id));
+
+        // New set: just the one validator that already acked.
+        let new_set = ValidatorSet::new([(keys[0].verifying_key().to_bytes(), 1)]).unwrap();
+        let newly_final = store.rotate_validators(&new_set);
+
+        assert_eq!(newly_final, vec![id]);
+        assert!(store.is_final(&id));
+    }
+
+    #[test]
+    fn test_rotate_validators_deterministic_ascending_order() {
+        // When a rotation finalizes multiple certificates at once, the
+        // returned Vec must be in ascending EventId order so callers get
+        // a stable, reproducible result.
+        let key = generate_keypair();
+        let old_set = ValidatorSet::new([(key.verifying_key().to_bytes(), 1), ([0xFF; 32], 1)]).unwrap();
+        let mut store = CertificateStore::new();
+
+        let ids = [eid(3), eid(1), eid(2)];
+        for id in ids {
+            store.add_ack(SignedAck::sign(id, &key), &old_set).unwrap();
+        }
+
+        // New set: just this one validator — every pending cert now has
+        // a lone quorum-crossing ack.
+        let new_set = ValidatorSet::new([(key.verifying_key().to_bytes(), 1)]).unwrap();
+        let newly_final = store.rotate_validators(&new_set);
+
+        assert_eq!(newly_final, vec![eid(1), eid(2), eid(3)]);
+    }
+
+    #[test]
+    fn test_rotate_validators_epoch_increments_even_with_no_pending() {
+        let (_keys, set) = three_validators();
+        let mut store = CertificateStore::new();
+        assert_eq!(store.epoch(), 0);
+        store.rotate_validators(&set);
+        assert_eq!(store.epoch(), 1);
+        store.rotate_validators(&set);
+        assert_eq!(store.epoch(), 2);
     }
 }

--- a/substrate/src/lib.rs
+++ b/substrate/src/lib.rs
@@ -1099,6 +1099,52 @@ impl Substrate {
         self.lane0_validators.as_ref().map(|_| self.lane0_store.stats())
     }
 
+    /// Number of Lane 0 validator-set rotations applied so far (0 =
+    /// original set, never rotated), or `None` when Lane 0 is disabled.
+    pub fn lane0_epoch(&self) -> Option<u64> {
+        self.lane0_validators.as_ref().map(|_| self.lane0_store.epoch())
+    }
+
+    /// Rotate the Lane 0 validator set (ADR-025 Stage 4: Lane 1 commits as
+    /// epoch fences for Lane 0 certificate validity).
+    ///
+    /// # Caller obligation
+    ///
+    /// This method must be invoked identically — same `new_validators`,
+    /// same logical point in the causal graph — by every honest node.
+    /// The only source of that agreement is a **Lane 1 (DAG-consensus
+    /// committed) event**: because the commit rule guarantees all honest
+    /// nodes compute the same committed order (the `Agreement` property
+    /// in `formal-verification/OmniaConsensus.tla`), a validator-set
+    /// change carried by a committed event and applied here at commit
+    /// time is applied identically everywhere. Calling this from
+    /// anything other than committed-event processing (e.g. from a
+    /// not-yet-finalized event, or from operator input) breaks that
+    /// guarantee and can fork Lane 0 finality across nodes.
+    ///
+    /// See [`lane0::CertificateStore::rotate_validators`] for the
+    /// monotonicity guarantee: certificates already final under the old
+    /// set stay final; pending certificates are re-evaluated against the
+    /// new set and may finalize immediately.
+    ///
+    /// No-op (returns an empty `Vec`) if Lane 0 was never enabled via
+    /// [`Self::init_lane0`] — a rotation with nothing to rotate.
+    pub fn rotate_lane0_validators(&mut self, new_validators: lane0::ValidatorSet) -> Vec<EventId> {
+        if self.lane0_validators.is_none() {
+            return Vec::new();
+        }
+        let newly_final = self.lane0_store.rotate_validators(&new_validators);
+        tracing::info!(
+            epoch = self.lane0_store.epoch(),
+            validators = new_validators.len(),
+            total_stake = new_validators.total_stake(),
+            newly_final = newly_final.len(),
+            "Lane 0 validator set rotated"
+        );
+        self.lane0_validators = Some(new_validators);
+        newly_final
+    }
+
     /// Sign Lane 0 acks for freshly inserted events, fold them into the
     /// local certificate store, and queue them for broadcast.
     ///
@@ -1433,6 +1479,49 @@ mod tests {
         let stats = substrate.stats().await;
         assert_eq!(stats.graph.total_events, 0);
         assert!(!stats.running);
+    }
+
+    #[test]
+    fn test_rotate_lane0_validators_noop_when_disabled() {
+        let config = SubstrateConfig::new(test_node(1));
+        let mut substrate = Substrate::new(config);
+        assert_eq!(substrate.lane0_epoch(), None);
+
+        let key = generate_keypair();
+        let set = lane0::ValidatorSet::new([(key.verifying_key().to_bytes(), 1)]).expect("valid set");
+        let newly_final = substrate.rotate_lane0_validators(set);
+
+        assert!(newly_final.is_empty());
+        assert_eq!(
+            substrate.lane0_epoch(),
+            None,
+            "rotation must stay a no-op until Lane 0 is enabled via init_lane0"
+        );
+    }
+
+    #[test]
+    fn test_rotate_lane0_validators_delegates_and_tracks_epoch() {
+        let config = SubstrateConfig::new(test_node(1));
+        let mut substrate = Substrate::new(config);
+
+        let key1 = generate_keypair();
+        let initial = lane0::ValidatorSet::new([(key1.verifying_key().to_bytes(), 1)]).expect("valid set");
+        substrate.init_lane0(initial);
+        assert_eq!(substrate.lane0_epoch(), Some(0));
+
+        let key2 = generate_keypair();
+        let rotated = lane0::ValidatorSet::new([(key2.verifying_key().to_bytes(), 1)]).expect("valid set");
+        substrate.rotate_lane0_validators(rotated);
+
+        assert_eq!(
+            substrate.lane0_epoch(),
+            Some(1),
+            "epoch must advance on every rotation, even with no pending certificates"
+        );
+        assert!(
+            substrate.lane0_stats().is_some(),
+            "Lane 0 must remain enabled after rotation"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

Lands the safety-critical piece of ADR-025 Stage 4 that was explicitly flagged as missing in the ADR's Consequences section:

> Cross-lane interactions ... need explicit sequencing rules — Lane 1 commits act as epoch fences for Lane 0 certificate validity.

Until now, Lane 0's validator set (`substrate/src/lane0.rs`) was fixed for the process lifetime — operator-configured once via `OMNIA_LANE0_VALIDATORS` at boot, with no way to change it without a restart. This PR adds the rotation primitive and the formal model proving it's safe.

### Rust: epoch-fenced rotation

- **`CertificateStore::rotate_validators(&mut self, new_validators: &ValidatorSet) -> Vec<EventId>`** — deterministically re-evaluates every pending (not-yet-final) certificate against the new set:
  - Acks from validators no longer in the set are dropped; their stake stops counting toward quorum.
  - Acks from validators that remain are kept, now weighted by the new set's stake for them.
  - If the retained acks already meet quorum under the new set, the certificate finalizes immediately.
  - **Already-finalized certificates are never touched** — finality is permanent, independent of how many rotations follow.
- **`Substrate::rotate_lane0_validators(&mut self, new_validators)`** — the integration point. Its doc comment is explicit about the caller obligation: this must be invoked identically (same `new_validators`, same logical point) by every honest node, which only a **Lane 1 (DAG-consensus committed) event** can guarantee — that's what makes a rotation an epoch *fence* rather than a race between nodes.
- `node_info`'s `lane0` block now reports the current epoch for operators.

### TLA+: `formal-verification/OmniaTwoLane.tla`

Rather than re-modeling Lane 1's fame/commit machinery a second time, the new spec **composes** with `OmniaConsensus.tla`: a Lane 1-committed validator-set-change is abstracted as `RotateEpoch`, a single atomic action applied identically to every node — sound precisely because `OmniaConsensus.tla`'s already-proven `Agreement` invariant guarantees that identical-application property.

It models Lane 0 certificates as a G-Set CRDT (`AckEvent`, `GossipMerge`) and checks:
- **`PendingAcksAreCurrentMembers`** (invariant) — every ack counted toward a pending certificate belongs to the currently active set; a rotation can never let a stale ack from a removed validator sneak a certificate over quorum.
- **`EpochFenceMonotone`** (temporal safety property) — `finalized` never shrinks under any action, including rotation.

Both were checked by manual inductive proof against the action definitions (documented inline). **TLC has not been run against this module in this environment** (no local `tla2tools.jar` available here) — the README says so plainly and gives the same CLI recipe used for the existing specs so it can be run before treating this as a completed verification pass.

### Explicitly out of scope

Wiring a governance proposal type that actually *calls* `rotate_lane0_validators` (i.e., a full validator-set-change execution path through the governance shard) is left for follow-up. This PR lands the safety primitive and its formal model — the same incremental scoping Stage 3 used (ship the mechanism statically-configured first, dynamic triggering after).

## Testing

- `cargo fmt --all --check`
- `cargo clippy --lib --workspace --exclude omnia-fuzz -- -D warnings -D clippy::unwrap_used`
- `cargo clippy --all-targets --workspace --exclude omnia-fuzz -- -D clippy::unwrap_used`
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace --exclude omnia-fuzz`
- `cargo test -p omnia-substrate --lib` — 76/76 pass, incl. 6 new `lane0::tests::test_rotate_validators_*` (monotonicity, non-member ack dropping, immediate finalization on rotation, deterministic ordering, epoch counting) and 2 new `Substrate`-level wrapper tests
- `cargo test -p omnia-node --lib` — 60/60 pass
- `cargo build -p omnia-node --tests` — integration tests still compile clean