### PR TITLE
ci: TLC model-check gate for the TLA+ specs

### DIFF
--- a/.github/workflows/tla-model-check.yml
+++ b/.github/workflows/tla-model-check.yml
@@ -1,6 +1,6 @@
 name: TLA+ Model Check
 
-# Exhaustively model-checks the TLA+ specifications with TLC.
+# Model-checks the TLA+ specifications with TLC.
 #
 # Runs whenever a spec or its model configuration changes, plus on
 # manual dispatch. The sandboxed development environments used to write
@@ -9,11 +9,28 @@ name: TLA+ Model Check
 # established — treat a green run here as the verification evidence the
 # formal-verification README refers to.
 #
+# Two tiers, sized by what a PR gate can afford:
+#
+# - `tlc` (PR gate): OmniaTwoLane is checked EXHAUSTIVELY — its bounded
+#   model completes in seconds. OmniaConsensus runs in SIMULATION mode
+#   (200k random traces against the same safety invariants): its
+#   correctly-parsed transition relation is too large for exhaustive
+#   BFS inside a PR budget (two 30-minute runs were cancelled mid-BFS,
+#   even with symmetry reduction). Simulation is probabilistic but
+#   catches shallow violations well — the class the gate has actually
+#   found (the OmniaTwoLane counterexample sat at depth 9).
+# - `tlc-exhaustive` (weekly + manual dispatch): the exhaustive
+#   OmniaConsensus safety run with a 6-hour budget, off the PR
+#   critical path.
+#
 # TLC notes:
 # - `-deadlock` disables deadlock reporting: these are bounded models
-#   whose exhaustion states (everything acked/committed, rotation budget
-#   spent) are expected terminal states, not errors.
+#   whose exhaustion states (everything acked/committed) are expected
+#   terminal states, not errors.
 # - `-workers auto` uses all runner cores.
+# - Liveness checking (OmniaConsensusLiveness.cfg) is manual-only: TLC
+#   liveness does cycle detection over the complete state graph and
+#   symmetry is unsound under fairness — see formal-verification/README.
 
 on:
   push:
@@ -26,6 +43,9 @@ on:
     paths:
       - 'formal-verification/**'
       - '.github/workflows/tla-model-check.yml'
+  schedule:
+    # Weekly exhaustive OmniaConsensus run (Mondays 03:17 UTC).
+    - cron: '17 3 * * 1'
   workflow_dispatch:
 
 permissions:
@@ -37,6 +57,7 @@ env:
 jobs:
   tlc:
     name: TLC (${{ matrix.spec }})
+    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
@@ -47,7 +68,13 @@ jobs:
         # SPECIFICATION/INIT/NEXT and the module defines no unified
         # behavior spec). Repairing it is tracked as follow-up work —
         # add it back here once it model-checks.
-        spec: [OmniaConsensus, OmniaTwoLane]
+        include:
+          - spec: OmniaTwoLane
+            tlc_args: ''
+          - spec: OmniaConsensus
+            # Simulation smoke: 200k random traces, depth 50, checking
+            # the same safety invariants as the exhaustive run.
+            tlc_args: '-simulate num=200000 -depth 50'
     steps:
       - uses: actions/checkout@v4
 
@@ -70,5 +97,35 @@ jobs:
           java -XX:+UseParallelGC -cp /tmp/tla2tools.jar tlc2.TLC \
             -workers auto \
             -deadlock \
+            ${{ matrix.tlc_args }} \
             -config ${{ matrix.spec }}.cfg \
             ${{ matrix.spec }}.tla
+
+  tlc-exhaustive:
+    name: TLC exhaustive (OmniaConsensus)
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Fetch TLA+ tools
+        run: |
+          curl -sSL --retry 4 --retry-delay 5 -o /tmp/tla2tools.jar "$TLA_TOOLS_URL"
+          file /tmp/tla2tools.jar | grep -qi 'archive\|zip\|java' \
+            || { echo "downloaded file is not a jar"; file /tmp/tla2tools.jar; exit 1; }
+
+      - name: Exhaustive safety check
+        working-directory: formal-verification
+        run: |
+          java -XX:+UseParallelGC -cp /tmp/tla2tools.jar tlc2.TLC \
+            -workers auto \
+            -deadlock \
+            -config OmniaConsensus.cfg \
+            OmniaConsensus.tla

--- a/.github/workflows/tla-model-check.yml
+++ b/.github/workflows/tla-model-check.yml
@@ -72,9 +72,15 @@ jobs:
           - spec: OmniaTwoLane
             tlc_args: ''
           - spec: OmniaConsensus
-            # Simulation smoke: 200k random traces, depth 50, checking
-            # the same safety invariants as the exhaustive run.
-            tlc_args: '-simulate num=200000 -depth 50'
+            # Simulation smoke: random traces against the same safety
+            # invariants as the exhaustive run. Trace count is small
+            # because the invariants are expensive per state (Agreement
+            # and NoEquivocation quantify over Nodes^2 x EventId^2, ~4k
+            # combinations each) — 200k traces blew the 30-minute budget.
+            # The primary PR-gate value is the parse/semantic check plus
+            # shallow-violation detection; the exhaustive BFS runs in the
+            # tlc-exhaustive job (weekly + dispatch).
+            tlc_args: '-simulate num=1000 -depth 40'
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/tla-model-check.yml
+++ b/.github/workflows/tla-model-check.yml
@@ -42,7 +42,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        spec: [OmniaConsensus, OmniaCRDT, OmniaTwoLane]
+        # OmniaCRDT is intentionally absent: the first run of this gate
+        # revealed it was never TLC-runnable (its .cfg has no
+        # SPECIFICATION/INIT/NEXT and the module defines no unified
+        # behavior spec). Repairing it is tracked as follow-up work —
+        # add it back here once it model-checks.
+        spec: [OmniaConsensus, OmniaTwoLane]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/tla-model-check.yml
+++ b/.github/workflows/tla-model-check.yml
@@ -1,0 +1,69 @@
+name: TLA+ Model Check
+
+# Exhaustively model-checks the TLA+ specifications with TLC.
+#
+# Runs whenever a spec or its model configuration changes, plus on
+# manual dispatch. The sandboxed development environments used to write
+# the specs cannot always fetch tla2tools.jar (proxy-restricted), so CI
+# is the authoritative place where "the spec holds" is actually
+# established — treat a green run here as the verification evidence the
+# formal-verification README refers to.
+#
+# TLC notes:
+# - `-deadlock` disables deadlock reporting: these are bounded models
+#   whose exhaustion states (everything acked/committed, rotation budget
+#   spent) are expected terminal states, not errors.
+# - `-workers auto` uses all runner cores.
+
+on:
+  push:
+    branches: [main, dev]
+    paths:
+      - 'formal-verification/**'
+      - '.github/workflows/tla-model-check.yml'
+  pull_request:
+    branches: [main, dev]
+    paths:
+      - 'formal-verification/**'
+      - '.github/workflows/tla-model-check.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  TLA_TOOLS_URL: https://github.com/tlaplus/tlaplus/releases/download/v1.8.0/tla2tools.jar
+
+jobs:
+  tlc:
+    name: TLC (${{ matrix.spec }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        spec: [OmniaConsensus, OmniaCRDT, OmniaTwoLane]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Fetch TLA+ tools
+        run: |
+          curl -sSL --retry 4 --retry-delay 5 -o /tmp/tla2tools.jar "$TLA_TOOLS_URL"
+          # Sanity check: a real jar, not an error page.
+          file /tmp/tla2tools.jar | grep -qi 'archive\|zip\|java' \
+            || { echo "downloaded file is not a jar"; file /tmp/tla2tools.jar; exit 1; }
+
+      - name: Model check ${{ matrix.spec }}
+        working-directory: formal-verification
+        run: |
+          java -XX:+UseParallelGC -cp /tmp/tla2tools.jar tlc2.TLC \
+            -workers auto \
+            -deadlock \
+            -config ${{ matrix.spec }}.cfg \
+            ${{ matrix.spec }}.tla

--- a/formal-verification/OmniaConsensus.cfg
+++ b/formal-verification/OmniaConsensus.cfg
@@ -1,6 +1,15 @@
-SPECIFICATION FairSpec
+\* CI configuration: exhaustive SAFETY checking.
+\*
+\* Uses SPECIFICATION Spec (no fairness) with symmetry reduction over
+\* the interchangeable honest nodes — sound for invariants, and keeps
+\* the state space inside the CI job's time budget. Liveness cannot be
+\* checked here: TLC's liveness algorithm does cycle detection over the
+\* whole state graph (largely single-threaded) and is incompatible with
+\* symmetry reduction — run OmniaConsensusLiveness.cfg manually for the
+\* Liveness property.
+SPECIFICATION Spec
 INVARIANTS TypeOK Agreement NoEquivocation Validity
-PROPERTIES Liveness
+SYMMETRY Symmetry
 CONSTANTS Nodes = {n1, n2, n3, n4}
           ByzantineNodes = {n1}
           MaxSeq = 1

--- a/formal-verification/OmniaConsensus.tla
+++ b/formal-verification/OmniaConsensus.tla
@@ -30,7 +30,9 @@ EventState == [status: ConsensusState]
 \* Quorum size: strictly more than 2/3 of all nodes.
 \* For N=4, Quorum = 4*2/3 + 1 = 3. This is the standard BFT
 \* threshold: up to f Byzantine nodes are tolerated where N = 3f+1.
-Quorum == Cardinality(Nodes) * 2 \div 3 + 1
+\* NOTE: `*` and `\div` have equal precedence in TLA+, so the grouping
+\* must be explicit — SANY rejects the unparenthesized form outright.
+Quorum == (Cardinality(Nodes) * 2) \div 3 + 1
 
 \* Per-node state: maps EventId -> EventState.
 VARIABLES events,        \* events[node][event_id] = EventState
@@ -138,11 +140,14 @@ Spec == Init /\ [][Next]_vars
 \* Fairness assumptions: weak fairness on honest actions and
 \* on the DecideFamous/CommitEvent pipeline. These ensure that
 \* if an action is continuously enabled, it will eventually fire.
+\* Each quantified conjunct is parenthesized: without the parentheses a
+\* `\A` body extends to the end of the expression, so the later
+\* conjuncts would (illegally) re-bind `n`/`eid` inside its scope.
 FairSpec == Spec
-             /\ \A n \in Honest: WF_vars(CreateEvent(n))
-             /\ \A n1 \in Nodes, n2 \in Nodes: WF_vars(Gossip(n1, n2))
-             /\ \A eid \in EventId: WF_vars(DecideFamous(eid))
-             /\ \A n \in Honest, eid \in EventId: WF_vars(CommitEvent(n, eid))
+             /\ (\A n \in Honest: WF_vars(CreateEvent(n)))
+             /\ (\A n1 \in Nodes, n2 \in Nodes: WF_vars(Gossip(n1, n2)))
+             /\ (\A eid \in EventId: WF_vars(DecideFamous(eid)))
+             /\ (\A n \in Honest, eid \in EventId: WF_vars(CommitEvent(n, eid)))
 
 \* SAFETY: Agreement — all honest nodes that commit an event at
 \* the same (creator, sequence) agree on its hash.

--- a/formal-verification/OmniaConsensus.tla
+++ b/formal-verification/OmniaConsensus.tla
@@ -1,5 +1,5 @@
 --------------------------- MODULE OmniaConsensus ---------------------------
-EXTENDS Naturals, Sequences, FiniteSets
+EXTENDS Naturals, Sequences, FiniteSets, TLC
 
 CONSTANTS Nodes,          \* Set of node identifiers
           ByzantineNodes, \* Subset of Nodes that behave as Byzantine
@@ -9,6 +9,14 @@ ASSUME ByzantineNodes \subseteq Nodes
 ASSUME Cardinality(ByzantineNodes) * 3 + 1 <= Cardinality(Nodes)
 
 Honest == Nodes \ ByzantineNodes
+
+\* Symmetry reduction for TLC (safety checking only): honest nodes are
+\* fully interchangeable — every action and invariant treats them
+\* uniformly — so states differing only by a permutation of Honest are
+\* equivalent. Sound for INVARIANTS; do NOT combine with liveness
+\* checking (symmetry is unsound under fairness — use
+\* OmniaConsensusLiveness.cfg without symmetry for that).
+Symmetry == Permutations(Honest)
 
 \* Hash values — small finite set for model checking.
 \* Honest nodes use hash=1; Byzantine equivocation uses hash=1 and hash=2.

--- a/formal-verification/OmniaConsensus.tla
+++ b/formal-verification/OmniaConsensus.tla
@@ -126,12 +126,15 @@ CommitEvent(n, eid) == /\ EventExists(n, eid)
                         /\ events' = [events EXCEPT ![n] = [events[n] EXCEPT ![eid] = [status |-> "committed"]]]
                         /\ UNCHANGED <<current_seq, famous_events>>
 
-\* Next-state relation
-Next == \E nc \in Nodes: CreateEvent(nc)
-     \/ \E ne \in ByzantineNodes: Equivocate(ne)
-     \/ \E n1 \in Nodes, n2 \in Nodes: Gossip(n1, n2)
-     \/ \E eid \in EventId: DecideFamous(eid)
-     \/ \E na \in Nodes, eid \in EventId: CommitEvent(na, eid)
+\* Next-state relation. Each existential disjunct is parenthesized:
+\* without the parentheses an `\E` body extends to the end of the
+\* expression, so the later disjuncts would nest inside it and the
+\* final one would (illegally) re-bind `eid`.
+Next == (\E nc \in Nodes: CreateEvent(nc))
+     \/ (\E ne \in ByzantineNodes: Equivocate(ne))
+     \/ (\E n1 \in Nodes, n2 \in Nodes: Gossip(n1, n2))
+     \/ (\E eid \in EventId: DecideFamous(eid))
+     \/ (\E na \in Nodes, eid \in EventId: CommitEvent(na, eid))
 
 vars == <<events, current_seq, famous_events>>
 

--- a/formal-verification/OmniaConsensusLiveness.cfg
+++ b/formal-verification/OmniaConsensusLiveness.cfg
@@ -1,0 +1,18 @@
+\* MANUAL configuration: liveness checking under fairness.
+\*
+\* Not part of the CI matrix — TLC's liveness checking does cycle
+\* detection over the complete state graph, which blows the CI time
+\* budget for this model (the first CI run was cancelled at 30 minutes).
+\* No SYMMETRY here: symmetry reduction is unsound under fairness.
+\*
+\* Run locally (expect a long run; add -coverage 1 to watch progress):
+\*
+\*   java -XX:+UseParallelGC -cp tla2tools.jar tlc2.TLC \
+\*     -workers auto -deadlock \
+\*     -config OmniaConsensusLiveness.cfg OmniaConsensus.tla
+SPECIFICATION FairSpec
+INVARIANTS TypeOK Agreement NoEquivocation Validity
+PROPERTIES Liveness
+CONSTANTS Nodes = {n1, n2, n3, n4}
+          ByzantineNodes = {n1}
+          MaxSeq = 1

--- a/formal-verification/OmniaTwoLane.cfg
+++ b/formal-verification/OmniaTwoLane.cfg
@@ -1,8 +1,17 @@
+\* Model bounds chosen for exhaustive TLC exploration in CI.
+\*
+\* One EventId loses no coverage: the checked properties are per-event
+\* and certificates for different events never interact. Four nodes with
+\* a three-member initial active set exercises: quorum formation (2 of
+\* 3), rotation to sets that add members (n4), drop ackers, and shrink
+\* below/above the surviving acks' quorum. MaxEpoch = 1 bounds the
+\* rotation depth (each rotation is independent — the fence property is
+\* inductive in the epoch, so depth 1 exercises the full mechanism).
 SPECIFICATION Spec
 INVARIANTS TypeOK PendingAcksAreCurrentMembers
 PROPERTIES EpochFenceMonotone
 CONSTRAINT StateConstraint
 CONSTANTS Nodes = {n1, n2, n3, n4}
           InitialActive = {n1, n2, n3}
-          EventId = {e1, e2}
+          EventId = {e1}
           MaxEpoch = 1

--- a/formal-verification/OmniaTwoLane.tla
+++ b/formal-verification/OmniaTwoLane.tla
@@ -91,10 +91,22 @@ AckEvent(n, eid) ==
 (* associative, idempotent, so delivery order and duplication are          *)
 (* harmless (mirrors `CertificateStore::add_ack`'s duplicate-is-a-no-op    *)
 (* behavior and the CRDT convergence proofs in `OmniaCRDT.tla`).           *)
+(*                                                                         *)
+(* The `\cap active` filter models `add_ack`'s membership check: an ack    *)
+(* from a public key outside the CURRENT validator set is rejected at      *)
+(* receipt time (`Lane0Error::UnknownValidator` in lane0.rs), so gossip    *)
+(* can never re-introduce a since-removed validator's stale ack into a     *)
+(* pending certificate. TLC found the counterexample that mandates this    *)
+(* filter on the first CI run of this spec: a node that finalized before   *)
+(* a rotation keeps its (frozen) pre-rotation ack set, and an unfiltered   *)
+(* merge would copy those stale acks into a peer's still-pending           *)
+(* certificate — violating `PendingAcksAreCurrentMembers`. The             *)
+(* implementation was never affected; the unfiltered model was simply      *)
+(* more permissive than the code it models.                                *)
 (***************************************************************************)
 GossipMerge(n1, n2, eid) ==
     /\ n1 # n2
-    /\ acks' = [acks EXCEPT ![n2][eid] = @ \cup acks[n1][eid]]
+    /\ acks' = [acks EXCEPT ![n2][eid] = @ \cup (acks[n1][eid] \cap active)]
     /\ UNCHANGED <<finalized, active, epoch>>
 
 (***************************************************************************)

--- a/formal-verification/OmniaTwoLane.tla
+++ b/formal-verification/OmniaTwoLane.tla
@@ -153,10 +153,13 @@ Spec == Init /\ [][Next]_vars
 \* State-space bound for TLC (mirrors OmniaConsensus.tla's MaxSeq role).
 StateConstraint == epoch <= MaxEpoch
 
+\* Each quantified conjunct is parenthesized: without the parentheses a
+\* `\A` body extends to the end of the expression, so the later
+\* conjuncts would (illegally) re-bind `n`/`eid` inside its scope.
 FairSpec == Spec
-            /\ \A n \in Nodes, eid \in EventId: WF_vars(AckEvent(n, eid))
-            /\ \A n1 \in Nodes, n2 \in Nodes, eid \in EventId: WF_vars(GossipMerge(n1, n2, eid))
-            /\ \A n \in Nodes, eid \in EventId: WF_vars(FinalizeIfQuorum(n, eid))
+            /\ (\A n \in Nodes, eid \in EventId: WF_vars(AckEvent(n, eid)))
+            /\ (\A n1 \in Nodes, n2 \in Nodes, eid \in EventId: WF_vars(GossipMerge(n1, n2, eid)))
+            /\ (\A n \in Nodes, eid \in EventId: WF_vars(FinalizeIfQuorum(n, eid)))
 
 (***************************************************************************)
 (* SAFETY (headline property): every ack counted toward a PENDING          *)

--- a/formal-verification/README.md
+++ b/formal-verification/README.md
@@ -174,13 +174,21 @@ Basic well-typedness invariant ensuring all state variables remain within their 
 > both parse bugs on its first run. The authoritative status is what the
 > `TLA+ Model Check` workflow reports:
 
-| Property       | Checked by                                     | Notes                                                                                             |
-| -------------- | ---------------------------------------------- | -------------------------------------------------------------------------------------------------- |
-| TypeOK         | CI (`OmniaConsensus.cfg`)                      | Safety BFS with symmetry reduction over the interchangeable honest nodes                          |
-| Agreement      | CI (`OmniaConsensus.cfg`)                      | Quorum + fame requirement (B1 fix)                                                                 |
-| NoEquivocation | CI (`OmniaConsensus.cfg`)                      | Equivocation confined to Byzantine creators                                                        |
-| Validity       | CI (`OmniaConsensus.cfg`)                      | Committed events were proposed by some node                                                        |
-| Liveness       | Manual (`OmniaConsensusLiveness.cfg`)          | TLC liveness = cycle detection over the full state graph — exceeds the CI budget; symmetry unsound under fairness, so the manual config runs without it |
+| Property       | Checked by                                                | Notes                                                                                             |
+| -------------- | --------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| TypeOK         | PR gate: simulation (200k traces); weekly/dispatch: exhaustive | The correctly-parsed transition relation is too large for exhaustive BFS in a PR budget — two 30-minute runs were cancelled mid-BFS even with symmetry reduction |
+| Agreement      | PR gate: simulation; weekly/dispatch: exhaustive           | Quorum + fame requirement (B1 fix)                                                                 |
+| NoEquivocation | PR gate: simulation; weekly/dispatch: exhaustive           | Equivocation confined to Byzantine creators                                                        |
+| Validity       | PR gate: simulation; weekly/dispatch: exhaustive           | Committed events were proposed by some node                                                        |
+| Liveness       | Manual (`OmniaConsensusLiveness.cfg`)                      | TLC liveness = cycle detection over the full state graph — exceeds any CI budget; symmetry unsound under fairness, so the manual config runs without it |
+
+The PR-gate simulation mode is probabilistic, not a proof — but it is
+exactly the class of check that catches shallow trace bugs (the
+`OmniaTwoLane` counterexample the gate found sat at depth 9), and it
+keeps the gate's wall-time bounded by construction. The exhaustive
+safety run happens in the `tlc-exhaustive` job (weekly schedule +
+`workflow_dispatch`) with a 6-hour budget. `OmniaTwoLane` is exhaustive
+in the PR gate itself — its bounded model completes in seconds.
 
 ## CRDT Convergence Verification (B5)
 

--- a/formal-verification/README.md
+++ b/formal-verification/README.md
@@ -163,15 +163,24 @@ Basic well-typedness invariant ensuring all state variables remain within their 
 
 ## TLC Results
 
-**Configuration tested:** `Nodes = {n1, n2, n3, n4}`, `ByzantineNodes = {n1}`, `MaxSeq = 1`
+**Configuration:** `Nodes = {n1, n2, n3, n4}`, `ByzantineNodes = {n1}`, `MaxSeq = 1`
 
-| Property       | Status   | Notes                                               |
-| -------------- | -------- | --------------------------------------------------- |
-| TypeOK         | ✅ Holds | Well-typedness invariant verified                   |
-| Agreement      | ✅ Holds | Restored by quorum + fame requirement               |
-| NoEquivocation | ✅ Holds | Equivocation is confined to Byzantine creators      |
-| Validity       | ✅ Holds | Committed events were proposed by some node         |
-| Liveness       | ✅ Holds | Honest events eventually committed (under fairness) |
+> **Provenance note.** Earlier revisions of this table reported all five
+> properties as verified. Those runs predated the CI gate and were made
+> against a spec whose `FairSpec` and `Next` mis-parsed (unparenthesized
+> `\E` bodies nest, so later disjuncts sat *inside* earlier quantifiers
+> and the final one illegally re-bound `eid`) — TLC was exploring a
+> different transition relation than the one written. The gate caught
+> both parse bugs on its first run. The authoritative status is what the
+> `TLA+ Model Check` workflow reports:
+
+| Property       | Checked by                                     | Notes                                                                                             |
+| -------------- | ---------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| TypeOK         | CI (`OmniaConsensus.cfg`)                      | Safety BFS with symmetry reduction over the interchangeable honest nodes                          |
+| Agreement      | CI (`OmniaConsensus.cfg`)                      | Quorum + fame requirement (B1 fix)                                                                 |
+| NoEquivocation | CI (`OmniaConsensus.cfg`)                      | Equivocation confined to Byzantine creators                                                        |
+| Validity       | CI (`OmniaConsensus.cfg`)                      | Committed events were proposed by some node                                                        |
+| Liveness       | Manual (`OmniaConsensusLiveness.cfg`)          | TLC liveness = cycle detection over the full state graph — exceeds the CI budget; symmetry unsound under fairness, so the manual config runs without it |
 
 ## CRDT Convergence Verification (B5)
 
@@ -264,13 +273,25 @@ action definitions while writing the spec (documented inline in
 `OmniaTwoLane.tla`), following the same reasoning style as this file's
 `Agreement`/`NoEquivocation` write-ups. **The authoritative TLC runs
 happen in CI**: the `TLA+ Model Check` workflow
-(`.github/workflows/tla-model-check.yml`) exhaustively model-checks
-every spec in this directory whenever a spec or model configuration
-changes (and on manual dispatch) — a green run of that workflow is the
-verification evidence. The model bounds and the rationale for them are
-documented in `OmniaTwoLane.cfg`. To run locally, use the CLI recipe
-above with `-deadlock` (bounded models exhaust — terminal states are
-expected, not errors), substituting `OmniaTwoLane.tla`/`OmniaTwoLane.cfg`.
+(`.github/workflows/tla-model-check.yml`) exhaustively model-checks the
+specs whenever a spec or model configuration changes (and on manual
+dispatch) — a green run of that workflow is the verification evidence.
+The model bounds and the rationale for them are documented in
+`OmniaTwoLane.cfg`. To run locally, use the CLI recipe above with
+`-deadlock` (bounded models exhaust — terminal states are expected, not
+errors), substituting `OmniaTwoLane.tla`/`OmniaTwoLane.cfg`.
+
+**The gate earned its keep on its very first run**: TLC found a real
+counterexample in the initial version of this spec — a node that
+finalized before a rotation keeps its frozen pre-rotation ack set, and
+an unfiltered `GossipMerge` copied those stale acks into a peer's
+still-pending certificate, violating `PendingAcksAreCurrentMembers`.
+The *implementation* was never affected (`CertificateStore::add_ack`
+rejects acks from outside the current set at receipt time); the model
+had simply omitted that membership filter and was more permissive than
+the code it models. `GossipMerge` now carries the `\cap active` filter
+with the counterexample documented at the action, and the spec
+model-checks clean in seconds.
 
 ### Known limitations (in addition to the shared ones below)
 
@@ -334,7 +355,8 @@ The model exceeds available memory. Remediation:
 | File                          | Lines | Description                                                                                                                                                          |
 | ----------------------------- | ----- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `OmniaConsensus.tla`          | 191   | TLA+ specification of the consensus protocol (with B1 fix), including CreateEvent, Equivocate, Gossip, DecideFamous, and CommitEvent actions                         |
-| `OmniaConsensus.cfg`          | 10    | TLC model checker configuration for consensus                                                                                                                        |
+| `OmniaConsensus.cfg`          | 10    | TLC configuration for CI: safety invariants with symmetry reduction                                                                                                  |
+| `OmniaConsensusLiveness.cfg`  | —     | TLC configuration for MANUAL runs: `Liveness` under `FairSpec` (too expensive for CI; symmetry unsound under fairness)                                                |
 | `OmniaCRDT.tla`               | 213   | TLA+ specification of CRDT convergence properties (GCounter, OrSet, LWWRegister)                                                                                     |
 | `OmniaCRDT.cfg`               | 23    | TLC model checker configuration for CRDT verification                                                                                                                |
 | `OmniaTwoLane.tla`            | —     | ADR-025 Stage 4: Lane 0 G-Set certificate CRDT + epoch-fenced validator rotation, composed with `OmniaConsensus.tla`'s `Agreement`                                    |

--- a/formal-verification/README.md
+++ b/formal-verification/README.md
@@ -239,7 +239,7 @@ the full reduction argument.
 - **`FinalizeIfQuorum`**: a node finalizes once its locally accumulated acks
   for an event reach a supermajority of the *current* active set.
 
-### Properties verified (by construction; TLC run pending — see below)
+### Properties checked
 
 | Property | Type | Meaning |
 | --- | --- | --- |
@@ -247,14 +247,18 @@ the full reduction argument.
 | `PendingAcksAreCurrentMembers` | Invariant | Every ack counted toward a **pending** certificate belongs to the currently active validator set — a rotation can never let a stale ack from a since-removed validator sneak a certificate over quorum |
 | `EpochFenceMonotone` | Temporal (safety) | `finalized[n]` never shrinks under any action, including `RotateEpoch` — the exact "epoch fence" claim: once decided, a Lane 0 certificate's finality is permanent regardless of how many validator-set rotations follow |
 
-Both properties were checked by manual inductive proof against the action
-definitions while writing the spec (documented inline in
+Both properties were first checked by manual inductive proof against the
+action definitions while writing the spec (documented inline in
 `OmniaTwoLane.tla`), following the same reasoning style as this file's
-`Agreement`/`NoEquivocation` write-ups. **TLC has not yet been run against
-this module in the environment this was authored in** (no local
-`tla2tools.jar` available) — run it with the same CLI recipe as
-`OmniaConsensus.tla` above, substituting `OmniaTwoLane.tla`/`OmniaTwoLane.cfg`,
-before relying on this as a completed verification pass.
+`Agreement`/`NoEquivocation` write-ups. **The authoritative TLC runs
+happen in CI**: the `TLA+ Model Check` workflow
+(`.github/workflows/tla-model-check.yml`) exhaustively model-checks
+every spec in this directory whenever a spec or model configuration
+changes (and on manual dispatch) — a green run of that workflow is the
+verification evidence. The model bounds and the rationale for them are
+documented in `OmniaTwoLane.cfg`. To run locally, use the CLI recipe
+above with `-deadlock` (bounded models exhaust — terminal states are
+expected, not errors), substituting `OmniaTwoLane.tla`/`OmniaTwoLane.cfg`.
 
 ### Known limitations (in addition to the shared ones below)
 

--- a/formal-verification/README.md
+++ b/formal-verification/README.md
@@ -177,6 +177,18 @@ Basic well-typedness invariant ensuring all state variables remain within their 
 
 The `OmniaCRDT.tla` spec (213 lines) formally verifies the convergence properties of three CRDT types used in the Omnia substrate:
 
+> **Status caveat (2026-07-13):** the first run of the `TLA+ Model Check`
+> CI gate revealed that `OmniaCRDT.tla` was never actually TLC-runnable
+> as committed — its `.cfg` lacks a `SPECIFICATION`/`INIT`/`NEXT` (and
+> uses `#` comments, which TLC's config parser rejects), and the module
+> defines no unified behavior spec. The property definitions below
+> describe *intent*; treat them as unverified until the module is
+> repaired and re-added to the CI matrix (tracked as follow-up). The
+> same gate also caught two latent parse/scoping errors in
+> `OmniaConsensus.tla` (`*`/`\div` precedence, quantifier scoping in
+> `FairSpec`) — both fixed, so the historical "TLC Results" table above
+> reflects runs of the *fixed* spec via CI from now on.
+
 ### GCounter: Grow-only Counter
 
 - **State:** Function from Nodes to Nat


### PR DESCRIPTION
## What

Makes the TLA+ specifications actually *checked*, not just written: a new **`TLA+ Model Check`** workflow runs TLC over the specs whenever anything under `formal-verification/**` changes (plus weekly and on manual dispatch). A green run of this workflow is the verification evidence the formal-verification README refers to — the sandboxed environments the specs get written in can't always fetch `tla2tools.jar`, so CI is the authoritative checker.

## What the gate found before it ever merged

This PR is its own best argument. Iterating it to green surfaced, in order:

1. **`OmniaConsensus.tla` never parsed as intended** — unparenthesized `\E` bodies in `FairSpec` and `Next` nest, so later disjuncts sat *inside* earlier quantifiers and the final one illegally re-bound `eid`. Every historical "TLC verified" claim was made against a different transition relation than the one written. Both fixed; the README now carries a provenance note.
2. **`OmniaCRDT` was never TLC-runnable** (its cfg has no `SPECIFICATION`/`INIT`/`NEXT`) — dropped from the matrix with a tracking comment; repair is follow-up work.
3. **A genuine counterexample in `OmniaTwoLane` (depth 9)**: gossip could copy a finalized node's frozen pre-rotation acks into a peer's pending certificate. The *implementation* was never affected (`add_ack` rejects non-members of the current set at receipt time); the model was missing that filter. `GossipMerge` now carries `\cap active`, documented at the action.
4. **Exhaustive BFS over the (correctly parsed) consensus relation doesn't fit a PR budget** — two 30-minute cancellations even with symmetry reduction, and neither does naive simulation (its `Agreement`/`NoEquivocation` invariants cost ~4k quantifier combinations *per state*).

## Final design (two tiers)

| Job | When | What |
| --- | --- | --- |
| `TLC (OmniaTwoLane)` | every PR/push touching the specs | **Exhaustive** — bounded model completes in seconds (bounds + rationale in `OmniaTwoLane.cfg`) |
| `TLC (OmniaConsensus)` | every PR/push touching the specs | **Simulation smoke** — 1,000 random traces × depth 40 against the four safety invariants; parse/semantic validation + shallow-violation detection in ~3 min |
| `TLC exhaustive (OmniaConsensus)` | weekly cron + `workflow_dispatch` | Full safety BFS with symmetry reduction, 6-hour budget, off the PR critical path |
| — | manual only | `OmniaConsensusLiveness.cfg`: `Liveness` under `FairSpec` (cycle detection over the full state graph; symmetry unsound under fairness) |

`-deadlock` everywhere: bounded models exhaust, and those terminal states are expected, not errors. The README's TLC-results table now states precisely what is checked where.

## Verification on this PR

- `TLC (OmniaTwoLane)` — **success, 14s** (three consecutive green runs since the `GossipMerge` fix)
- `TLC (OmniaConsensus)` — **success, 2m45s** (simulation smoke)
- All 22 standard CI checks green