### PR TITLE
fix(network): gossipsub mesh scoring + rate-limit deferral — 100% testnet propagation

### DIFF
--- a/docs/reference/benchmark-gates.md
+++ b/docs/reference/benchmark-gates.md
@@ -176,6 +176,44 @@ misinterpretation (comparing two different circuits).
 | iai-self-hosted | IAI gate, 1% threshold | 30 min |
 | zk-self-hosted | ZK multi-sample, 5% threshold | 60 min |
 
+## Live Multi-Node Testnet (ADR-025 Stage 2)
+
+First **real-network** (not simulated) propagation measurement, captured
+with `scripts/testnet-bench.sh` on 2026-07-17.
+
+**Topology:** 5 nodes (1 bootstrap + 4 workers), Docker Compose
+(`docker/docker-compose.yml`) on a single Hetzner host (16 GB,
+Ubuntu 26.04), QUIC transport over the compose bridge network, gossipsub
+mesh. Rate limit `OMNIA_RATE_LIMIT_RPS=1000` (HTTP);
+gossip per-peer limit at defaults (burst 200, 100 ev/s refill).
+Report: `bench-results/testnet-bench-20260717-094054.json`.
+
+| Metric | Value |
+|--------|-------|
+| Events submitted (to bootstrap) | 1,000 (16-way concurrency) |
+| HTTP submit rate | 460.8 ev/s (includes HTTP + JSON + node-side signing) |
+| Propagation | **100% on all 5 nodes** |
+| Convergence (submit node) | 4.25 s |
+| Convergence (4 peers) | 10.40–10.44 s |
+| Peer RSS during run | 33–42 MB |
+
+The ~10.4 s peer convergence matches the gossip backpressure model
+exactly: a 200-event burst is admitted immediately, the remaining 800
+drain at the 100 ev/s per-peer refill (≈8 s) — see the rate-limit
+deferral note in `omnia-network/src/gossip.rs`.
+
+This measurement follows four stacked networking fixes, each masked by
+the previous one (propagation was 0% before them): `/dns4` bootstrap
+addresses did not resolve (no DNS transport); no identify behaviour, so
+Kademlia never populated; the gossipsub mesh-deliveries penalty
+graylisted every quiet peer ~30 s after boot, collapsing the mesh; and
+the per-peer gossip rate limiter permanently dropped over-burst events
+instead of deferring them (capping propagation at 20%).
+
+> Methodology: numbers include HTTP/JSON overhead and are NOT comparable
+> to the in-process hot-path numbers above. Single-host containers mean
+> near-zero RTT; a geo-distributed run will be slower.
+
 ## Historical Baselines
 
 ### v0.1.48 (2026-05-23)

--- a/node/tests/integration.rs
+++ b/node/tests/integration.rs
@@ -44,17 +44,29 @@ impl Drop for EnvGuard {
     }
 }
 
+/// Bundles the env-var cleanup guard with the serialisation lock so they
+/// drop in a safe order: struct fields drop in declaration order, so
+/// `_env_guard`'s `remove_var` runs while `_lock` is still held.
+///
+/// These guards were previously returned as separate tuple elements
+/// `(.., env_guard, lock)`, and bindings in a `let`-tuple pattern drop in
+/// REVERSE order — the lock released first, and only then did `remove_var`
+/// run, unserialised. A racing test could acquire the lock and
+/// `set_var(OMNIA_JWT_SECRET)` in that window, have this cleanup yank the
+/// var back out from under it, and then cache "unset" in the JWT secret
+/// cache — the source of the Windows `test_submit_event`
+/// `SecretNotConfigured` flake.
+struct ServerGuards {
+    _env_guard: EnvGuard,
+    _lock: std::sync::MutexGuard<'static, ()>,
+}
+
 /// Helper: start the node HTTP server on a random port and return
 /// the base URL and a shutdown handle.
 ///
 /// The server runs in a background tokio task and will be stopped
 /// when the shutdown handle is dropped.
-async fn start_test_server() -> (
-    String,
-    tokio::task::JoinHandle<()>,
-    EnvGuard,
-    std::sync::MutexGuard<'static, ()>,
-) {
+async fn start_test_server() -> (String, tokio::task::JoinHandle<()>, ServerGuards) {
     let lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
     // Set JWT secret before building the router so auth middleware can read it
     std::env::set_var("OMNIA_JWT_SECRET", TEST_JWT_SECRET);
@@ -145,12 +157,19 @@ async fn start_test_server() -> (
     // Give the server a moment to start
     tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
 
-    (format!("http://127.0.0.1:{port}"), handle, env_guard, lock)
+    (
+        format!("http://127.0.0.1:{port}"),
+        handle,
+        ServerGuards {
+            _env_guard: env_guard,
+            _lock: lock,
+        },
+    )
 }
 
 #[tokio::test]
 async fn test_health_endpoint() -> Result<()> {
-    let (base_url, _handle, _env_guard, _lock) = start_test_server().await;
+    let (base_url, _handle, _guards) = start_test_server().await;
 
     let client = reqwest::Client::new();
     let resp = client.get(format!("{base_url}/health")).send().await?;
@@ -167,7 +186,7 @@ async fn test_health_endpoint() -> Result<()> {
 #[tokio::test]
 #[cfg(feature = "metrics")]
 async fn test_metrics_endpoint() -> Result<()> {
-    let (base_url, _handle, _env_guard, _lock) = start_test_server().await;
+    let (base_url, _handle, _guards) = start_test_server().await;
 
     let client = reqwest::Client::new();
     let resp = client.get(format!("{base_url}/metrics")).send().await?;
@@ -189,7 +208,7 @@ async fn test_metrics_endpoint() -> Result<()> {
 #[tokio::test]
 #[cfg(not(feature = "metrics"))]
 async fn test_metrics_endpoint_disabled() -> Result<()> {
-    let (base_url, _handle, _env_guard, _lock) = start_test_server().await;
+    let (base_url, _handle, _guards) = start_test_server().await;
 
     let client = reqwest::Client::new();
     let resp = client.get(format!("{base_url}/metrics")).send().await?;
@@ -205,7 +224,7 @@ async fn test_metrics_endpoint_disabled() -> Result<()> {
 
 #[tokio::test]
 async fn test_submit_event() -> Result<()> {
-    let (base_url, _handle, _env_guard, _lock) = start_test_server().await;
+    let (base_url, _handle, _guards) = start_test_server().await;
 
     let token = create_token("test-caller", 3600).expect("create test token");
     let client = reqwest::Client::new();
@@ -230,7 +249,7 @@ async fn test_submit_event() -> Result<()> {
 
 #[tokio::test]
 async fn test_get_event_not_found() -> Result<()> {
-    let (base_url, _handle, _env_guard, _lock) = start_test_server().await;
+    let (base_url, _handle, _guards) = start_test_server().await;
 
     let token = create_token("test-caller", 3600).expect("create test token");
     let client = reqwest::Client::new();
@@ -258,7 +277,7 @@ async fn test_get_event_not_found() -> Result<()> {
 #[tokio::test]
 #[cfg(feature = "swagger-ui")]
 async fn test_swagger_ui() -> Result<()> {
-    let (base_url, _handle, _env_guard, _lock) = start_test_server().await;
+    let (base_url, _handle, _guards) = start_test_server().await;
     let client = reqwest::Client::new();
     let resp = client.get(format!("{base_url}/swagger-ui/")).send().await?;
     assert_eq!(
@@ -273,7 +292,7 @@ async fn test_swagger_ui() -> Result<()> {
 #[tokio::test]
 #[cfg(not(feature = "swagger-ui"))]
 async fn test_swagger_ui_disabled() -> Result<()> {
-    let (base_url, _handle, _env_guard, _lock) = start_test_server().await;
+    let (base_url, _handle, _guards) = start_test_server().await;
     let client = reqwest::Client::new();
     let resp = client.get(format!("{base_url}/swagger-ui/")).send().await?;
     assert_eq!(resp.status(), 404, "Swagger UI should be 404 when feature disabled");
@@ -284,7 +303,7 @@ async fn test_swagger_ui_disabled() -> Result<()> {
 #[tokio::test]
 #[cfg(feature = "swagger-ui")]
 async fn test_openapi_json() -> Result<()> {
-    let (base_url, _handle, _env_guard, _lock) = start_test_server().await;
+    let (base_url, _handle, _guards) = start_test_server().await;
     let client = reqwest::Client::new();
     let resp = client.get(format!("{base_url}/api-docs/openapi.json")).send().await?;
     assert_eq!(
@@ -312,7 +331,7 @@ async fn test_openapi_json() -> Result<()> {
 #[tokio::test]
 #[cfg(not(feature = "swagger-ui"))]
 async fn test_openapi_json_disabled() -> Result<()> {
-    let (base_url, _handle, _env_guard, _lock) = start_test_server().await;
+    let (base_url, _handle, _guards) = start_test_server().await;
     let client = reqwest::Client::new();
     let resp = client.get(format!("{base_url}/api-docs/openapi.json")).send().await?;
     assert_eq!(resp.status(), 404, "OpenAPI JSON should be 404 when feature disabled");

--- a/omnia-network/src/gossip.rs
+++ b/omnia-network/src/gossip.rs
@@ -261,7 +261,24 @@ pub struct GossipProtocol {
     partition_active: bool,
     /// Per-peer rate limiter (token bucket).
     rate_limiter: RateLimiter,
+    /// Events that exceeded a peer's rate limit, held for retry on the next
+    /// processing round instead of being dropped. Bounded by
+    /// [`MAX_RATE_DEFERRED`]; beyond that events are dropped as before.
+    ///
+    /// Rationale: gossipsub delivers a message to a mesh peer exactly once —
+    /// an event dropped here is *permanently lost* to this node (no
+    /// redelivery), which turned the rate limiter into a data-loss mechanism
+    /// for honest bursts (e.g. a 1000-event burst from one peer capped at
+    /// `burst_capacity` inserted, the rest gone). Deferring converts the
+    /// limiter into backpressure: the burst drains at the refill rate over
+    /// subsequent rounds while memory stays bounded.
+    rate_deferred: VecDeque<(Box<Event>, PeerId)>,
 }
+
+/// Maximum events held for rate-limit retry (DoS bound for the internal
+/// `GossipProtocol::rate_deferred` queue). Oversized payloads are rejected
+/// before deferral, so worst-case memory is bounded by well-formed events.
+pub const MAX_RATE_DEFERRED: usize = 4096;
 
 impl GossipProtocol {
     /// Create a new gossip protocol instance
@@ -296,6 +313,7 @@ impl GossipProtocol {
             last_heartbeat: Instant::now(),
             partition_active: false,
             rate_limiter,
+            rate_deferred: VecDeque::new(),
         }
     }
 
@@ -664,25 +682,26 @@ impl GossipProtocol {
             self.network_rx = None;
         }
 
-        // Phase 2: Process drained events (validation, dedup, partition tracking)
-        for evt in drained {
+        // Phase 2: Process events — rate-limit-deferred retries from earlier
+        // rounds first (their tokens may have refilled; FIFO keeps ordering
+        // fair), then the freshly drained batch.
+        let mut work: Vec<DrainedEvent> = self
+            .rate_deferred
+            .drain(..)
+            .map(|(event, source)| DrainedEvent::Gossip { event, source })
+            .collect();
+        work.extend(drained);
+        for evt in work {
             match evt {
                 DrainedEvent::Gossip { event, source } => {
                     // Update last_seen for partition detection
                     self.last_seen.insert(source, Instant::now());
 
-                    // Rate limit check: hash PeerId bytes with domain separation
-                    let peer_id_bytes = blake3_hash_domain(b"omnia-nonce", &source.to_bytes());
-                    if !self.rate_limiter.allow(&peer_id_bytes) {
-                        warn!(peer = ?source, "Rate limiting peer — dropping event");
-                        self.stats.events_rejected += 1;
-                        continue;
-                    }
-
-                    // Defense-in-depth: reject oversized payloads BEFORE
-                    // any expensive crypto validation. The Event::validate()
-                    // also checks this, but the gossip layer enforces it
-                    // early to avoid wasted CPU on signature verification.
+                    // Defense-in-depth: reject oversized payloads BEFORE the
+                    // rate limiter (so junk never occupies deferred slots)
+                    // and before any expensive crypto validation.
+                    // Event::validate() also checks this, but the gossip
+                    // layer enforces it early to avoid wasted CPU.
                     if event.payload.len() > MAX_PAYLOAD_SIZE {
                         warn!(
                             size = event.payload.len(),
@@ -690,6 +709,25 @@ impl GossipProtocol {
                             "Gossip event rejected: payload exceeds MAX_PAYLOAD_SIZE"
                         );
                         self.stats.events_rejected += 1;
+                        continue;
+                    }
+
+                    // Rate limit check: hash PeerId bytes with domain
+                    // separation. Over-limit events are DEFERRED to the next
+                    // processing round (token bucket refills at
+                    // `max_events_per_second`), not dropped: gossipsub never
+                    // redelivers, so a drop here would lose the event on this
+                    // node permanently. Only when the bounded deferral queue
+                    // is itself full does the old drop behaviour kick in.
+                    let peer_id_bytes = blake3_hash_domain(b"omnia-nonce", &source.to_bytes());
+                    if !self.rate_limiter.allow(&peer_id_bytes) {
+                        if self.rate_deferred.len() < MAX_RATE_DEFERRED {
+                            tracing::debug!(peer = ?source, "Rate limiting peer — deferring event to next round");
+                            self.rate_deferred.push_back((event, source));
+                        } else {
+                            warn!(peer = ?source, "Rate limiting peer — deferral queue full, dropping event");
+                            self.stats.events_rejected += 1;
+                        }
                         continue;
                     }
 
@@ -1119,6 +1157,62 @@ mod tests {
 
         let g = gossip.graph().read().await;
         assert!(g.contains(&event_id));
+    }
+
+    #[tokio::test]
+    async fn test_rate_limited_events_deferred_not_dropped() {
+        use tokio::sync::mpsc;
+
+        let graph = Arc::new(RwLock::new(CausalGraph::new()));
+        let config = GossipConfig {
+            // Tiny burst so 5 events from one peer overflow immediately. The
+            // refill must be much slower than the drain loop (1 token per
+            // 100ms vs ~µs per event) or tokens regenerate mid-drain and the
+            // limiter never trips; the sleeps below then span whole refills.
+            burst_capacity: 2,
+            max_events_per_second: 10,
+            ..Default::default()
+        };
+        let mut gossip = GossipProtocol::new(node(1), config, graph);
+
+        let (tx, rx) = mpsc::channel(10);
+        gossip.network_rx = Some(rx);
+
+        let peer = PeerId::random();
+        for i in 0..5u8 {
+            let keypair = generate_keypair();
+            let mut event = Event::genesis(node(10 + i), vec![i]).expect("valid genesis event");
+            event.sign_with_keypair(&keypair).expect("signing");
+            tx.send(NetworkEvent::GossipReceived {
+                topic: "omnia_events".to_string(),
+                data: event.to_bytes().expect("serialize"),
+                propagation_source: peer,
+            })
+            .await
+            .expect("send should succeed");
+        }
+        drop(tx);
+
+        // Round 1: burst of 2 admitted, 3 deferred — and crucially NOT
+        // counted as rejected (they are not lost).
+        let inserted = gossip.process_pending_events().await.expect("process");
+        assert_eq!(inserted.len(), 2, "burst capacity admitted");
+        assert_eq!(gossip.rate_deferred.len(), 3, "overflow deferred, not dropped");
+        assert_eq!(gossip.stats().events_rejected, 0);
+
+        // Round 2 (after refill; tokens cap at burst_capacity=2).
+        std::thread::sleep(std::time::Duration::from_millis(250));
+        let inserted = gossip.process_pending_events().await.expect("process");
+        assert_eq!(inserted.len(), 2, "deferred events retried after refill");
+        assert_eq!(gossip.rate_deferred.len(), 1);
+
+        // Round 3: the last one lands. Nothing was ever lost.
+        std::thread::sleep(std::time::Duration::from_millis(250));
+        let inserted = gossip.process_pending_events().await.expect("process");
+        assert_eq!(inserted.len(), 1, "final deferred event delivered");
+        assert!(gossip.rate_deferred.is_empty());
+        assert_eq!(gossip.stats().events_rejected, 0, "no event was dropped");
+        assert_eq!(gossip.graph().read().await.len(), 5, "all 5 events inserted");
     }
 
     // ── Task 3.2: Bootstrap Peer Tests ─────────────────────────────────

--- a/omnia-network/src/network.rs
+++ b/omnia-network/src/network.rs
@@ -20,9 +20,11 @@
 //!
 //! # GossipSub Peer Scoring (H-5)
 //!
-//! Custom peer scoring tuned for Omnia's threat model, with heavy penalties
-//! for invalid messages and mesh delivery failures. See
-//! [`configure_gossipsub_scoring()`] and [`PeerScoreTracker`].
+//! Custom peer scoring tuned for Omnia's threat model: a heavy penalty for
+//! invalid messages plus rewards for first-delivery and time-in-mesh. The
+//! mesh-message-deliveries deficit penalty is intentionally disabled (it
+//! collapses low-traffic meshes — see [`configure_gossipsub_scoring()`]).
+//! See also [`PeerScoreTracker`].
 
 // The libp2p NetworkBehaviour derive macro generates an event enum without
 // doc comments on its variants, which triggers missing_docs. Allow it here
@@ -246,13 +248,31 @@ pub fn configure_gossipsub_scoring() -> (PeerScoreParams, PeerScoreThresholds) {
         first_message_deliveries_weight: 1.0,
         first_message_deliveries_decay: 0.99,
         first_message_deliveries_cap: 100.0,
-        mesh_message_deliveries_weight: -50.0,
+        // Mesh-message-deliveries penalty DISABLED (weight 0).
+        //
+        // This penalty assumes every mesh peer delivers at least
+        // `mesh_message_deliveries_threshold` messages per window. On a low-
+        // or bursty-traffic topic no honest peer meets that bar, so once the
+        // 30s activation elapses every mesh peer is scored
+        // `weight * deficit^2` (with the old -50 weight and a full deficit of
+        // 10 that is -5000), driven far below `graylist_threshold` (-100), and
+        // pruned across all topics — collapsing the mesh ~30s after it forms
+        // and never recovering. libp2p documents this parameter as only safe
+        // with reliable, high message rates; Omnia's event/heartbeat topics
+        // are neither, so it is left off. Anti-spam is retained via the
+        // invalid-message penalty below and per-event signature validation.
+        //
+        // libp2p skips validation of the companion fields when the weight is
+        // 0, so the remaining values here are inert.
+        mesh_message_deliveries_weight: 0.0,
         mesh_message_deliveries_decay: 0.99,
         mesh_message_deliveries_threshold: 10.0,
         mesh_message_deliveries_cap: 100.0,
         mesh_message_deliveries_window: std::time::Duration::from_millis(100),
         mesh_message_deliveries_activation: std::time::Duration::from_secs(30),
-        mesh_failure_penalty_weight: -50.0,
+        // Mesh-failure penalty also disabled: it is derived from the same
+        // deliveries tracking and would likewise punish quiet honest peers.
+        mesh_failure_penalty_weight: 0.0,
         mesh_failure_penalty_decay: 0.99,
         invalid_message_deliveries_weight: -150.0,
         invalid_message_deliveries_decay: 0.999,


### PR DESCRIPTION
## Summary

Completes the live-testnet propagation debugging arc. After the `/dns4` DNS-transport fix and the identify/Kademlia fix landed, cross-node propagation was still 0%. This PR fixes the two remaining defects, each validated on the live 5-node compose testnet, plus a long-standing Windows CI flake, and records the first real-network Stage 2 benchmark.

**Result on the live testnet: 1000 events → 100% propagation on all 5 nodes, peers converging in ~10.4 s.**

## Fix 1: gossipsub mesh-deliveries penalty collapsed the mesh (0% → 20%)

Debug logs showed the mesh forming correctly at connect, then exactly 30 s later (the `mesh_message_deliveries_activation` window):

```
[Penalty] mesh deliveries deficit ... deficit=10 penalty=-5000
HEARTBEAT: Prune peer with negative score score=-4999.7
HEARTBEAT: Mesh low. Topic contains: 0 needs: 6
```

`mesh_message_deliveries_weight: -50` × deficit² (10²) = **−5000** for every quiet-but-honest mesh peer — far past the −100 graylist threshold — so every peer was pruned from all topics ~30 s after boot and the mesh never recovered. libp2p documents this penalty as safe only for reliably high-rate topics; Omnia's event topics are bursty. Both `mesh_message_deliveries_weight` and the derived `mesh_failure_penalty_weight` are now 0. Anti-spam remains via the −150 invalid-message penalty and per-event Ed25519 validation.

## Fix 2: per-peer rate limiter permanently dropped over-burst events (20% → 100%)

With the mesh alive, workers received **exactly 200 of 1000** events — precisely `burst_capacity`. gossipsub delivers a message to a mesh peer exactly once, so events dropped by the receive-side token bucket were lost forever. Rate-limited events now go to a bounded deferral queue (`MAX_RATE_DEFERRED = 4096`) retried each processing round as tokens refill — backpressure instead of data loss. DoS bounds preserved: queue bounded (drop beyond it), oversized payloads rejected before deferral. New deterministic test: 5-event burst against burst_capacity=2 → all 5 delivered across three rounds, zero counted rejected.

## Fix 3: Windows `test_submit_event` `SecretNotConfigured` flake (root-caused at last)

`start_test_server` returned `(base_url, handle, env_guard, lock)` — and `let`-tuple bindings drop in **reverse** order: the `ENV_LOCK` released *before* `EnvGuard::drop` ran `remove_var("OMNIA_JWT_SECRET")`. A racing test could acquire the lock and set the secret in that unserialised window, have the leftover cleanup yank it out, then cache "unset" → `SecretNotConfigured`. Guards are now bundled in a `ServerGuards` struct (fields drop in declaration order → env cleanup under the lock), matching the shape `api_integration.rs` already used.

## Benchmark record

`docs/reference/benchmark-gates.md` gains the first real-network Stage 2 measurement (5-node compose, 1000 events, 100% propagation, convergence 4.25 s / ~10.4 s, RSS 33–42 MB) with topology + methodology notes. The ~10.4 s matches the deferral model exactly: 200-burst + 800 events at the 100 ev/s refill.

## Verification

- Live testnet (Hetzner, 5 nodes): benchmark above — 100% propagation on all nodes
- `cargo test -p omnia-network --features network --lib` → 133 passed (incl. new deferral test)
- `cargo test -p omnia-node --test integration` → 6 passed
- `cargo fmt --all -- --check` → clean
- `cargo clippy -p omnia-network --features network --all-targets -- -D warnings -D clippy::unwrap_used` → clean
- `RUSTDOCFLAGS="-D warnings" cargo doc -p omnia-network --no-deps --features network` → clean