### PR TITLE
fix(gossip): defer out-of-window events instead of losing them to gap rejects

### DIFF
--- a/omnia-consensus/src/causal_graph.rs
+++ b/omnia-consensus/src/causal_graph.rs
@@ -111,6 +111,15 @@ impl SequenceBuffer {
         }
     }
 
+    /// Whether buffering `sequence` for `creator` would be rejected with
+    /// [`CausalGraphError::SequenceBufferOverflow`] (per-creator buffer at
+    /// capacity and the sequence not already buffered).
+    fn would_overflow(&self, creator: &NodeId, sequence: u64) -> bool {
+        self.buffers
+            .get(creator)
+            .is_some_and(|buf| buf.len() >= MAX_SEQUENCE_BUFFER_PER_CREATOR && !buf.contains_key(&sequence))
+    }
+
     /// Evict the least-recently-buffered creator's entire buffer (H-4).
     ///
     /// Called only when a *new* creator would exceed [`MAX_BUFFERED_CREATORS`].
@@ -778,6 +787,30 @@ impl CausalGraph {
     /// buffer. Bounded by `MAX_BUFFERED_CREATORS` (H-4).
     pub fn buffered_creator_count(&self) -> usize {
         self.seq_buffer.tracked_creators()
+    }
+
+    /// Whether inserting `event` right now would be rejected by the
+    /// out-of-order bounds — either the sequence gap cap
+    /// ([`CausalGraphError::SequenceGapTooLarge`]) or a full per-creator
+    /// buffer ([`CausalGraphError::SequenceBufferOverflow`]).
+    ///
+    /// Multi-path gossip delivery reorders events, so an event can arrive
+    /// far ahead of its creator's chain head while its predecessors are
+    /// still in flight. Both rejections are *permanent* from the graph's
+    /// perspective; callers that can retry later (e.g. the gossip layer's
+    /// deferral queue) should use this pre-check to hold such events back
+    /// instead of losing them to a hard reject.
+    pub fn insert_would_reject_out_of_order(&self, event: &Event) -> bool {
+        let has_existing = self.node_sequences.contains_key(&event.creator);
+        let last_known = self.node_sequences.get(&event.creator).copied().unwrap_or(0);
+        let expected_next = if has_existing { last_known + 1 } else { 0 };
+        if event.sequence <= expected_next {
+            return false;
+        }
+        if event.sequence - expected_next > MAX_SEQUENCE_GAP {
+            return true;
+        }
+        self.seq_buffer.would_overflow(&event.creator, event.sequence)
     }
 
     /// Check if `ancestor` is an ancestor of `descendant`.

--- a/omnia-network/src/gossip.rs
+++ b/omnia-network/src/gossip.rs
@@ -267,9 +267,11 @@ pub struct GossipProtocol {
     partition_active: bool,
     /// Per-peer rate limiter (token bucket).
     rate_limiter: RateLimiter,
-    /// Events that exceeded a peer's rate limit, held for retry on the next
-    /// processing round instead of being dropped. Bounded by
-    /// [`MAX_RATE_DEFERRED`]; beyond that events are dropped as before.
+    /// Events held for retry on the next processing round instead of being
+    /// dropped: those that exceeded a peer's rate limit, and those that
+    /// arrived too far ahead of their creator's chain head to be insertable
+    /// yet (multi-path delivery reorder). Bounded by [`MAX_RATE_DEFERRED`];
+    /// beyond that events are dropped as before.
     ///
     /// Rationale: gossipsub delivers a message to a mesh peer exactly once —
     /// an event dropped here is *permanently lost* to this node (no
@@ -750,6 +752,36 @@ impl GossipProtocol {
                             self.stats.messages_rejected_invalid_sig += 1;
                         }
                         self.stats.events_rejected += 1;
+                        continue;
+                    }
+
+                    // Out-of-window deferral: multi-path (mesh) delivery
+                    // reorders events across per-peer rate-limit buckets, so
+                    // an event can arrive far ahead of its creator's chain
+                    // head while its predecessors are still deferred or in
+                    // flight. Inserting it now would hit the causal graph's
+                    // hard out-of-order bounds (SequenceGapTooLarge /
+                    // SequenceBufferOverflow) and be PERMANENTLY lost —
+                    // gossipsub never redelivers, and there is no
+                    // anti-entropy repair yet (issue #315). Defer it for
+                    // retry alongside rate-limited events: by later rounds
+                    // the lagging chain segment has landed and the insert
+                    // succeeds. (Observed live: a 2,000-event mesh benchmark
+                    // lost ~half its events to gap rejects without this.)
+                    if self.graph.read().await.insert_would_reject_out_of_order(&event) {
+                        if self.rate_deferred.len() < MAX_RATE_DEFERRED {
+                            tracing::debug!(
+                                seq = event.sequence,
+                                "Event ahead of creator chain — deferring to next round"
+                            );
+                            self.rate_deferred.push_back((event, source));
+                        } else {
+                            warn!(
+                                seq = event.sequence,
+                                "Deferral queue full — dropping out-of-window event"
+                            );
+                            self.stats.events_rejected += 1;
+                        }
                         continue;
                     }
 
@@ -1238,6 +1270,83 @@ mod tests {
         assert!(gossip.rate_deferred.is_empty());
         assert_eq!(gossip.stats().events_rejected, 0, "no event was dropped");
         assert_eq!(gossip.graph().read().await.len(), 5, "all 5 events inserted");
+    }
+
+    #[tokio::test]
+    async fn test_out_of_window_events_deferred_not_dropped() {
+        use tokio::sync::mpsc;
+
+        let graph = Arc::new(RwLock::new(CausalGraph::new()));
+        let config = GossipConfig {
+            // Rate limiting neutralized — this test isolates the
+            // sequence-window deferral path.
+            burst_capacity: 100_000,
+            max_events_per_second: 100_000,
+            ..Default::default()
+        };
+        let mut gossip = GossipProtocol::new(node(1), config, graph);
+
+        let (tx, rx) = mpsc::channel(1024);
+        gossip.network_rx = Some(rx);
+
+        // A single creator's chain of 600 events (> MAX_SEQUENCE_GAP = 512),
+        // signed and self-parent-linked.
+        let keypair = generate_keypair();
+        let creator = node(42);
+        let mut chain: Vec<Event> = Vec::new();
+        for seq in 0..600u64 {
+            let mut ev = if seq == 0 {
+                Event::genesis(creator, vec![1]).expect("genesis")
+            } else {
+                let parent_id = chain[(seq - 1) as usize].id;
+                Event::new(
+                    creator,
+                    seq,
+                    VectorClock::with_node(creator, seq + 1),
+                    Some(parent_id),
+                    None,
+                    vec![1],
+                )
+                .expect("valid event")
+            };
+            ev.sign_with_keypair(&keypair).expect("signing");
+            chain.push(ev);
+        }
+
+        // Simulate multi-path reorder: the chain HEAD (seq 599, gap 599 from
+        // an empty graph) arrives first, then the rest in order.
+        let peer = PeerId::random();
+        let send = |ev: &Event| NetworkEvent::GossipReceived {
+            topic: "omnia_events".to_string(),
+            data: ev.to_bytes().expect("serialize"),
+            propagation_source: peer,
+        };
+        tx.send(send(&chain[599])).await.expect("send");
+        for ev in chain.iter().take(599) {
+            tx.send(send(ev)).await.expect("send");
+        }
+        drop(tx);
+
+        // Round 1: the window check runs against the graph as it stood at
+        // the start of the round (inserts land at the end), so everything
+        // beyond gap 512 from an empty chain is DEFERRED, never
+        // hard-rejected: seqs 0..=512 insert, seqs 513..599 (87 events,
+        // including the reordered head) wait.
+        gossip.process_pending_events().await.expect("process");
+        assert_eq!(gossip.graph().read().await.len(), 513);
+        assert_eq!(
+            gossip.rate_deferred.len(),
+            87,
+            "out-of-window tail deferred, not dropped"
+        );
+        assert_eq!(gossip.stats().events_rejected, 0);
+
+        // Round 2: the chain head advanced to 512, the whole tail is now in
+        // window and inserts. Nothing was lost to the reorder.
+        gossip.process_pending_events().await.expect("process");
+        assert_eq!(gossip.graph().read().await.len(), 600, "no event was lost to reorder");
+        assert!(gossip.rate_deferred.is_empty());
+        assert_eq!(gossip.stats().events_rejected, 0);
     }
 
     // ── Task 3.2: Bootstrap Peer Tests ─────────────────────────────────


### PR DESCRIPTION
## The bug (found by the mesh benchmark)

The worker-mesh topology (#317) regressed the 2,000-event benchmark from 100% propagation to ~50%, with every worker stalling permanently around 1,010–1,067 events. Logs pinned it precisely — 543/602/583/600 occurrences per worker of:

```
Failed to insert event: Sequence gap too large: ... sequence 1994 exceeds expected 1067 by more than 512
```

**Mechanism:** multi-path delivery spreads a single creator's burst across different per-peer rate-limit buckets. Sibling-relayed events arrive under a *fresh* token bucket and leapfrog the ~1,800 events deferred under the origin peer's bucket. The worker inserts, say, seq 1500 while seqs 300–900 are still deferred; from then on every event more than `MAX_SEQUENCE_GAP` (512) ahead of the chain head is **hard-rejected by the causal graph — permanently** (gossipsub never redelivers; no anti-entropy repair, #315). Chains stall forever once the next-needed sequence itself has been gap-rejected.

The star topology never hit this because a single source = a single bucket = FIFO order. The mesh's capacity multiplication worked exactly as designed — and that's what broke ordering.

## The fix

Pre-check the graph's out-of-order bounds at the gossip layer and **defer instead of attempting a doomed insert**:

- New `CausalGraph::insert_would_reject_out_of_order(&event)` — true when insertion would hit `SequenceGapTooLarge` **or** `SequenceBufferOverflow` (both are permanent losses from the caller's perspective).
- In `process_pending_events`, such events go into the existing bounded deferral queue and retry on later rounds, by which time the lagging chain segment has landed and the insert succeeds.

Security bounds unchanged: the deferral queue stays capped at `MAX_RATE_DEFERRED` (4,096; beyond it events drop as before), and the graph's hard limits still reject genuinely malicious far-future sequences — they just cost an attacker queue slots instead of poisoning honest chains.

## Regression test

A 600-event single-creator chain delivered **head-first** (gap 599 against an empty graph — the exact reorder shape from the live failure) now inserts completely across two rounds: 513 in round 1, the deferred 87-event tail in round 2, zero rejected.

## Verification

- `cargo test -p omnia-network --features network --lib` → 134 passed (incl. new test)
- `cargo test -p omnia-consensus --lib causal` → 36 passed
- `cargo fmt --all -- --check` → clean
- `cargo clippy -p omnia-network --features network --all-targets -- -D warnings -D clippy::unwrap_used` → clean
- `cargo clippy -p omnia-consensus --all-targets -- -D warnings -D clippy::unwrap_used` → clean
- `RUSTDOCFLAGS="-D warnings" cargo doc` (both crates) → clean

**Live validation pending:** re-run the 2,000-event mesh benchmark — expect 100% propagation restored (and `finalized_total` climbing, with the Lane 0 overlay active).