### PR TITLE
fix(network): resolve /dns4 bootstrap addresses via DNS transport

### DIFF
--- a/omnia-network/src/network.rs
+++ b/omnia-network/src/network.rs
@@ -514,6 +514,13 @@ impl OmniaNetwork {
         let mut swarm = SwarmBuilder::with_existing_identity(local_key)
             .with_tokio()
             .with_quic()
+            // Wrap the transport in a DNS resolver so `/dns4/…` and
+            // `/dnsaddr/…` bootstrap multiaddrs resolve. Without this, the
+            // stock docker-compose testnet (whose peers dial the bootstrap by
+            // service name, e.g. `/dns4/omnia-bootstrap/udp/4001/quic-v1`)
+            // can never connect — the dial fails to resolve the hostname, so
+            // no gossip mesh forms and Kademlia reports `NoKnownPeers`.
+            .with_dns()?
             .with_relay_client(libp2p::noise::Config::new, libp2p::yamux::Config::default)?
             .with_behaviour(move |key, relay_client| {
                 let local_pid = PeerId::from(key.public());


### PR DESCRIPTION

The libp2p SwarmBuilder chained with_quic() straight into
with_relay_client() with no with_dns() step, so the QUIC transport could
not resolve DNS multiaddrs. Every worker in the stock docker-compose
testnet dials the bootstrap by service name
(`/dns4/omnia-bootstrap/udp/4001/quic-v1`); without a DNS resolver those
dials fail to resolve the hostname, no connection is established, no
gossip mesh forms, and Kademlia reports `NoKnownPeers`. The net effect
was zero cross-node event propagation — a submitted event stayed in the
receiving node's DAG and never reached its peers.

Insert `.with_dns()?` between `.with_quic()` and `.with_relay_client()`
(the required SwarmBuilder typestate order). It uses the system resolver,
which under Docker resolves inter-container service names, so `/dns4/…`
and `/dnsaddr/…` bootstrap peers now connect and the mesh forms. The
`dns` libp2p feature was already enabled; it was simply never wired into
the transport.
