### PR TITLE
feat(testnet): worker mesh topology, Lane 0 finality metric, deferral observability

### DIFF
--- a/docker/docker-compose.lane0.yml
+++ b/docker/docker-compose.lane0.yml
@@ -1,0 +1,54 @@
+# Omnia Protocol — Lane 0 validator overlay for the 5-node testnet
+#
+# Enables ADR-025 Lane 0 (consensusless quorum-ack finality) on the stock
+# docker-compose.yml stack by giving every node a persistent validator
+# keypair whose public key is in the shared OMNIA_LANE0_VALIDATORS set.
+#
+# Setup (once):
+#   NODES=5 ./scripts/setup-validators.sh
+#     — generates ops/testnet-keys/node{0..4}/ and writes
+#       OMNIA_LANE0_VALIDATORS (+ a fresh OMNIA_JWT_SECRET if absent)
+#       into docker/.env, which compose reads automatically.
+#
+# Run:
+#   docker compose -f docker/docker-compose.yml -f docker/docker-compose.lane0.yml up -d --build
+#
+# Verify Lane 0 is live (each node reports a lane0 epoch, not null):
+#   for p in 9090 9091 9092 9093 9094; do
+#     curl -s http://localhost:$p/api/v1/node/info | jq '{node_id, lane0}'
+#   done
+#
+# With Lane 0 enabled, `omnia_node_events_finalized_total` counts
+# quorum-acked events, so scripts/testnet-bench.sh measures real finality
+# instead of DAG replication only.
+
+services:
+  omnia-bootstrap:
+    environment:
+      - OMNIA_NODE_KEY_FILE=/keys/validator_key.bin
+    volumes:
+      - ../ops/testnet-keys/node0:/keys:ro
+
+  omnia-node-1:
+    environment:
+      - OMNIA_NODE_KEY_FILE=/keys/validator_key.bin
+    volumes:
+      - ../ops/testnet-keys/node1:/keys:ro
+
+  omnia-node-2:
+    environment:
+      - OMNIA_NODE_KEY_FILE=/keys/validator_key.bin
+    volumes:
+      - ../ops/testnet-keys/node2:/keys:ro
+
+  omnia-node-3:
+    environment:
+      - OMNIA_NODE_KEY_FILE=/keys/validator_key.bin
+    volumes:
+      - ../ops/testnet-keys/node3:/keys:ro
+
+  omnia-node-4:
+    environment:
+      - OMNIA_NODE_KEY_FILE=/keys/validator_key.bin
+    volumes:
+      - ../ops/testnet-keys/node4:/keys:ro

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -73,7 +73,7 @@ services:
     environment:
       - RUST_LOG=info
       - OMNIA_NODE_ID=3
-      - OMNIA_BOOTSTRAP_NODES=/dns4/omnia-bootstrap/udp/4001/quic-v1
+      - OMNIA_BOOTSTRAP_NODES=/dns4/omnia-bootstrap/udp/4001/quic-v1,/dns4/omnia-node-1/udp/4001/quic-v1
       - OMNIA_LISTEN_ADDR=/ip4/0.0.0.0/udp/4001/quic-v1
       - OMNIA_HTTP_PORT=8080
       - OMNIA_DATA_DIR=/app/data
@@ -92,6 +92,8 @@ services:
     depends_on:
       omnia-bootstrap:
         condition: service_healthy
+      omnia-node-1:
+        condition: service_started
 
   omnia-node-3:
     build:
@@ -101,7 +103,7 @@ services:
     environment:
       - RUST_LOG=info
       - OMNIA_NODE_ID=4
-      - OMNIA_BOOTSTRAP_NODES=/dns4/omnia-bootstrap/udp/4001/quic-v1
+      - OMNIA_BOOTSTRAP_NODES=/dns4/omnia-bootstrap/udp/4001/quic-v1,/dns4/omnia-node-1/udp/4001/quic-v1,/dns4/omnia-node-2/udp/4001/quic-v1
       - OMNIA_LISTEN_ADDR=/ip4/0.0.0.0/udp/4001/quic-v1
       - OMNIA_HTTP_PORT=8080
       - OMNIA_DATA_DIR=/app/data
@@ -120,6 +122,10 @@ services:
     depends_on:
       omnia-bootstrap:
         condition: service_healthy
+      omnia-node-1:
+        condition: service_started
+      omnia-node-2:
+        condition: service_started
 
   omnia-node-4:
     build:
@@ -129,7 +135,7 @@ services:
     environment:
       - RUST_LOG=info
       - OMNIA_NODE_ID=5
-      - OMNIA_BOOTSTRAP_NODES=/dns4/omnia-bootstrap/udp/4001/quic-v1
+      - OMNIA_BOOTSTRAP_NODES=/dns4/omnia-bootstrap/udp/4001/quic-v1,/dns4/omnia-node-1/udp/4001/quic-v1,/dns4/omnia-node-2/udp/4001/quic-v1,/dns4/omnia-node-3/udp/4001/quic-v1
       - OMNIA_LISTEN_ADDR=/ip4/0.0.0.0/udp/4001/quic-v1
       - OMNIA_HTTP_PORT=8080
       - OMNIA_DATA_DIR=/app/data
@@ -148,6 +154,12 @@ services:
     depends_on:
       omnia-bootstrap:
         condition: service_healthy
+      omnia-node-1:
+        condition: service_started
+      omnia-node-2:
+        condition: service_started
+      omnia-node-3:
+        condition: service_started
 
   # ── Omnia Web Dashboard ───────────────────────────────────────────────
   omnia-web:

--- a/docs/operations/testnet-benchmark.md
+++ b/docs/operations/testnet-benchmark.md
@@ -95,9 +95,31 @@ These become the **pre-Lane-0 baseline** that ADR-025 Stage 3 must beat.
 - **prop % = 0 on non-target nodes** — the nodes never meshed: verify
   bootstrap addresses and that UDP/QUIC ports are reachable between hosts.
 - **429s during submission** — raise `OMNIA_RATE_LIMIT_RPS` (see above).
-- **finalized_total stays 0** — expected on topologies without a validator
-  quorum; finality metrics become meaningful once the validator set is
-  established (Stage 2+ with staked validators).
+- **finalized_total stays 0** — expected without Lane 0: all benchmark
+  events are signed by the submit node (one creator), so Lane 1 rounds
+  cannot advance (fame voting needs ≥ 2f+1 distinct creators). To measure
+  real finality, enable the Lane 0 validator overlay:
+
+  ```
+  NODES=5 ./scripts/setup-validators.sh
+  docker compose -f docker/docker-compose.yml \
+                 -f docker/docker-compose.lane0.yml up -d --build
+  ```
+
+  Quorum-acked events then feed `omnia_node_events_finalized_total`, and
+  the bench's `finalized_total` column reports Lane 0 finality.
+
+## Topology
+
+The stock `docker-compose.yml` forms a **worker mesh**: node-K dials the
+bootstrap plus workers 1..K-1 (all dial targets are compose service
+names, resolved by the DNS transport). This removes the bootstrap as the
+sole distributor and — because the gossip receive rate limit is
+per-peer — multiplies each node's effective ingest rate by its peer
+count. Watch for the `Rate-limit deferral queue` log lines (and the
+`rate_deferred_depth` / `rate_deferred_high_water` gossip stats) during
+heavy bursts: a high-water near the 4,096 cap means events are about to
+be dropped (issue #315 tracks recovery for that case).
 
 ---
 

--- a/docs/reference/benchmark-gates.md
+++ b/docs/reference/benchmark-gates.md
@@ -216,9 +216,22 @@ during the ~12 s submit window ≈ 5,300). Three workers converged at
 2,703 events (54.1%) — and **stayed there**, because events dropped at
 the gossip layer are never re-requested (no anti-entropy repair yet;
 tracked in issue #315). Practical guidance with default config:
-keep single-peer bursts ≤ 4,000 events, or raise
-`max_events_per_second`/`burst_capacity` in the gossip config for
-higher-throughput deployments.
+for full propagation in under 30 s, keep single-source bursts in the
+**2,000–3,000 event** range; the hard drop threshold sits near 4,500–5,000
+(one node in run C crossed it). For more, raise
+`max_events_per_second`/`burst_capacity` in the gossip config — or use
+the worker-mesh topology (now the compose default), which spreads
+ingest across multiple peers and multiplies the effective per-node rate
+limit.
+
+> Note on `finalized_total = 0`: these runs measured **DAG replication**,
+> not finality. All benchmark events are signed by the submit node (a
+> single creator), so Lane 1 rounds cannot advance (fame voting needs
+> events from ≥ 2f+1 distinct creators), and Lane 0 was disabled. To
+> measure real finality, enable the Lane 0 validator overlay
+> (`docker/docker-compose.lane0.yml` + `NODES=5
+> ./scripts/setup-validators.sh`) — quorum-acked events then feed
+> `omnia_node_events_finalized_total`.
 
 This measurement follows four stacked networking fixes, each masked by
 the previous one (propagation was 0% before them): `/dns4` bootstrap

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -490,6 +490,8 @@ async fn spawn_background_tasks(
         let mut last_dag_total: u64 = 0;
         #[cfg(feature = "metrics")]
         let mut last_committed: u64 = 0;
+        #[cfg(feature = "metrics")]
+        let mut last_lane0_finalized: u64 = 0;
 
         loop {
             tokio::select! {
@@ -520,6 +522,22 @@ async fn spawn_background_tasks(
                             node_metrics.events_finalized.inc_by(delta);
                             node_metrics.consensus_tps.inc_by(delta);
                             last_committed = stats.committed;
+                        }
+                        // Lane 0 fast-path finality (ADR-025): quorum-acked
+                        // events are just as final as Lane 1 commits, so they
+                        // feed the same finalized counter. Without this, a
+                        // single-writer workload (e.g. the testnet benchmark
+                        // submitting through one node) reports zero finality
+                        // even with Lane 0 fully operational — Lane 1 rounds
+                        // can only advance with events from 2f+1 distinct
+                        // creators.
+                        if let Some((_, _, lane0_finalized)) = substrate.lane0_stats() {
+                            if lane0_finalized > last_lane0_finalized {
+                                let delta = lane0_finalized - last_lane0_finalized;
+                                node_metrics.events_finalized.inc_by(delta);
+                                node_metrics.consensus_tps.inc_by(delta);
+                                last_lane0_finalized = lane0_finalized;
+                            }
                         }
                         node_metrics.consensus_round.set(substrate.current_round() as i64);
                         node_metrics.sample_memory_rss();

--- a/omnia-network/src/gossip.rs
+++ b/omnia-network/src/gossip.rs
@@ -160,6 +160,12 @@ pub struct GossipStats {
     pub events_rejected: u64,
     /// Number of events rejected specifically due to invalid signatures.
     pub messages_rejected_invalid_sig: u64,
+    /// Current depth of the rate-limit deferral queue (events awaiting
+    /// token-bucket refill; see `MAX_RATE_DEFERRED`).
+    pub rate_deferred_depth: u64,
+    /// High-water mark of the rate-limit deferral queue since startup —
+    /// how close a burst has come to the drop threshold.
+    pub rate_deferred_high_water: u64,
     /// Number of syncs completed
     pub syncs_completed: u64,
     /// Total number of events received across all completed sync operations.
@@ -829,6 +835,25 @@ impl GossipProtocol {
                     }
                 }
             }
+        }
+
+        // Deferral-queue observability: track depth so burst headroom is
+        // visible (a high-water near MAX_RATE_DEFERRED means events are
+        // about to be dropped — see the capacity-ceiling note in
+        // docs/reference/benchmark-gates.md).
+        let depth = self.rate_deferred.len() as u64;
+        self.stats.rate_deferred_depth = depth;
+        if depth > self.stats.rate_deferred_high_water {
+            self.stats.rate_deferred_high_water = depth;
+            if depth as usize * 2 >= MAX_RATE_DEFERRED {
+                warn!(
+                    depth,
+                    cap = MAX_RATE_DEFERRED,
+                    "Rate-limit deferral queue above half capacity — nearing drop threshold"
+                );
+            }
+        } else if depth > 0 {
+            tracing::debug!(depth, "Rate-limit deferral queue draining");
         }
 
         Ok(inserted_ids)


### PR DESCRIPTION
## Summary

Implements all four follow-ups from the Stage 2 benchmark review:

### 1. Topology — worker mesh (was: star)

`docker-compose.yml` now has node-K dial the bootstrap **plus workers 1..K-1** (`OMNIA_BOOTSTRAP_NODES` already accepts a comma-separated list; service names resolve via the DNS transport), with `depends_on` ordering so dial targets are listening when each node starts. The bootstrap is no longer the sole distributor — and because the gossip receive limit is **per-peer**, each node's effective ingest rate now scales with its peer count. Expected effect: remote convergence times drop substantially, and the run-C overflow mode becomes much harder to hit.

### 2. Finality is now measurable

Root cause of `finalized_total = 0`: the metric counted only **Lane 1 commits**, which a single-writer benchmark can never produce — all bench events are signed by the submit node (one creator), and fame voting needs ≥ 2f+1 distinct creators to advance rounds. Lane 0 was additionally disabled on the stock stack.

- `omnia_node_events_finalized_total` now also samples **Lane 0 quorum-ack finality** (from `Substrate::lane0_stats()`), so finality is lane-agnostic.
- New `docker/docker-compose.lane0.yml` overlay mounts per-node validator keys (from `NODES=5 ./scripts/setup-validators.sh`) to enable Lane 0 on the stock 5-node stack. With it, `testnet-bench.sh`'s `finalized_total` column measures real finality.

### 3. Deferral-queue observability

New gossip stats `rate_deferred_depth` / `rate_deferred_high_water`, plus a warn log when a burst pushes the queue past half of `MAX_RATE_DEFERRED` — the run-C overflow was invisible until convergence failed; now it announces itself with headroom to spare.

### 4. Throughput guidance recorded

`benchmark-gates.md`: for full propagation in < 30 s with default limits, keep single-source bursts in the **2,000–3,000** range (hard drop threshold ≈ 4,500–5,000); the runbook documents the mesh topology, the Lane 0 overlay, and the finalized-total interpretation.

## Verification

- `cargo build -p omnia-node --no-default-features --features full` → clean
- `cargo test -p omnia-network --features network --lib` → 133 passed
- `cargo fmt --all -- --check` → clean
- `cargo clippy -p omnia-network --features network --all-targets -- -D warnings -D clippy::unwrap_used` → clean
- `cargo clippy -p omnia-node --all-targets -- -D clippy::unwrap_used` → clean
- `RUSTDOCFLAGS="-D warnings" cargo doc -p omnia-network --no-deps` → clean
- Compose files YAML-validated (8 services; node-4 depends on bootstrap + workers 1–3)

**Live validation pending:** rebuild the testnet from this branch, confirm peers > 1 on workers, re-run the A/B/C matrix (expect faster convergence + deferral-depth logs), and run once with the Lane 0 overlay to see `finalized_total` move.