### PR TITLE
fix(network): add identify so Kademlia populates and peers discover each other

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3803,6 +3803,7 @@ dependencies = [
  "libp2p-dcutr",
  "libp2p-dns",
  "libp2p-gossipsub",
+ "libp2p-identify",
  "libp2p-identity",
  "libp2p-kad",
  "libp2p-mdns",
@@ -3962,6 +3963,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "libp2p-identify"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ab792a8b68fdef443a62155b01970c81c3aadab5e659621b063ef252a8e65e8"
+dependencies = [
+ "asynchronous-codec",
+ "either",
+ "futures",
+ "futures-bounded",
+ "futures-timer",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+ "quick-protobuf",
+ "quick-protobuf-codec",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
 name = "libp2p-identity"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4035,6 +4057,7 @@ dependencies = [
  "libp2p-core",
  "libp2p-dcutr",
  "libp2p-gossipsub",
+ "libp2p-identify",
  "libp2p-identity",
  "libp2p-kad",
  "libp2p-relay",

--- a/omnia-network/Cargo.toml
+++ b/omnia-network/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = { workspace = true }
 [dependencies]
 omnia-primitives = { path = "../omnia-primitives" }
 omnia-consensus = { path = "../omnia-consensus" }
-libp2p = { version = "0.56", optional = true, features = ["quic", "kad", "gossipsub", "mdns", "noise", "yamux", "tcp", "dns", "macros", "request-response", "cbor", "tokio", "autonat", "relay", "dcutr"] }
+libp2p = { version = "0.56", optional = true, features = ["quic", "kad", "gossipsub", "mdns", "identify", "noise", "yamux", "tcp", "dns", "macros", "request-response", "cbor", "tokio", "autonat", "relay", "dcutr"] }
 tokio = { version = "1.35", features = ["sync", "rt", "time"], optional = true }
 snap = "1"
 tracing = "0.1"
@@ -30,7 +30,7 @@ snapshot = []
 
 [dev-dependencies]
 omnia-crypto = { path = "../omnia-crypto" }
-libp2p = { version = "0.56", features = ["quic", "kad", "gossipsub", "mdns", "noise", "yamux", "tcp", "dns", "macros", "request-response", "cbor", "tokio", "autonat", "relay", "dcutr"] }
+libp2p = { version = "0.56", features = ["quic", "kad", "gossipsub", "mdns", "identify", "noise", "yamux", "tcp", "dns", "macros", "request-response", "cbor", "tokio", "autonat", "relay", "dcutr"] }
 tokio = { version = "1.35", features = ["macros", "rt", "time", "rt-multi-thread"] }
 tokio-test = "0.4"
 tempfile = "3"

--- a/omnia-network/src/network.rs
+++ b/omnia-network/src/network.rs
@@ -514,6 +514,13 @@ impl OmniaNetwork {
         let mut swarm = SwarmBuilder::with_existing_identity(local_key)
             .with_tokio()
             .with_quic()
+            // Wrap the transport in a DNS resolver so `/dns4/…` and
+            // `/dnsaddr/…` bootstrap multiaddrs resolve. Without this, the
+            // stock docker-compose testnet (whose peers dial the bootstrap by
+            // service name, e.g. `/dns4/omnia-bootstrap/udp/4001/quic-v1`)
+            // can never connect — the dial fails to resolve the hostname, so
+            // no gossip mesh forms and Kademlia reports `NoKnownPeers`.
+            .with_dns()?
             .with_relay_client(libp2p::noise::Config::new, libp2p::yamux::Config::default)?
             .with_behaviour(move |key, relay_client| {
                 let local_pid = PeerId::from(key.public());

--- a/omnia-network/src/network.rs
+++ b/omnia-network/src/network.rs
@@ -407,6 +407,10 @@ pub struct OmniaBehaviour {
     pub req_res: libp2p::request_response::cbor::Behaviour<Vec<u8>, Vec<u8>>,
     /// Kademlia DHT for wide-area peer discovery
     pub kademlia: libp2p::kad::Behaviour<libp2p::kad::store::MemoryStore>,
+    /// Identify — exchanges listen addresses and supported protocols so
+    /// Kademlia can populate its routing table (without it Kademlia has no
+    /// known peers and DHT discovery never bootstraps).
+    pub identify: libp2p::identify::Behaviour,
     /// AutoNAT for NAT type detection
     pub autonat: libp2p::autonat::Behaviour,
     /// Relay client for NAT traversal
@@ -553,6 +557,13 @@ impl OmniaNetwork {
                     }
                 }
 
+                // Identify: advertise our protocols/addresses and learn peers'
+                // so Kademlia can route. Uses the same libp2p keypair.
+                let identify = libp2p::identify::Behaviour::new(
+                    libp2p::identify::Config::new("/omnia/id/1.0.0".to_string(), key.public())
+                        .with_agent_version(format!("omnia-node/{}", env!("CARGO_PKG_VERSION"))),
+                );
+
                 // AutoNAT for NAT detection
                 let autonat = libp2p::autonat::Behaviour::new(local_pid, autonat_config);
 
@@ -564,6 +575,7 @@ impl OmniaNetwork {
                     mdns,
                     req_res,
                     kademlia,
+                    identify,
                     autonat,
                     relay_client,
                     dcutr,
@@ -772,6 +784,22 @@ impl OmniaNetwork {
                     }
                     _ => {}
                 }
+            }
+            // Identify event handling — feed a peer's advertised listen
+            // addresses into Kademlia's routing table. Without this the
+            // routing table stays empty (`bootstrap()` → NoKnownPeers) and
+            // peers never discover each other beyond the initial dial, so the
+            // gossip mesh cannot grow past a star around the bootstrap.
+            SwarmEvent::Behaviour(OmniaBehaviourEvent::Identify(libp2p::identify::Event::Received {
+                peer_id,
+                info,
+                ..
+            })) => {
+                for addr in info.listen_addrs {
+                    self.swarm.behaviour_mut().kademlia.add_address(&peer_id, addr.clone());
+                    self.known_peers.insert(peer_id, addr);
+                }
+                tracing::debug!(peer = %peer_id, "Identify: added peer addresses to Kademlia");
             }
             // AutoNAT event handling — log NAT status changes
             SwarmEvent::Behaviour(OmniaBehaviourEvent::Autonat(libp2p::autonat::Event::StatusChanged { old, new })) => {


### PR DESCRIPTION

The swarm had no identify behaviour, so Kademlia never learned any peer's
listen addresses: its routing table stayed empty (`bootstrap()` →
NoKnownPeers) and nodes never discovered each other beyond the initial
bootstrap dial. On the docker-compose testnet this left a star — every
worker connected only to the bootstrap (peers=1) and never to its
siblings — and cross-node gossip propagation stayed at 0%.

Add libp2p::identify (protocol `/omnia/id/1.0.0`) and, on
identify::Event::Received, feed the peer's advertised listen addresses
into Kademlia's routing table (and known_peers). This is the standard
libp2p Kademlia pairing: identify is what lets the DHT route, which lets
peers find each other and the gossip mesh grow past the bootstrap star.

Stacked on the /dns4 DNS-resolution fix (both are required for the
compose testnet to mesh): DNS lets workers dial the bootstrap by service
name; identify lets them then discover and connect to one another.

