### PR TITLE
fix(network): resolve /dns4 bootstrap addresses so the testnet mesh forms

### DIFF
--- a/omnia-network/src/network.rs
+++ b/omnia-network/src/network.rs
@@ -514,6 +514,13 @@ impl OmniaNetwork {
         let mut swarm = SwarmBuilder::with_existing_identity(local_key)
             .with_tokio()
             .with_quic()
+            // Wrap the transport in a DNS resolver so `/dns4/…` and
+            // `/dnsaddr/…` bootstrap multiaddrs resolve. Without this, the
+            // stock docker-compose testnet (whose peers dial the bootstrap by
+            // service name, e.g. `/dns4/omnia-bootstrap/udp/4001/quic-v1`)
+            // can never connect — the dial fails to resolve the hostname, so
+            // no gossip mesh forms and Kademlia reports `NoKnownPeers`.
+            .with_dns()?
             .with_relay_client(libp2p::noise::Config::new, libp2p::yamux::Config::default)?
             .with_behaviour(move |key, relay_client| {
                 let local_pid = PeerId::from(key.public());


### PR DESCRIPTION
## The bug

On the live 5-node docker-compose testnet, **every node reported 0 peers** and worker nodes logged:

```
WARN omnia_network::network: Kademlia bootstrap failed: NoKnownPeers
```

A benchmark confirmed the impact: 1000 events submitted to one node stayed in that node's DAG and propagated to **0%** of its peers.

## Root cause

The libp2p `SwarmBuilder` transport chain was:

```rust
SwarmBuilder::with_existing_identity(local_key)
    .with_tokio()
    .with_quic()
    .with_relay_client(...)?   // no .with_dns() before this
    .with_behaviour(...)
```

There is **no `.with_dns()`**, so the QUIC transport cannot resolve DNS multiaddrs. The stock `docker-compose.yml` has every worker dial the bootstrap by Docker **service name**:

```
OMNIA_BOOTSTRAP_NODES=/dns4/omnia-bootstrap/udp/4001/quic-v1
```

Without a DNS-resolving transport, that dial can't resolve `omnia-bootstrap`, so no connection is established, no gossipsub mesh forms, and Kademlia's routing table stays empty (`NoKnownPeers`). The dial code already handled peer-id-less bootstrap addresses correctly — the missing piece was purely transport-level name resolution. Net effect: the compose testnet never meshed multi-node; single-node wallet-to-bootstrap traffic still worked, which masked it.

## Fix

Insert `.with_dns()?` between `.with_quic()` and `.with_relay_client()` (the required `SwarmBuilder` typestate order). It uses the system resolver, which under Docker resolves inter-container service names, so `/dns4/…` and `/dnsaddr/…` bootstrap peers now connect. The `dns` libp2p feature was already enabled in `Cargo.toml` — it was simply never wired into the builder.

## Verification

- `cargo build -p omnia-network --features network` → compiles (typestate order correct)
- `cargo test -p omnia-network --features network --lib` → 132 passed, 0 failed
- `cargo fmt -p omnia-network -- --check` → clean
- `cargo clippy -p omnia-network --features network --all-targets -- -D warnings -D clippy::unwrap_used` → clean
- `RUSTDOCFLAGS="-D warnings" cargo doc -p omnia-network --no-deps --features network` → clean

**Live validation pending:** rebuild the testnet and confirm each node's `/api/v1/node/peers` reaches 4 and the benchmark shows ~100% propagation.