### PR TITLE
feat(node): wallet-signed self-sovereign spend authorization (Step 2)

### DIFF
--- a/node/src/api/economics.rs
+++ b/node/src/api/economics.rs
@@ -24,6 +24,13 @@ use crate::state::{AppState, TransferRecord};
 /// operation and is self-identifying to future decoders.
 const TRANSFER_PAYLOAD_TAG: &[u8] = b"OMNIA_XFER_V1";
 
+/// Wire prefix for **wallet-signed** transfer receipts (spend
+/// authorization Step 2). The v2 payload embeds the wallet's public key,
+/// the consumed nonce, and the Ed25519 signature over the canonical
+/// transfer message, so the spend authorization itself is on-chain —
+/// anyone can re-verify that the key owner, not the node, authorized it.
+const TRANSFER_PAYLOAD_TAG_V2: &[u8] = b"OMNIA_XFER_V2";
+
 /// On-chain provenance record for a UBC transfer, embedded (tagged +
 /// postcard-encoded) in the payload of a causal-graph event.
 ///
@@ -46,6 +53,31 @@ fn encode_transfer_payload(p: &TransferEventPayload) -> Vec<u8> {
     let mut bytes = TRANSFER_PAYLOAD_TAG.to_vec();
     // postcard encoding of a small struct is infallible in practice; on the
     // impossible error, fall back to just the tag (an empty-body receipt).
+    if let Ok(body) = postcard::to_allocvec(p) {
+        bytes.extend(body);
+    }
+    bytes
+}
+
+/// On-chain provenance record for a **wallet-signed** transfer (v2).
+///
+/// Extends the v1 receipt with the self-sovereign authorization proof:
+/// the wallet's Ed25519 public key, the single-use nonce it consumed, and
+/// its signature over [`crate::api::wallet_auth::transfer_message`]
+/// `(nonce, from_did, to_did, amount)`. `from_did` is derived from
+/// `wallet_pubkey`, so the receipt is self-verifying.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+struct SignedTransferEventPayload {
+    transfer: TransferEventPayload,
+    wallet_pubkey: [u8; 32],
+    nonce: String,
+    /// 64-byte Ed25519 signature (Vec because serde lacks `[u8; 64]` impls).
+    signature: Vec<u8>,
+}
+
+/// Encode a wallet-signed transfer receipt as `TAG_V2 ++ postcard(payload)`.
+fn encode_signed_transfer_payload(p: &SignedTransferEventPayload) -> Vec<u8> {
+    let mut bytes = TRANSFER_PAYLOAD_TAG_V2.to_vec();
     if let Ok(body) = postcard::to_allocvec(p) {
         bytes.extend(body);
     }
@@ -96,6 +128,33 @@ pub struct TransferRequest {
     pub to_did: String,
     /// Amount of UBC to spend.
     pub amount: u64,
+    /// Optional wallet-signed spend authorization (Step 2, self-sovereign
+    /// transfers). When present, the node verifies the wallet's own
+    /// Ed25519 signature over the transfer before spending — the node
+    /// merely attests receipt; the *key owner* authorizes the spend.
+    /// When absent, the transfer is authorized by the JWT alone
+    /// (node-attested, the v1 behavior — kept for deployed clients).
+    #[serde(default)]
+    pub authorization: Option<TransferAuthorization>,
+}
+
+/// Wallet-signed spend authorization attached to a [`TransferRequest`].
+///
+/// Flow: the wallet requests a nonce from `POST /api/v1/auth/challenge`
+/// (with its public key), signs the canonical transfer message
+/// (`omnia-transfer-v1\n<nonce>\n<from_did>\n<to_did>\n<amount>`, where
+/// `from_did` is derived from the public key), and attaches all three
+/// fields here. The nonce is single-use — a captured authorization
+/// cannot be replayed.
+#[derive(Debug, Clone, Deserialize, ToSchema)]
+pub struct TransferAuthorization {
+    /// Hex-encoded 32-byte Ed25519 public key of the spending wallet.
+    pub public_key: String,
+    /// The single-use nonce obtained from `/auth/challenge`.
+    pub nonce: String,
+    /// Hex-encoded 64-byte Ed25519 signature over the canonical
+    /// transfer message.
+    pub signature: String,
 }
 
 /// Handler for `GET /api/v1/economics/balance/:did`.
@@ -186,6 +245,83 @@ pub async fn transfer_ubc(
         );
     }
 
+    // The canonical transfer message is newline-delimited; a DID
+    // containing control characters could forge field boundaries. Reject
+    // them outright (also plain hygiene for the unsigned path).
+    if body.to_did.chars().any(char::is_control) || from_did.chars().any(char::is_control) {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(json!({"error": "DIDs must not contain control characters"})),
+        ));
+    }
+
+    // Step 2 (self-sovereign spend): when a wallet-signed authorization is
+    // attached, verify it BEFORE any state change. The signature — not
+    // the JWT — is what authorizes the spend; the JWT still authenticates
+    // the caller and the two identities must agree.
+    let wallet_authorized = match &body.authorization {
+        Some(auth) => {
+            use crate::api::wallet_auth::{self, decode_hex_fixed};
+            use omnia_substrate::crypto::{Signature, VerifyingKey};
+
+            let pubkey_bytes = decode_hex_fixed::<32>(&auth.public_key).map_err(|e| {
+                (
+                    StatusCode::BAD_REQUEST,
+                    Json(json!({"error": format!("invalid authorization.public_key: {e}")})),
+                )
+            })?;
+            let verifying_key = VerifyingKey::from_bytes(&pubkey_bytes).map_err(|e| {
+                (
+                    StatusCode::BAD_REQUEST,
+                    Json(json!({"error": format!("invalid authorization.public_key: {e}")})),
+                )
+            })?;
+            let sig_bytes = decode_hex_fixed::<64>(&auth.signature).map_err(|e| {
+                (
+                    StatusCode::BAD_REQUEST,
+                    Json(json!({"error": format!("invalid authorization.signature: {e}")})),
+                )
+            })?;
+
+            // The signing key's derived DID is the spender. It must match
+            // the JWT identity — otherwise a stolen JWT could be paired
+            // with an attacker's own key (or vice versa).
+            let signer_did = wallet_auth::did_from_public_key(&pubkey_bytes);
+            if signer_did != from_did {
+                return Err((
+                    StatusCode::FORBIDDEN,
+                    Json(json!({
+                        "error": "authorization key does not belong to the authenticated caller",
+                        "authenticated_did": from_did,
+                        "signer_did": signer_did,
+                    })),
+                ));
+            }
+
+            // Consume the single-use nonce (bound to this key), then
+            // verify the signature over the canonical transfer message.
+            let public_key_hex = hex::encode(pubkey_bytes);
+            wallet_auth::consume_challenge(&state, &auth.nonce, &public_key_hex).await?;
+            let message = wallet_auth::transfer_message(&auth.nonce, &from_did, &body.to_did, body.amount);
+            verifying_key
+                .verify_strict(message.as_bytes(), &Signature::from_bytes(&sig_bytes))
+                .map_err(|_| {
+                    (
+                        StatusCode::UNAUTHORIZED,
+                        Json(json!({"error": "transfer signature verification failed"})),
+                    )
+                })?;
+
+            Some((pubkey_bytes, auth.nonce.clone(), sig_bytes.to_vec()))
+        }
+        None => None,
+    };
+    let provenance = if wallet_authorized.is_some() {
+        "wallet_signed"
+    } else {
+        "node_attested"
+    };
+
     // Reject self-transfers. UBC is soulbound: a "transfer" spends (burns)
     // the sender's tokens without crediting the recipient, so sending to
     // yourself can only destroy your own balance. Fail loudly instead of
@@ -247,13 +383,24 @@ pub async fn transfer_ubc(
     // authoritative balance change already happened above; if the
     // provenance event fails to submit, the transfer still succeeded — we
     // just record event_id: None and log it.
-    let payload = encode_transfer_payload(&TransferEventPayload {
+    let transfer_payload = TransferEventPayload {
         from_did: from_did.clone(),
         to_did: body.to_did.clone(),
         amount: body.amount,
         transfer_id: id.clone(),
         timestamp: now_ms,
-    });
+    };
+    // Wallet-signed transfers carry the authorization proof on-chain (v2
+    // receipt); node-attested transfers keep the v1 receipt.
+    let payload = match &wallet_authorized {
+        Some((wallet_pubkey, nonce, signature)) => encode_signed_transfer_payload(&SignedTransferEventPayload {
+            transfer: transfer_payload,
+            wallet_pubkey: *wallet_pubkey,
+            nonce: nonce.clone(),
+            signature: signature.clone(),
+        }),
+        None => encode_transfer_payload(&transfer_payload),
+    };
     let event_id = match build_sign_submit_event(&state, payload).await {
         Ok(submitted) => match submitted.submit_result {
             Ok(()) => Some(submitted.event_id_hex),
@@ -285,6 +432,7 @@ pub async fn transfer_ubc(
         status: "completed".to_string(),
         new_balance,
         event_id: event_id.clone(),
+        provenance: provenance.to_string(),
     };
     crate::state::record_transfer(&state.transfer_history, record).await;
 
@@ -295,6 +443,7 @@ pub async fn transfer_ubc(
         new_balance = new_balance,
         transfer_id = %id,
         event_id = ?event_id,
+        provenance = provenance,
         "UBC spend operation completed"
     );
     Ok((
@@ -307,6 +456,7 @@ pub async fn transfer_ubc(
             "amount": body.amount,
             "new_balance": new_balance,
             "event_id": event_id,
+            "provenance": provenance,
             "note": "UBC is soulbound — tokens are spent (consumed), not transferred to the recipient",
         })),
     ))
@@ -431,6 +581,93 @@ mod tests {
             omnia_shards::ShardPayload::from_bytes(&bytes).is_err(),
             "transfer receipt must not deserialize as a ShardPayload"
         );
+    }
+
+    #[test]
+    fn test_transfer_request_without_authorization_deserializes() {
+        // Deployed v1 clients send no authorization block — must stay valid.
+        let json = r#"{"from_did":"did:omnia:abc","to_did":"did:omnia:def","amount":100}"#;
+        let req: TransferRequest = serde_json::from_str(json).unwrap();
+        assert!(req.authorization.is_none());
+    }
+
+    #[test]
+    fn test_transfer_request_with_authorization_deserializes() {
+        let json = r#"{
+            "from_did":"did:omnia:abc","to_did":"did:omnia:def","amount":100,
+            "authorization":{"public_key":"aa","nonce":"bb","signature":"cc"}
+        }"#;
+        let req: TransferRequest = serde_json::from_str(json).unwrap();
+        let auth = req.authorization.unwrap();
+        assert_eq!(auth.public_key, "aa");
+        assert_eq!(auth.nonce, "bb");
+        assert_eq!(auth.signature, "cc");
+    }
+
+    #[test]
+    fn test_signed_transfer_payload_roundtrip_and_not_shard_payload() {
+        let p = SignedTransferEventPayload {
+            transfer: TransferEventPayload {
+                from_did: "did:omnia:aaaa".to_string(),
+                to_did: "did:omnia:bbbb".to_string(),
+                amount: 250,
+                transfer_id: "cafef00d".to_string(),
+                timestamp: 1_752_000_000_000,
+            },
+            wallet_pubkey: [7u8; 32],
+            nonce: "deadbeef".to_string(),
+            signature: vec![9u8; 64],
+        };
+        let bytes = encode_signed_transfer_payload(&p);
+        assert!(bytes.starts_with(TRANSFER_PAYLOAD_TAG_V2));
+        let body = &bytes[TRANSFER_PAYLOAD_TAG_V2.len()..];
+        let decoded: SignedTransferEventPayload = postcard::from_bytes(body).unwrap();
+        assert_eq!(decoded.transfer.from_did, p.transfer.from_did);
+        assert_eq!(decoded.wallet_pubkey, p.wallet_pubkey);
+        assert_eq!(decoded.nonce, p.nonce);
+        assert_eq!(decoded.signature, p.signature);
+        // The router must skip v2 receipts too (not a shard op).
+        assert!(omnia_shards::ShardPayload::from_bytes(&bytes).is_err());
+    }
+
+    #[test]
+    fn test_v2_signature_verifies_over_canonical_message() {
+        use omnia_substrate::crypto::{Signer, SigningKey};
+        use rand::RngCore;
+
+        // The exact flow a wallet performs: derive DID, build the
+        // canonical message, sign it — and the node-side verification
+        // accepts it while rejecting any field mutation.
+        let mut seed = [0u8; 32];
+        rand::thread_rng().fill_bytes(&mut seed);
+        let sk = SigningKey::from_bytes(&seed);
+        let vk = sk.verifying_key();
+        let from_did = crate::api::wallet_auth::did_from_public_key(&vk.to_bytes());
+
+        let nonce = "00ff00ff";
+        let to_did = "did:omnia:recipient";
+        let amount = 42u64;
+        let message = crate::api::wallet_auth::transfer_message(nonce, &from_did, to_did, amount);
+        let sig = sk.sign(message.as_bytes());
+
+        assert!(vk.verify_strict(message.as_bytes(), &sig).is_ok());
+        // Any mutated field must fail verification.
+        let tampered_amount = crate::api::wallet_auth::transfer_message(nonce, &from_did, to_did, 43);
+        assert!(vk.verify_strict(tampered_amount.as_bytes(), &sig).is_err());
+        let tampered_recipient = crate::api::wallet_auth::transfer_message(nonce, &from_did, "did:omnia:evil", amount);
+        assert!(vk.verify_strict(tampered_recipient.as_bytes(), &sig).is_err());
+        let tampered_nonce = crate::api::wallet_auth::transfer_message("11ee11ee", &from_did, to_did, amount);
+        assert!(vk.verify_strict(tampered_nonce.as_bytes(), &sig).is_err());
+    }
+
+    #[test]
+    fn test_transfer_message_field_boundaries_unambiguous() {
+        // Two different (to_did, amount) splits must never produce the
+        // same message — newline delimiting guarantees it as long as
+        // fields contain no newlines (enforced by the handler).
+        let a = crate::api::wallet_auth::transfer_message("n", "did:omnia:x", "did:omnia:y", 12);
+        let b = crate::api::wallet_auth::transfer_message("n", "did:omnia:x", "did:omnia:y\n1", 2);
+        assert_ne!(a, b);
     }
 
     #[test]

--- a/node/src/api/wallet_auth.rs
+++ b/node/src/api/wallet_auth.rs
@@ -67,6 +67,13 @@ pub const TOKEN_TTL_SECS: u64 = 86_400;
 /// The client must sign the byte string `"omnia-auth:" + nonce_hex`.
 pub const AUTH_MESSAGE_PREFIX: &str = "omnia-auth:";
 
+/// Domain-separation prefix for wallet-signed transfer authorizations
+/// (spend authorization Step 2 — self-sovereign transfers).
+///
+/// Distinct from [`AUTH_MESSAGE_PREFIX`] so a login signature can never be
+/// replayed as a spend authorization or vice versa.
+pub const TRANSFER_MESSAGE_PREFIX: &str = "omnia-transfer-v1";
+
 /// Length of the Ed25519 public key, in bytes.
 const PUBKEY_LEN: usize = 32;
 
@@ -112,8 +119,60 @@ pub fn did_from_public_key(public_key_bytes: &[u8]) -> String {
     format!("did:omnia:{}", &hex_digest[..32])
 }
 
+/// Build the canonical byte string a wallet signs to authorize a transfer.
+///
+/// Newline-delimited with a fixed field count:
+///
+/// ```text
+/// omnia-transfer-v1\n<nonce_hex>\n<from_did>\n<to_did>\n<amount_decimal>
+/// ```
+///
+/// Newlines make the encoding unambiguous (DIDs contain `:` so a
+/// colon-delimited format could collide across field boundaries); the
+/// transfer handler rejects DIDs containing control characters before
+/// verification. This rule is duplicated verbatim in wallet clients.
+pub fn transfer_message(nonce: &str, from_did: &str, to_did: &str, amount: u64) -> String {
+    format!("{TRANSFER_MESSAGE_PREFIX}\n{nonce}\n{from_did}\n{to_did}\n{amount}")
+}
+
+/// Look up and consume a challenge nonce (single-use).
+///
+/// Shared by login and wallet-signed transfers: removes the nonce under
+/// the store lock (so two concurrent requests cannot both consume it),
+/// then checks expiry and that it was issued to `public_key_hex`
+/// (lower-case hex). Returns an HTTP error tuple suitable for returning
+/// straight from a handler.
+pub async fn consume_challenge(
+    state: &AppState,
+    nonce: &str,
+    public_key_hex: &str,
+) -> Result<(), (StatusCode, Json<Value>)> {
+    let entry = {
+        let mut store = state.challenges.lock().await;
+        match store.remove(nonce) {
+            Some(e) => e,
+            None => {
+                return Err(err(
+                    StatusCode::UNAUTHORIZED,
+                    "unknown or already-used nonce — request a new challenge",
+                ))
+            }
+        }
+    };
+    if entry.expires_at_ms <= now_ms() {
+        return Err(err(StatusCode::UNAUTHORIZED, "challenge expired — request a new one"));
+    }
+    if entry.public_key != public_key_hex {
+        return Err(err(
+            StatusCode::UNAUTHORIZED,
+            "nonce was issued to a different public key",
+        ));
+    }
+    Ok(())
+}
+
 /// Decode a hex string into a fixed-size byte array of length `N`.
-fn decode_hex_fixed<const N: usize>(hex_str: &str) -> Result<[u8; N], String> {
+pub(crate) fn decode_hex_fixed<const N: usize>(hex_str: &str) -> Result<[u8; N], String> {
     let bytes = hex::decode(hex_str.trim()).map_err(|e| format!("invalid hex: {e}"))?;
     <[u8; N]>::try_from(bytes.as_slice()).map_err(|_| format!("expected {N} bytes, got {} ", hex_str.len() / 2))
 }
@@ -265,33 +324,9 @@ pub async fn login(
     let signature = Signature::from_bytes(&sig_bytes);
 
     let public_key = hex::encode(pubkey_bytes);
-    let now = now_ms();
 
-    // Look up and consume the nonce (single-use). Holding the lock across the
-    // remove ensures two concurrent logins cannot both consume it.
-    let entry = {
-        let mut store = state.challenges.lock().await;
-        match store.remove(&body.nonce) {
-            Some(e) => e,
-            None => {
-                return Err(err(
-                    StatusCode::UNAUTHORIZED,
-                    "unknown or already-used nonce — request a new challenge",
-                ))
-            }
-        }
-    };
-
-    // The nonce must belong to this public key and still be valid.
-    if entry.expires_at_ms <= now {
-        return Err(err(StatusCode::UNAUTHORIZED, "challenge expired — request a new one"));
-    }
-    if entry.public_key != public_key {
-        return Err(err(
-            StatusCode::UNAUTHORIZED,
-            "nonce was issued to a different public key",
-        ));
-    }
+    // Look up and consume the nonce (single-use, bound to this key).
+    consume_challenge(&state, &body.nonce, &public_key).await?;
 
     // Verify the signature over the domain-separated challenge message.
     let message = format!("{AUTH_MESSAGE_PREFIX}{}", body.nonce);

--- a/node/src/state.rs
+++ b/node/src/state.rs
@@ -76,6 +76,18 @@ pub struct TransferRecord {
     /// event could not be submitted (the balance change still succeeded).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub event_id: Option<String>,
+    /// Who authorized the spend: `"wallet_signed"` (the key owner's own
+    /// Ed25519 signature over the transfer was verified — self-sovereign,
+    /// spend-authorization Step 2) or `"node_attested"` (JWT-only
+    /// authorization, the original flow).
+    #[serde(default = "default_provenance")]
+    pub provenance: String,
+}
+
+/// Serde default for [`TransferRecord::provenance`] — records written
+/// before the field existed were all JWT-only authorized.
+fn default_provenance() -> String {
+    "node_attested".to_string()
 }
 
 /// Append a transfer record to the bounded history log.

--- a/node/tests/api_integration.rs
+++ b/node/tests/api_integration.rs
@@ -1498,6 +1498,220 @@ async fn test_transfer_emits_provenance_event() {
     );
 }
 
+// ---- economics: wallet-signed (self-sovereign) transfer, Step 2 ----
+
+#[tokio::test]
+async fn test_transfer_wallet_signed_end_to_end_with_replay_rejection() {
+    use omnia_substrate::crypto::{Signer, SigningKey};
+    use rand::RngCore;
+
+    // The wallet's own keypair; its DID is derived from the public key.
+    let mut seed = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut seed);
+    let sk = SigningKey::from_bytes(&seed);
+    let public_key_hex = hex::encode(sk.verifying_key().to_bytes());
+    let wallet_did = omnia_node::api::wallet_auth::did_from_public_key(&sk.verifying_key().to_bytes());
+
+    let wallet_did_for_setup = wallet_did.clone();
+    let server = setup_server_with_economics(move |econ| {
+        register_and_mint(econ, &wallet_did_for_setup, 10_000);
+        register_and_mint(econ, "did:test:recipient", 100);
+    })
+    .await;
+
+    let client = reqwest::Client::new();
+    let token = make_valid_token(&wallet_did);
+
+    // 1. Obtain a single-use nonce bound to the wallet's public key.
+    let challenge: Value = client
+        .post(format!("{}/api/v1/auth/challenge", server.base_url))
+        .json(&json!({ "public_key": public_key_hex }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let nonce = challenge["nonce"].as_str().unwrap().to_string();
+    assert_eq!(challenge["did"].as_str().unwrap(), wallet_did);
+
+    // 2. Sign the canonical transfer message with the wallet key.
+    let to_did = "did:test:recipient";
+    let amount = 500u64;
+    let message = omnia_node::api::wallet_auth::transfer_message(&nonce, &wallet_did, to_did, amount);
+    let signature_hex = hex::encode(sk.sign(message.as_bytes()).to_bytes());
+
+    // 3. Submit the wallet-signed transfer.
+    let body = json!({
+        "from_did": wallet_did,
+        "to_did": to_did,
+        "amount": amount,
+        "authorization": {
+            "public_key": public_key_hex,
+            "nonce": nonce,
+            "signature": signature_hex,
+        }
+    });
+    let resp = client
+        .post(format!("{}/api/v1/economics/transfer", server.base_url))
+        .bearer_auth(&token)
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200, "wallet-signed transfer should succeed");
+    let resp_body: Value = resp.json().await.unwrap();
+    assert_eq!(resp_body["provenance"].as_str().unwrap(), "wallet_signed");
+    // Registration grants a base quota on top of the minted 10_000, so
+    // assert the spend relative to that floor (as the v1 test does).
+    let balance_after_spend = resp_body["new_balance"].as_u64().unwrap();
+    assert!(
+        balance_after_spend >= 9_500,
+        "new balance should reflect the 500 spend, got {balance_after_spend}"
+    );
+
+    // 4. Replay the SAME authorization — the nonce is consumed, so the
+    //    spend must be rejected and the balance untouched.
+    let replay = client
+        .post(format!("{}/api/v1/economics/transfer", server.base_url))
+        .bearer_auth(&token)
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(replay.status(), 401, "replayed authorization must be rejected");
+
+    // 5. The listing shows the provenance.
+    let list: Value = client
+        .get(format!("{}/api/v1/economics/transfers", server.base_url))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(list["transfers"][0]["provenance"].as_str().unwrap(), "wallet_signed");
+}
+
+#[tokio::test]
+async fn test_transfer_wallet_signed_rejects_wrong_key_and_bad_signature() {
+    use omnia_substrate::crypto::{Signer, SigningKey};
+    use rand::RngCore;
+
+    let mut seed = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut seed);
+    let sk = SigningKey::from_bytes(&seed);
+    let public_key_hex = hex::encode(sk.verifying_key().to_bytes());
+    let wallet_did = omnia_node::api::wallet_auth::did_from_public_key(&sk.verifying_key().to_bytes());
+
+    let wallet_did_for_setup = wallet_did.clone();
+    let server = setup_server_with_economics(move |econ| {
+        register_and_mint(econ, &wallet_did_for_setup, 10_000);
+        register_and_mint(econ, "did:test:recipient", 100);
+    })
+    .await;
+    let client = reqwest::Client::new();
+
+    // Balance before any attack attempts — must be identical afterwards.
+    let balance_before: Value = client
+        .get(format!("{}/api/v1/economics/balance/{wallet_did}", server.base_url))
+        .bearer_auth(make_valid_token(&wallet_did))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let balance_before = balance_before["balance"].as_u64().unwrap();
+
+    // (a) A JWT for a DIFFERENT identity than the signing key → 403,
+    //     even with a perfectly valid signature and fresh nonce.
+    let challenge: Value = client
+        .post(format!("{}/api/v1/auth/challenge", server.base_url))
+        .json(&json!({ "public_key": public_key_hex }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let nonce = challenge["nonce"].as_str().unwrap().to_string();
+    // The message signs the ATTACKER's spend from their own DID — but the
+    // JWT belongs to REGULAR_CALLER, whose funds would be spent.
+    let message = omnia_node::api::wallet_auth::transfer_message(&nonce, &wallet_did, "did:test:recipient", 500);
+    let signature_hex = hex::encode(sk.sign(message.as_bytes()).to_bytes());
+    let mismatched = client
+        .post(format!("{}/api/v1/economics/transfer", server.base_url))
+        .bearer_auth(make_valid_token(REGULAR_CALLER))
+        .json(&json!({
+            "from_did": REGULAR_CALLER,
+            "to_did": "did:test:recipient",
+            "amount": 500,
+            "authorization": {
+                "public_key": public_key_hex,
+                "nonce": nonce,
+                "signature": signature_hex,
+            }
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        mismatched.status(),
+        403,
+        "authorization key not matching the JWT identity must be rejected"
+    );
+
+    // (b) A corrupted signature with a fresh nonce → 401, no spend.
+    let challenge: Value = client
+        .post(format!("{}/api/v1/auth/challenge", server.base_url))
+        .json(&json!({ "public_key": public_key_hex }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let nonce = challenge["nonce"].as_str().unwrap().to_string();
+    let message = omnia_node::api::wallet_auth::transfer_message(&nonce, &wallet_did, "did:test:recipient", 500);
+    let mut sig = sk.sign(message.as_bytes()).to_bytes();
+    sig[0] ^= 0xFF;
+    let bad_sig = client
+        .post(format!("{}/api/v1/economics/transfer", server.base_url))
+        .bearer_auth(make_valid_token(&wallet_did))
+        .json(&json!({
+            "from_did": wallet_did,
+            "to_did": "did:test:recipient",
+            "amount": 500,
+            "authorization": {
+                "public_key": public_key_hex,
+                "nonce": nonce,
+                "signature": hex::encode(sig),
+            }
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(bad_sig.status(), 401, "corrupted signature must be rejected");
+
+    // Balance is untouched by all rejected attempts.
+    let balance_after: Value = client
+        .get(format!("{}/api/v1/economics/balance/{wallet_did}", server.base_url))
+        .bearer_auth(make_valid_token(&wallet_did))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(
+        balance_after["balance"].as_u64().unwrap(),
+        balance_before,
+        "rejected authorization attempts must never move funds"
+    );
+}
+
 // ---- economics: transfer 400 self-transfer ----
 
 #[tokio::test]


### PR DESCRIPTION
## What

Step 2 of the spend-authorization plan: transfers can now be authorized by **the wallet's own Ed25519 key** instead of node attestation. The node verifies the key owner's signature over the exact transfer before touching any state — the JWT authenticates the caller, but the *signature* authorizes the spend.

### Protocol

`POST /api/v1/economics/transfer` accepts an optional `authorization` block:

```json
{
  "from_did": "did:omnia:…", "to_did": "did:omnia:…", "amount": 500,
  "authorization": {
    "public_key": "<64-hex Ed25519 pubkey>",
    "nonce": "<from POST /auth/challenge>",
    "signature": "<128-hex Ed25519 signature>"
  }
}
```

The wallet obtains a nonce from the **existing** `/auth/challenge` endpoint (single-use, 5-min TTL, bound to the public key — reused as-is, so replay protection needs no new state), then signs the canonical newline-delimited message:

```
omnia-transfer-v1\n<nonce>\n<from_did>\n<to_did>\n<amount>
```

Newline delimiting keeps field boundaries unambiguous (DIDs contain `:`, so a colon format could collide); DIDs containing control characters are rejected before verification.

### Security order of operations (all before any state change)

1. **Key ↔ identity binding**: the signing key's derived DID must equal the JWT identity — a stolen JWT can't be paired with an attacker's key (403), and a stolen key can't spend without the matching JWT.
2. **Nonce consumption** under the store lock (single-use — a captured authorization replays as 401).
3. **`verify_strict`** over the exact transfer fields — mutating recipient, amount, or nonce invalidates the signature (401).

### On-chain provenance

Wallet-signed transfers emit a new **`OMNIA_XFER_V2`** receipt embedding the pubkey, nonce, and signature — the authorization proof itself is on-chain and independently re-verifiable. JWT-only transfers keep the v1 receipt.

### Compatibility

The `authorization` block is optional: requests without it keep the exact existing behavior (provenance `"node_attested"`), so the deployed wallet v1 keeps working unchanged. `TransferRecord`, the transfer response, and `GET /economics/transfers` all now report `provenance`; records predating the field deserialize as `node_attested`.

`login()` was refactored onto the same `consume_challenge()` helper the transfer path uses (behavior unchanged).

### Client adoption (wallet follow-up, separate repo)

The Flutter wallet's send flow adds: challenge → sign `transfer_message` → attach `authorization`. The DID rule and message format are documented in the handler docs; the canonical-message vector is pinned by `test_v2_signature_verifies_over_canonical_message`.

## Testing

- `cargo test -p omnia-node --lib` — 65/65 (new: canonical-message sign/verify incl. per-field tamper rejection; v2 payload round-trip + not-a-ShardPayload; field-boundary unambiguity; request (de)serialization with/without the block)
- `cargo test -p omnia-node --test api_integration -- --test-threads=1` — 36/36, including two new end-to-end tests:
  - challenge → sign → transfer → **200 + `wallet_signed`** → replay of the same authorization → **401**, listing shows provenance
  - JWT/key identity mismatch → **403**; corrupted signature → **401**; balance provably untouched by all rejected attempts
- `cargo fmt --all --check`, both clippy gates, `RUSTDOCFLAGS="-D warnings" cargo doc` — clean