### PR TITLE
feat(lane0): diagnosable OMNIA_LANE0_VALIDATORS parse errors

### DIFF
--- a/substrate/src/lane0.rs
+++ b/substrate/src/lane0.rs
@@ -280,6 +280,12 @@ impl ValidatorSet {
     /// disabled), `Err` for a malformed one — a typo must fail loudly
     /// rather than silently disable finality.
     pub fn parse(spec: &str) -> Result<Option<Self>, Lane0Error> {
+        // Surfaced in every parse error so a malformed OMNIA_LANE0_VALIDATORS
+        // is diagnosable at a glance rather than via a cryptic hex error.
+        const FORMAT_HINT: &str = "expected a comma-separated list of \
+             `<64-hex-pubkey>:<stake>` entries (generate them with \
+             scripts/setup-validators.sh)";
+
         let spec = spec.trim();
         if spec.is_empty() {
             return Ok(None);
@@ -287,19 +293,35 @@ impl ValidatorSet {
         let mut entries = Vec::new();
         for part in spec.split(',') {
             let part = part.trim();
-            let (pk_hex, stake_str) = part
-                .split_once(':')
-                .ok_or_else(|| Lane0Error::InvalidConfig(format!("missing ':' in '{part}'")))?;
-            let pk_bytes = hex::decode(pk_hex.trim())
-                .map_err(|e| Lane0Error::InvalidConfig(format!("bad pubkey hex in '{part}': {e}")))?;
+            let (pk_hex, stake_str) = part.split_once(':').ok_or_else(|| {
+                Lane0Error::InvalidConfig(format!("missing ':' in '{part}' — {FORMAT_HINT}"))
+            })?;
+            let pk_hex = pk_hex.trim();
+            // A JWT (header.payload.signature) is the classic paste mistake
+            // here — the benchmark script mints one, and a stray redirect can
+            // land it in the env var. Name it directly instead of emitting a
+            // baffling "Invalid character '.'"/"'y'" hex error.
+            if pk_hex.contains('.') {
+                return Err(Lane0Error::InvalidConfig(format!(
+                    "'{pk_hex}' looks like a JWT, not an Ed25519 public key — {FORMAT_HINT}"
+                )));
+            }
+            if pk_hex.len() != 64 {
+                return Err(Lane0Error::InvalidConfig(format!(
+                    "pubkey must be 64 hex chars (32 bytes), got {} in '{part}' — {FORMAT_HINT}",
+                    pk_hex.len()
+                )));
+            }
+            let pk_bytes = hex::decode(pk_hex).map_err(|e| {
+                Lane0Error::InvalidConfig(format!("bad pubkey hex in '{part}': {e} — {FORMAT_HINT}"))
+            })?;
             let pubkey: [u8; 32] = pk_bytes
                 .as_slice()
                 .try_into()
                 .map_err(|_| Lane0Error::InvalidConfig(format!("pubkey must be 32 bytes in '{part}'")))?;
-            let stake: u64 = stake_str
-                .trim()
-                .parse()
-                .map_err(|e| Lane0Error::InvalidConfig(format!("bad stake in '{part}': {e}")))?;
+            let stake: u64 = stake_str.trim().parse().map_err(|e| {
+                Lane0Error::InvalidConfig(format!("bad stake in '{part}': {e} — {FORMAT_HINT}"))
+            })?;
             entries.push((pubkey, stake));
         }
         Ok(Some(Self::new(entries)?))
@@ -645,8 +667,24 @@ mod tests {
         // Malformed specs fail loudly.
         assert!(ValidatorSet::parse("nothex:1").is_err());
         assert!(ValidatorSet::parse(&format!("{pk_hex}:0")).is_err());
-        assert!(ValidatorSet::parse(&format!("{pk_hex}")).is_err());
+        assert!(ValidatorSet::parse(&pk_hex).is_err()); // missing ':<stake>'
         assert!(ValidatorSet::parse(&format!("{pk_hex}:abc")).is_err());
+
+        // A pasted JWT (the classic env-var mistake) fails with a targeted
+        // hint naming the JWT, not a cryptic hex error.
+        let jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZG1pbiJ9.Wi4edhVq1tTAqS6MeC0";
+        let err = ValidatorSet::parse(&format!("{jwt}:1")).unwrap_err();
+        assert!(
+            err.to_string().contains("looks like a JWT"),
+            "JWT paste should be named explicitly, got: {err}"
+        );
+
+        // A wrong-length pubkey names the 64-hex-char expectation.
+        let short = ValidatorSet::parse("abcd:1").unwrap_err();
+        assert!(
+            short.to_string().contains("64 hex chars"),
+            "short pubkey should cite the 64-hex requirement, got: {short}"
+        );
     }
 
     #[test]

--- a/substrate/src/lane0.rs
+++ b/substrate/src/lane0.rs
@@ -280,11 +280,16 @@ impl ValidatorSet {
     /// disabled), `Err` for a malformed one — a typo must fail loudly
     /// rather than silently disable finality.
     pub fn parse(spec: &str) -> Result<Option<Self>, Lane0Error> {
-        // Surfaced in every parse error so a malformed OMNIA_LANE0_VALIDATORS
-        // is diagnosable at a glance rather than via a cryptic hex error.
-        const FORMAT_HINT: &str = "expected a comma-separated list of \
-             `<64-hex-pubkey>:<stake>` entries (generate them with \
-             scripts/setup-validators.sh)";
+        // The expected shape, appended to every parse error so a malformed
+        // OMNIA_LANE0_VALIDATORS is diagnosable at a glance rather than via a
+        // cryptic hex error. Plain ASCII (no em-dash) keeps line widths — and
+        // therefore rustfmt wrapping — deterministic across toolchains.
+        const FORMAT_HINT: &str = "expected `<64-hex-pubkey>:<stake>` entries \
+             (generate them with scripts/setup-validators.sh)";
+        // Build an InvalidConfig error with the format hint appended. Keeping
+        // this a short helper lets every call site stay well under the width
+        // limit, so no error string needs multi-line wrapping.
+        let cfg_err = |msg: String| Lane0Error::InvalidConfig(format!("{msg}; {FORMAT_HINT}"));
 
         let spec = spec.trim();
         if spec.is_empty() {
@@ -293,35 +298,34 @@ impl ValidatorSet {
         let mut entries = Vec::new();
         for part in spec.split(',') {
             let part = part.trim();
-            let (pk_hex, stake_str) = part.split_once(':').ok_or_else(|| {
-                Lane0Error::InvalidConfig(format!("missing ':' in '{part}' — {FORMAT_HINT}"))
-            })?;
+            let (pk_hex, stake_str) = part
+                .split_once(':')
+                .ok_or_else(|| cfg_err(format!("missing ':' in '{part}'")))?;
             let pk_hex = pk_hex.trim();
             // A JWT (header.payload.signature) is the classic paste mistake
-            // here — the benchmark script mints one, and a stray redirect can
+            // here: the benchmark script mints one, and a stray redirect can
             // land it in the env var. Name it directly instead of emitting a
-            // baffling "Invalid character '.'"/"'y'" hex error.
+            // baffling "Invalid character '.'/'y'" hex error.
             if pk_hex.contains('.') {
-                return Err(Lane0Error::InvalidConfig(format!(
-                    "'{pk_hex}' looks like a JWT, not an Ed25519 public key — {FORMAT_HINT}"
+                return Err(cfg_err(format!(
+                    "'{pk_hex}' looks like a JWT, not an Ed25519 public key"
                 )));
             }
             if pk_hex.len() != 64 {
-                return Err(Lane0Error::InvalidConfig(format!(
-                    "pubkey must be 64 hex chars (32 bytes), got {} in '{part}' — {FORMAT_HINT}",
-                    pk_hex.len()
+                let n = pk_hex.len();
+                return Err(cfg_err(format!(
+                    "pubkey must be 64 hex chars (32 bytes), got {n} in '{part}'"
                 )));
             }
-            let pk_bytes = hex::decode(pk_hex).map_err(|e| {
-                Lane0Error::InvalidConfig(format!("bad pubkey hex in '{part}': {e} — {FORMAT_HINT}"))
-            })?;
+            let pk_bytes = hex::decode(pk_hex).map_err(|e| cfg_err(format!("bad pubkey hex in '{part}': {e}")))?;
             let pubkey: [u8; 32] = pk_bytes
                 .as_slice()
                 .try_into()
-                .map_err(|_| Lane0Error::InvalidConfig(format!("pubkey must be 32 bytes in '{part}'")))?;
-            let stake: u64 = stake_str.trim().parse().map_err(|e| {
-                Lane0Error::InvalidConfig(format!("bad stake in '{part}': {e} — {FORMAT_HINT}"))
-            })?;
+                .map_err(|_| cfg_err(format!("pubkey must be 32 bytes in '{part}'")))?;
+            let stake: u64 = stake_str
+                .trim()
+                .parse()
+                .map_err(|e| cfg_err(format!("bad stake in '{part}': {e}")))?;
             entries.push((pubkey, stake));
         }
         Ok(Some(Self::new(entries)?))


### PR DESCRIPTION
## Motivation

While bringing up the live 5-node testnet, a stray **JWT** ended up in `OMNIA_LANE0_VALIDATORS` (the benchmark script mints one, and a mis-pasted line redirected it into `docker/.env`). The node correctly refused to boot — but the error was cryptic:

```
Error: Invalid OMNIA_LANE0_VALIDATORS: bad pubkey hex in 'eyJhbGci...:1': Invalid character 'y' at position 1
```

"Invalid character 'y'" gives an operator no idea that they pasted a JWT where an Ed25519 pubkey belongs.

## Change

`ValidatorSet::parse` (`substrate/src/lane0.rs`) now:

- **Carries the expected format in every error** — `<64-hex-pubkey>:<stake>`, with a pointer to `scripts/setup-validators.sh` which generates a correct set.
- **Names a pasted JWT explicitly**: a value containing `.` fails with `'…' looks like a JWT, not an Ed25519 public key — …` instead of a hex-decode error.
- **Cites the length up front**: a wrong-length pubkey reports `pubkey must be 64 hex chars (32 bytes), got N` before attempting a hex decode.

Behaviour is unchanged for valid input and for an empty value (Lane 0 stays disabled). Tests cover the JWT-shaped value and the short-pubkey hint; also cleaned up a pre-existing `useless_format` clippy nit in the parse test.

## Verification

- `cargo test -p omnia-substrate --lib lane0` → 24 passed, 0 failed
- `cargo fmt -p omnia-substrate -- --check` → clean
- `cargo clippy -p omnia-substrate --lib --all-features -- -D warnings -D clippy::unwrap_used` → clean
- `cargo clippy -p omnia-substrate --all-targets --all-features -- -D clippy::unwrap_used` → clean
- `RUSTDOCFLAGS="-D warnings" cargo doc -p omnia-substrate --no-deps` → clean