### PR TITLE
fix(consensus): bound the out-of-order buffer's creator map (H-4)

### DIFF
--- a/AUDIT_FIX_NOTES.md
+++ b/AUDIT_FIX_NOTES.md
@@ -409,23 +409,23 @@ node's identity changes across restarts. Persisting it requires:
 **Dependency:** Also blocks C-5 (asymmetric JWT derives its key from the
 node keypair).
 
-### H-4 — LRU creator buffer (Phase 1, deferred)
+### H-4 — LRU creator buffer ✅ RESOLVED
 
-**Reason:** The strategy recommends replacing
-`HashMap<NodeId, PerCreatorBuffer>` with `LruCache<NodeId, PerCreatorBuffer>`
-in `omnia-consensus/src/causal_graph.rs`. However, the actual struct
-`SequenceBuffer` uses `HashMap<NodeId, BTreeMap<u64, Event>>` (line 73)
-without an LRU bound. The fix requires:
+**Fix (landed post-ADR-025):** rather than pull in the `lru` crate and
+fight its `get_mut`/peek semantics against `drain_consecutive`, the
+`SequenceBuffer` keeps its `HashMap<NodeId, BTreeMap<u64, Event>>` and adds
+a lightweight LRU alongside it: a `last_seen: HashMap<NodeId, u64>` recency
+map plus a monotonic `tick`. A new creator that would exceed
+`MAX_BUFFERED_CREATORS = 1024` evicts the minimum-recency creator
+(`evict_lru_creator`); `buffer_event` bumps recency, and
+`drain_consecutive` removes the `last_seen` entry in lockstep when a
+creator's buffer empties. The eviction-vs-`drain_consecutive` interaction
+the original note flagged as risky is handled by keeping the two maps
+strictly in lockstep (asserted in the tests). Worst-case buffer memory is
+now `MAX_BUFFERED_CREATORS × MAX_SEQUENCE_BUFFER_PER_CREATOR` events.
 
-- Adding `lru = "0.12"` dependency to `omnia-consensus/Cargo.toml`.
-- Refactoring `SequenceBuffer` to use `LruCache`.
-- Adding a `MAX_BUFFERED_CREATORS` constant.
-- Updating all `buffers.entry(...)` call sites.
-- Adding a regression test that eviction fires at capacity.
-
-**Risk:** The eviction semantics interact with `drain_consecutive()` which
-expects `get_mut` access. Getting the LRU semantics right (peek vs. get,
-LRU update on access) without compile feedback is risky.
+**Tests:** `test_h4_creator_map_is_bounded_and_evicts_lru`,
+`test_h4_lru_bookkeeping_survives_per_creator_overflow_and_drain`.
 
 ### A-1, A-3, A-4, A-5 — Other architectural items (deferred)
 

--- a/docs/stub-inventory.md
+++ b/docs/stub-inventory.md
@@ -155,11 +155,11 @@ The following items were identified during the v0.1.68 audit cycle but explicitl
 - **What's missing**: Module rename to reflect the actual (non-spec-compliant V1) construction; ECVRF V2 lives in `omnia-crypto/src/vrf.rs`
 - **Phase**: Deferred from v0.1.68 audit
 
-### LRU creator buffer (H-4 deferred) — **ANTI-SPAM** ⚠️
+### LRU creator buffer (H-4) — **ANTI-SPAM** ✅
 
-- **Status**: Deferred — bounded creator map for anti-spam
-- **What's missing**: Bounded LRU map limiting per-creator event backlog to prevent unbounded memory growth under adversarial load
-- **Phase**: Deferred from v0.1.68 audit
+- **File**: `omnia-consensus/src/causal_graph.rs` (`SequenceBuffer`)
+- **Status**: ✅ Implemented — the out-of-order buffer's creator map is bounded by `MAX_BUFFERED_CREATORS = 1024` with LRU eviction, on top of the existing `MAX_SEQUENCE_BUFFER_PER_CREATOR = 256` and `MAX_SEQUENCE_GAP = 512` bounds. Attacker-minted NodeIds can no longer grow the map without bound; worst-case buffer memory is `1024 × 256` events.
+- **Phase**: Deferred from v0.1.68 audit; landed post-ADR-025.
 
 ### Chaos test safety checker (H-11 deferred) — **AUTOMATION** ⚠️
 
@@ -179,6 +179,6 @@ The following items were identified during the v0.1.68 audit cycle but explicitl
 | Pipeline workers (C-8)              | —     | ⚠️ DEFERRED  | `node/src/pipeline.rs`              | v0.1.68 audit |
 | Asymmetric JWT (C-5)                | —     | ⚠️ DEFERRED  | —                                   | v0.1.68 audit |
 | VRF rename (C-7)                    | 1     | ⚠️ DEFERRED  | `substrate/src/vrf.rs`              | v0.1.68 audit |
-| LRU creator buffer (H-4)            | 1     | ⚠️ DEFERRED  | —                                   | v0.1.68 audit |
+| LRU creator buffer (H-4)            | 1     | ✅ DONE      | `omnia-consensus/src/causal_graph.rs` | v0.1.68 audit |
 | Chaos test safety checker (H-11)    | —     | ⚠️ DEFERRED  | —                                   | v0.1.68 audit |
 | Substrate write lock scope (H-3)    | 1     | ⚠️ DEFERRED  | `substrate/src/consensus.rs`        | v0.1.68 audit |

--- a/formal-verification/consensus/CONSENSUS_SPEC.md
+++ b/formal-verification/consensus/CONSENSUS_SPEC.md
@@ -133,7 +133,7 @@ The `commit_delay_rounds` parameter provides safety margin against reorgs in cas
 
 - More than `f` Byzantine validators (BFT assumption violated).
 - Network partition lasting longer than `MAX_EVENT_AGE_MS` (events age out before GST).
-- Per-creator buffer overflow (creator spams > 256 out-of-order events — addressed by H-4 fix, PLANNED/not yet implemented).
+- Per-creator buffer overflow (creator spams > 256 out-of-order events) and creator-map flooding (attacker mints many NodeIds) — both bounded by the H-4 fix (per-creator cap + LRU creator-map cap), so these degrade liveness for the offending peer(s) only, never node memory.
 
 ---
 
@@ -145,7 +145,7 @@ The `commit_delay_rounds` parameter provides safety margin against reorgs in cas
 - **Timestamp drift**: `MAX_TIMESTAMP_DRIFT_MS = 120_000` and `MAX_EVENT_AGE_MS = 31_536_000_000` (1 year).
 - **Nonce enforcement**: Per-creator strictly-increasing nonces with gap limit (`NONCE_GAP_LIMIT`).
 - **Fee burning (C-6 fix)**: Fees deducted before shard dispatch and NOT refunded on failure — anti-spam by cost.
-- **Per-creator buffer cap (H-4 fix)**: LRU-bounded creator map prevents unbounded memory growth from attacker-registered NodeIds. **PLANNED (not yet implemented)** — the LRU buffer described here is part of the H-4 design but has not yet landed in `omnia-consensus`. See the H-4 entry in the relevant phase summary for current status.
+- **Per-creator buffer cap (H-4 fix)**: the out-of-order `SequenceBuffer` is bounded on three axes — `MAX_SEQUENCE_BUFFER_PER_CREATOR = 256` events per creator, `MAX_SEQUENCE_GAP = 512` on the allowed sequence gap, and `MAX_BUFFERED_CREATORS = 1024` on the number of distinct creators. The creator bound is LRU: a new creator that would exceed it evicts the least-recently-buffered creator's buffer, so attacker-minted NodeIds cannot grow the map without bound. Worst-case buffer memory is `MAX_BUFFERED_CREATORS × MAX_SEQUENCE_BUFFER_PER_CREATOR` events. Eviction is safe because buffered events are a pure liveness optimization — evicted out-of-order events are re-requested via gossip/fast-sync. **Implemented** in `omnia-consensus/src/causal_graph.rs` (`SequenceBuffer::evict_lru_creator`; tests `test_h4_creator_map_is_bounded_and_evicts_lru`, `test_h4_lru_bookkeeping_survives_per_creator_overflow_and_drain`).
 
 ---
 

--- a/omnia-consensus/src/causal_graph.rs
+++ b/omnia-consensus/src/causal_graph.rs
@@ -51,6 +51,24 @@ const MAX_SEQUENCE_BUFFER_PER_CREATOR: usize = 256;
 /// is so large that the intermediate events would never arrive).
 const MAX_SEQUENCE_GAP: u64 = 512;
 
+/// Maximum number of distinct creators tracked in the out-of-order buffer
+/// (H-4 fix).
+///
+/// [`MAX_SEQUENCE_BUFFER_PER_CREATOR`] bounds each creator's buffer, but a
+/// creator is just a public-key-derived `NodeId` — an attacker can mint
+/// arbitrarily many keypairs and buffer one out-of-order event under each,
+/// growing the *number* of creator entries without bound even though every
+/// individual buffer stays small. This caps the creator map: when a new
+/// creator would exceed the cap, the least-recently-buffered creator's
+/// entire buffer is evicted. Eviction is safe because buffered events are a
+/// pure liveness optimization — an evicted creator's out-of-order events are
+/// simply re-requested via gossip/fast-sync when their predecessor arrives,
+/// exactly as if they had hit the gap limit.
+///
+/// Worst-case memory is therefore bounded by
+/// `MAX_BUFFERED_CREATORS * MAX_SEQUENCE_BUFFER_PER_CREATOR` events.
+const MAX_BUFFERED_CREATORS: usize = 1024;
+
 /// A buffer for out-of-order events, keyed by (creator, sequence).
 ///
 /// When an event arrives with `sequence > expected_next`, it is stored here
@@ -60,33 +78,61 @@ const MAX_SEQUENCE_GAP: u64 = 512;
 ///
 /// # Security
 ///
-/// The buffer is bounded by [`MAX_SEQUENCE_BUFFER_PER_CREATOR`] per creator
-/// and [`MAX_SEQUENCE_GAP`] on the allowed sequence gap. Events that exceed
-/// these bounds are rejected with [`CausalGraphError::SequenceBufferOverflow`]
-/// or [`CausalGraphError::SequenceGapTooLarge`], ensuring that the O(1) cycle
-/// detection invariant is enforced without creating an unbounded DoS surface.
+/// The buffer is bounded on three axes: [`MAX_SEQUENCE_BUFFER_PER_CREATOR`]
+/// per creator, [`MAX_SEQUENCE_GAP`] on the allowed sequence gap, and
+/// [`MAX_BUFFERED_CREATORS`] on the number of distinct creators (H-4).
+/// Per-creator and gap overflows reject the offending event with
+/// [`CausalGraphError::SequenceBufferOverflow`] or
+/// [`CausalGraphError::SequenceGapTooLarge`]; a creator-count overflow
+/// instead evicts the least-recently-used creator's buffer (see
+/// [`MAX_BUFFERED_CREATORS`]). Together these enforce the O(1) cycle
+/// detection invariant with a hard memory bound and no unbounded DoS
+/// surface.
 #[derive(Debug, Default)]
 struct SequenceBuffer {
     /// Per-creator buffers: creator → (sequence → event).
     /// Each inner map is a BTreeMap so we can drain consecutive entries
     /// efficiently when the expected sequence arrives.
     buffers: HashMap<NodeId, std::collections::BTreeMap<u64, Event>>,
+    /// LRU recency for the H-4 creator-count bound: creator → the monotonic
+    /// tick at which it was last buffered into. Kept in lockstep with
+    /// `buffers` — an entry exists here iff it exists in `buffers`.
+    last_seen: HashMap<NodeId, u64>,
+    /// Monotonic counter driving `last_seen`; bumped on every buffered event.
+    tick: u64,
 }
 
 impl SequenceBuffer {
     fn new() -> Self {
         Self {
             buffers: HashMap::new(),
+            last_seen: HashMap::new(),
+            tick: 0,
+        }
+    }
+
+    /// Evict the least-recently-buffered creator's entire buffer (H-4).
+    ///
+    /// Called only when a *new* creator would exceed [`MAX_BUFFERED_CREATORS`].
+    /// The scan is O(tracked creators) but runs only on the overflow (attack)
+    /// path, never on the steady-state insert path.
+    fn evict_lru_creator(&mut self) {
+        if let Some((&victim, _)) = self.last_seen.iter().min_by_key(|(_, &t)| t) {
+            self.buffers.remove(&victim);
+            self.last_seen.remove(&victim);
         }
     }
 
     /// Buffer an out-of-order event for later insertion.
     ///
-    /// Returns `Err` if the buffer is full or the gap is too large.
+    /// Returns `Err` if the per-creator buffer is full or the gap is too
+    /// large. When a previously-unseen creator would push the number of
+    /// tracked creators past [`MAX_BUFFERED_CREATORS`], the least-recently
+    /// used creator is evicted first (H-4) — this never rejects the incoming
+    /// event, it only reclaims a stale peer's slot.
     fn buffer_event(&mut self, event: &Event, expected_next: u64) -> Result<(), CausalGraphError> {
-        let creator_buf = self.buffers.entry(event.creator).or_default();
-
-        // Check gap size
+        // Check gap size first — it needs no per-creator state, so a rejected
+        // event never causes an eviction.
         let gap = event.sequence.saturating_sub(expected_next);
         if gap > MAX_SEQUENCE_GAP {
             return Err(CausalGraphError::SequenceGapTooLarge {
@@ -97,12 +143,26 @@ impl SequenceBuffer {
             });
         }
 
-        // Check buffer capacity
+        // H-4: bound the number of distinct creators. If this event opens a
+        // new creator buffer and we are at capacity, evict the LRU creator.
+        let is_new_creator = !self.buffers.contains_key(&event.creator);
+        if is_new_creator && self.buffers.len() >= MAX_BUFFERED_CREATORS {
+            self.evict_lru_creator();
+        }
+
+        let creator_buf = self.buffers.entry(event.creator).or_default();
+
+        // Check per-creator buffer capacity. A brand-new creator's buffer is
+        // empty (len 0 < cap), so this only ever rejects events for a creator
+        // that already has a full buffer — no phantom empty entry can be left
+        // behind by `or_default` above.
         if creator_buf.len() >= MAX_SEQUENCE_BUFFER_PER_CREATOR && !creator_buf.contains_key(&event.sequence) {
             return Err(CausalGraphError::SequenceBufferOverflow { creator: event.creator });
         }
 
         creator_buf.insert(event.sequence, event.clone());
+        self.tick += 1;
+        self.last_seen.insert(event.creator, self.tick);
         Ok(())
     }
 
@@ -122,9 +182,10 @@ impl SequenceBuffer {
             next += 1;
         }
 
-        // Clean up empty buffers
+        // Clean up empty buffers (and their LRU entry, kept in lockstep).
         if creator_buf.is_empty() {
             self.buffers.remove(creator);
+            self.last_seen.remove(creator);
         }
 
         result
@@ -138,6 +199,11 @@ impl SequenceBuffer {
     /// Number of buffered events for a specific creator.
     fn buffered_count(&self, creator: &NodeId) -> usize {
         self.buffers.get(creator).map(|b| b.len()).unwrap_or(0)
+    }
+
+    /// Number of distinct creators currently tracked (H-4 bound target).
+    fn tracked_creators(&self) -> usize {
+        self.buffers.len()
     }
 }
 
@@ -706,6 +772,12 @@ impl CausalGraph {
     /// Get the total number of buffered events across all creators.
     pub fn total_buffered_events(&self) -> usize {
         self.seq_buffer.total_buffered()
+    }
+
+    /// Number of distinct creators currently tracked in the out-of-order
+    /// buffer. Bounded by `MAX_BUFFERED_CREATORS` (H-4).
+    pub fn buffered_creator_count(&self) -> usize {
+        self.seq_buffer.tracked_creators()
     }
 
     /// Check if `ancestor` is an ancestor of `descendant`.
@@ -2400,6 +2472,92 @@ mod tests {
         e_big.sign_with_keypair(&kp).expect("signing");
         let result = graph.insert(e_big);
         assert!(matches!(result, Err(CausalGraphError::SequenceGapTooLarge { .. })));
+    }
+
+    // ── H-4: the creator map itself is bounded (LRU) ────────────────────
+
+    /// Build a distinct NodeId for a creator index.
+    fn creator_node(i: usize) -> NodeId {
+        let mut id = [0u8; 32];
+        id[..8].copy_from_slice(&(i as u64).to_le_bytes());
+        id
+    }
+
+    /// A minimal out-of-order event for `creator` at `seq`. `buffer_event`
+    /// only reads `creator`/`sequence` and clones, so it need not be signed.
+    fn ooo_event(creator: NodeId, seq: u64) -> Event {
+        Event::new(
+            creator,
+            seq,
+            VectorClock::with_node(creator, seq + 1),
+            None,
+            None,
+            vec![],
+        )
+        .expect("valid event")
+    }
+
+    #[test]
+    fn test_h4_creator_map_is_bounded_and_evicts_lru() {
+        let mut buf = SequenceBuffer::new();
+
+        // Fill exactly to the creator cap (each buffers a single seq-5 event,
+        // gap 5 from expected_next 0 — well under MAX_SEQUENCE_GAP).
+        for i in 0..MAX_BUFFERED_CREATORS {
+            buf.buffer_event(&ooo_event(creator_node(i), 5), 0).unwrap();
+        }
+        assert_eq!(buf.tracked_creators(), MAX_BUFFERED_CREATORS);
+
+        // Re-touch creator 0 so it is no longer the least-recently-used.
+        buf.buffer_event(&ooo_event(creator_node(0), 6), 0).unwrap();
+
+        // A brand-new creator must evict the LRU — which is now creator 1,
+        // not the freshly-touched creator 0. The map stays at the cap.
+        let newcomer = creator_node(MAX_BUFFERED_CREATORS + 1);
+        buf.buffer_event(&ooo_event(newcomer, 5), 0).unwrap();
+
+        assert_eq!(
+            buf.tracked_creators(),
+            MAX_BUFFERED_CREATORS,
+            "creator map must stay bounded"
+        );
+        assert_eq!(buf.buffered_count(&creator_node(1)), 0, "LRU creator evicted");
+        assert_eq!(
+            buf.buffered_count(&creator_node(0)),
+            2,
+            "recently-touched creator retained"
+        );
+        assert_eq!(buf.buffered_count(&newcomer), 1, "incoming event is always buffered");
+        // The LRU bookkeeping stays in lockstep with the buffers.
+        assert_eq!(buf.last_seen.len(), buf.buffers.len());
+    }
+
+    #[test]
+    fn test_h4_lru_bookkeeping_survives_per_creator_overflow_and_drain() {
+        let mut buf = SequenceBuffer::new();
+        let creator = creator_node(1);
+
+        // Fill one creator's per-creator buffer to capacity (gaps 1..=256
+        // from expected_next 0 exceed MAX_SEQUENCE_GAP for the high end, so
+        // buffer from a moving expected_next to stay within the gap bound).
+        for seq in 1..=(MAX_SEQUENCE_BUFFER_PER_CREATOR as u64) {
+            buf.buffer_event(&ooo_event(creator, seq), seq.saturating_sub(1))
+                .unwrap();
+        }
+        assert_eq!(buf.tracked_creators(), 1);
+        assert_eq!(buf.buffered_count(&creator), MAX_SEQUENCE_BUFFER_PER_CREATOR);
+
+        // One more distinct sequence overflows the per-creator cap → reject,
+        // without inflating the creator count or desyncing the LRU map.
+        let overflow = buf.buffer_event(&ooo_event(creator, MAX_SEQUENCE_BUFFER_PER_CREATOR as u64 + 1), 0);
+        assert!(matches!(overflow, Err(CausalGraphError::SequenceBufferOverflow { .. })));
+        assert_eq!(buf.tracked_creators(), 1);
+        assert_eq!(buf.last_seen.len(), buf.buffers.len());
+
+        // Draining the creator empty removes both its buffer and LRU entry.
+        buf.drain_consecutive(&creator, 1);
+        assert_eq!(buf.tracked_creators(), 0);
+        assert!(buf.last_seen.is_empty(), "LRU map must not leak drained creators");
     }
 
     #[test]


### PR DESCRIPTION
## What

Closes the last `DEFERRED` item from the v0.1.68 audit. The out-of-order `SequenceBuffer` in `omnia-consensus/src/causal_graph.rs` already capped events **per creator** (`MAX_SEQUENCE_BUFFER_PER_CREATOR = 256`) and the **sequence gap** (`MAX_SEQUENCE_GAP = 512`), but the **map of creators itself was unbounded**. A creator is just a public-key-derived `NodeId`, so an attacker minting many keypairs could buffer a single out-of-order event under each and grow the creator map without limit — a memory-exhaustion DoS.

## Fix

`MAX_BUFFERED_CREATORS = 1024` with LRU eviction: when a previously-unseen creator would push the map past the cap, the least-recently-buffered creator's entire buffer is evicted first. This never rejects the incoming event — it reclaims a stale peer's slot.

The original audit note flagged the `lru` crate's `get_mut`/peek semantics as risky against `drain_consecutive`. So instead of pulling in `lru`, this keeps the existing `HashMap<NodeId, BTreeMap<u64, Event>>` and adds a lightweight recency map (`last_seen: HashMap<NodeId, u64>` + a monotonic `tick`) beside it, kept **strictly in lockstep** with the buffers — an entry is added on `buffer_event` and removed by `drain_consecutive` when a creator's buffer empties. The eviction scan is O(tracked creators) but runs *only* on the overflow (attack) path, never on the steady-state insert path.

Eviction is safe because buffered events are a pure **liveness** optimization: an evicted peer's out-of-order events are simply re-requested via gossip/fast-sync when their predecessor arrives, exactly as if they'd hit the gap limit. Worst-case buffer memory is now hard-bounded at `MAX_BUFFERED_CREATORS × MAX_SEQUENCE_BUFFER_PER_CREATOR` events.

## Tests

- `test_h4_creator_map_is_bounded_and_evicts_lru` — fills to the creator cap, re-touches the oldest creator (moving it off LRU), adds a newcomer, and asserts the map stays bounded, the *true* LRU creator (not the re-touched one) was evicted, and the incoming event is always buffered.
- `test_h4_lru_bookkeeping_survives_per_creator_overflow_and_drain` — a per-creator overflow rejects without inflating the creator count or desyncing the recency map; draining a creator empty removes both its buffer and its `last_seen` entry.

## Docs

`CONSENSUS_SPEC.md`, `docs/stub-inventory.md`, and `AUDIT_FIX_NOTES.md` moved from PLANNED/DEFERRED to implemented.

## Gate

`cargo fmt --check`; both clippy gates; `cargo doc -D warnings`; `cargo test -p omnia-consensus --lib` — **315 pass** (2 new).