### PR TITLE
docs(benchmarks): record full Stage 2 multi-node load matrix

### DIFF
--- a/docs/reference/benchmark-gates.md
+++ b/docs/reference/benchmark-gates.md
@@ -2,7 +2,7 @@
 
 > Audience: Developers, CI Engineers
 > Context: 3-layer benchmark regression gate architecture, current baselines, and IAI instruction-count gates
-> Last Updated: 2026-07-09
+> Last Updated: 2026-07-17
 
 
 ## Local Reference Run — 2026-07-09 (v0.1.76+/dev)
@@ -178,29 +178,47 @@ misinterpretation (comparing two different circuits).
 
 ## Live Multi-Node Testnet (ADR-025 Stage 2)
 
-First **real-network** (not simulated) propagation measurement, captured
-with `scripts/testnet-bench.sh` on 2026-07-17.
+First **real-network** (not simulated) propagation measurements, captured
+with `scripts/testnet-bench.sh` on 2026-07-17 against stock `dev`.
 
 **Topology:** 5 nodes (1 bootstrap + 4 workers), Docker Compose
 (`docker/docker-compose.yml`) on a single Hetzner host (16 GB,
-Ubuntu 26.04), QUIC transport over the compose bridge network, gossipsub
-mesh. Rate limit `OMNIA_RATE_LIMIT_RPS=1000` (HTTP);
-gossip per-peer limit at defaults (burst 200, 100 ev/s refill).
-Report: `bench-results/testnet-bench-20260717-094054.json`.
+Ubuntu 26.04), QUIC transport over the compose bridge network. Workers
+connect to the bootstrap (star); gossipsub floods through the hub. Rate
+limit `OMNIA_RATE_LIMIT_RPS=1000` (HTTP); gossip per-peer limit at
+defaults (burst 200, 100 ev/s refill, deferral queue 4096).
+Reports: `bench-results/testnet-bench-20260717-16*.json`.
 
-| Metric | Value |
-|--------|-------|
-| Events submitted (to bootstrap) | 1,000 (16-way concurrency) |
-| HTTP submit rate | 460.8 ev/s (includes HTTP + JSON + node-side signing) |
-| Propagation | **100% on all 5 nodes** |
-| Convergence (submit node) | 4.25 s |
-| Convergence (4 peers) | 10.40–10.44 s |
-| Peer RSS during run | 33–42 MB |
+### Load matrix
 
-The ~10.4 s peer convergence matches the gossip backpressure model
-exactly: a 200-event burst is admitted immediately, the remaining 800
-drain at the 100 ev/s per-peer refill (≈8 s) — see the rate-limit
-deferral note in `omnia-network/src/gossip.rs`.
+| Run | Events | Conc. | Submit rate | Propagation | Peer convergence |
+|-----|--------|-------|-------------|-------------|------------------|
+| A1 | 1,000 | 16 | 465.1 ev/s | 100% ×5 | 10.38–10.43 s |
+| A2 | 1,000 | 16 | 485.4 ev/s | 100% ×5 | 10.28–10.32 s |
+| A3 | 1,000 | 16 | 497.5 ev/s | 100% ×5 | 10.23–10.28 s |
+| B | 2,000 | 32 | 449.4 ev/s | 100% ×5 | 20.99–21.04 s |
+| C | 5,000 | 32 | 431.4 ev/s | 100% ×4, **54.1% ×1** | 50.60–50.64 s |
+
+**Standard load (A, n=3):** submit **482.7 ± 16 ev/s**; peers converge in
+**10.3 ± 0.1 s**; submit node in ~4.2 s. Peer RSS 33–42 MB (1k), 62–73 MB
+(5k).
+
+**Scaling (A→B):** peer convergence is linear in burst size, matching the
+gossip backpressure model exactly — a 200-event burst is admitted
+immediately, the remainder drains at the 100 ev/s per-peer refill
+(1,000 ev → ~10 s; 2,000 ev → ~21 s). See the rate-limit deferral note in
+`omnia-network/src/gossip.rs`.
+
+**Capacity ceiling (C):** a single-source burst of 5,000 events sits at
+the edge of per-peer capacity (burst 200 + deferral queue 4,096 + refill
+during the ~12 s submit window ≈ 5,300). Three workers converged at
+100% in ~50.6 s; one worker's deferral queue overflowed and it capped at
+2,703 events (54.1%) — and **stayed there**, because events dropped at
+the gossip layer are never re-requested (no anti-entropy repair yet;
+tracked in issue #315). Practical guidance with default config:
+keep single-peer bursts ≤ 4,000 events, or raise
+`max_events_per_second`/`burst_capacity` in the gossip config for
+higher-throughput deployments.
 
 This measurement follows four stacked networking fixes, each masked by
 the previous one (propagation was 0% before them): `/dns4` bootstrap


### PR DESCRIPTION
## Summary

Replaces the single-point Stage 2 entry in `docs/reference/benchmark-gates.md` with the complete load matrix captured 2026-07-17 against **stock `dev`** on the live 5-node compose testnet. This closes the last open ADR-025 Stage 2 deliverable (real multi-node benchmark numbers).

## The matrix

| Run | Events | Conc. | Submit rate | Propagation | Peer convergence |
|-----|--------|-------|-------------|-------------|------------------|
| A1–A3 | 1,000 | 16 | 482.7 ± 16 ev/s | 100% ×5, every run | 10.3 ± 0.1 s |
| B | 2,000 | 32 | 449.4 ev/s | 100% ×5 | ~21.0 s |
| C | 5,000 | 32 | 431.4 ev/s | 100% ×4, 54.1% ×1 | ~50.6 s |

- **Repeatability:** three standard-load samples agree within 2% on convergence time.
- **Linear scaling:** convergence tracks the gossip backpressure model exactly (burst 200 admitted instantly, remainder drains at the 100 ev/s per-peer refill).
- **Capacity ceiling found:** run C deliberately probed the deferral-queue headroom (burst 200 + queue 4,096 + refill during submit ≈ 5,300). One worker overflowed and permanently capped at 2,703/5,000 — gossip-layer drops have no anti-entropy repair, now tracked in #315. The doc records the practical guidance: single-peer bursts ≤ 4,000 with default config.

Also bumps the doc's Last-Updated date. Raw reports live on the benchmark host under `bench-results/testnet-bench-20260717-16*.json`.

Docs-only change — no code paths affected.