### PR TITLE
fix(gossip): break deferral-queue priority-inversion deadlock

### DIFF
--- a/docs/reference/benchmark-gates.md
+++ b/docs/reference/benchmark-gates.md
@@ -293,15 +293,35 @@ response gate and batch size were both global/small. `finalized_total`
 being identical across nodes is correct — the finality CRDT tracks the
 ≥4-of-5-quorum floor, which cannot exceed propagation.
 
-**Repair-throughput fix (PR pending):** the serve-side rate gate is now
-**per requesting peer** (each behind node is answered once per interval
-instead of one node globally), the batch size cap is **1,024 events**
-(byte-budgeted to 1 MiB so large-payload events truncate cleanly), and
-the receive cap is **2 MiB** (previously 512 KiB could not even carry one
-maximum-payload event). Combined this raises repair throughput by roughly
-an order of magnitude, so a 10k-scale deficit heals in a handful of
-intervals rather than dribbling out. Regression tests cover per-peer
+**Repair-throughput fix (PR #325, merged):** the serve-side rate gate is
+now **per requesting peer** (each behind node is answered once per
+interval instead of one node globally), the batch size cap is **1,024
+events** (byte-budgeted to 1 MiB so large-payload events truncate
+cleanly), and the receive cap is **2 MiB** (previously 512 KiB could not
+even carry one maximum-payload event). Regression tests cover per-peer
 gating and byte-budget truncation (`omnia-network/src/gossip.rs`).
+
+**10k re-run on #325 exposed the real bottleneck — a deferral-queue
+deadlock:** with the throughput fix live, the four workers still wedged at
+**59.1–65.1%** for the full 600 s window. Node logs showed repair *active*
+(42 requests, 69 batches served) yet every batch queued exactly
+`events=66` of 1,024, alongside **2,666 "deferral queue full — dropping"**
+warnings. Root cause: the bounded `rate_deferred` queue (cap 4,096) was
+FIFO with drop-on-full and no notion of distance-to-frontier. A burst —
+amplified by mesh fan-out re-delivering the same events from four peers
+*before* the dedup check — saturated it with far-future, out-of-window
+events that cannot be admitted until the gap below them fills. Repair
+batches carrying the low-sequence gap-fillers were then starved of slots,
+so the frontier never advanced: a hard priority-inversion deadlock, not
+slow convergence.
+
+**Deferral-queue priority fix:** `defer_event()` now keeps the
+queue biased toward the events nearest each creator's frontier — when
+full, a lower-sequence event *displaces* the highest-sequence queued entry
+instead of being dropped; a farther-future event is dropped instead. This
+guarantees repair gap-fillers always get a slot, so the frontier always
+advances and the deficit drains. Regression test
+`test_defer_event_evicts_farthest_from_frontier` locks the invariant.
 
 Operational note: validator keys mounted into the containers must be
 readable by uid 1000 (the container user) — `setup-validators.sh` now

--- a/omnia-network/src/gossip.rs
+++ b/omnia-network/src/gossip.rs
@@ -685,6 +685,58 @@ impl GossipProtocol {
         }
     }
 
+    /// Defer an event for retry on a later processing round, keeping the
+    /// bounded queue biased toward the events closest to their creator's
+    /// frontier (lowest sequence).
+    ///
+    /// When the queue has room the event is simply appended. When it is
+    /// full, the incoming event *displaces* the highest-sequence queued
+    /// event — but only if it is itself closer to the frontier (strictly
+    /// lower sequence); otherwise it is dropped as the farthest.
+    ///
+    /// Rationale: with plain FIFO drop-on-full, a burst (amplified by mesh
+    /// fan-out re-delivering the same events from several peers) saturates
+    /// the queue with *far-future, out-of-window* events. Those cannot be
+    /// admitted until the gap below them is filled, so they never leave the
+    /// queue — and the near-frontier gap-fillers that anti-entropy repair
+    /// serves get dropped for lack of a slot. The frontier then never
+    /// advances and propagation deadlocks (observed live: a 10k burst wedged
+    /// at ~60% with repair batches able to queue only ~66 of 1024 events).
+    /// Evicting the highest-sequence event guarantees the queue always
+    /// retains the most-admissible events, so the frontier can always move;
+    /// the evicted far-future events are re-served by repair (or re-gossiped)
+    /// once the gap below them closes.
+    ///
+    /// Returns `true` if the event is now queued (possibly via eviction),
+    /// `false` if it was dropped as the farthest-from-frontier.
+    fn defer_event(&mut self, event: Box<Event>, source: PeerId) -> bool {
+        if self.rate_deferred.len() < MAX_RATE_DEFERRED {
+            self.rate_deferred.push_back((event, source));
+            return true;
+        }
+        // Queue full: locate the highest-sequence entry (the least likely to
+        // become admissible soon) and displace it if this event is closer to
+        // the frontier. Linear scan is fine — it runs only while saturated
+        // and the queue is a few thousand entries of integer comparisons.
+        let mut max_idx = 0usize;
+        let mut max_seq = 0u64;
+        for (i, (ev, _)) in self.rate_deferred.iter().enumerate() {
+            if ev.sequence >= max_seq {
+                max_seq = ev.sequence;
+                max_idx = i;
+            }
+        }
+        if event.sequence < max_seq {
+            // swap_remove_back is O(1); deferral order does not matter for
+            // correctness (every entry is retried each round regardless).
+            self.rate_deferred.swap_remove_back(max_idx);
+            self.rate_deferred.push_back((event, source));
+            true
+        } else {
+            false
+        }
+    }
+
     /// Process pending events: first drain network_rx into the pending queue,
     /// then insert all pending events into the graph.
     ///
@@ -814,9 +866,8 @@ impl GossipProtocol {
                     // is itself full does the old drop behaviour kick in.
                     let peer_id_bytes = blake3_hash_domain(b"omnia-nonce", &source.to_bytes());
                     if !self.rate_limiter.allow(&peer_id_bytes) {
-                        if self.rate_deferred.len() < MAX_RATE_DEFERRED {
+                        if self.defer_event(event, source) {
                             tracing::debug!(peer = ?source, "Rate limiting peer — deferring event to next round");
-                            self.rate_deferred.push_back((event, source));
                         } else {
                             warn!(peer = ?source, "Rate limiting peer — deferral queue full, dropping event");
                             self.stats.events_rejected += 1;
@@ -854,17 +905,11 @@ impl GossipProtocol {
                     // succeeds. (Observed live: a 2,000-event mesh benchmark
                     // lost ~half its events to gap rejects without this.)
                     if self.graph.read().await.insert_would_reject_out_of_order(&event) {
-                        if self.rate_deferred.len() < MAX_RATE_DEFERRED {
-                            tracing::debug!(
-                                seq = event.sequence,
-                                "Event ahead of creator chain — deferring to next round"
-                            );
-                            self.rate_deferred.push_back((event, source));
+                        let seq = event.sequence;
+                        if self.defer_event(event, source) {
+                            tracing::debug!(seq, "Event ahead of creator chain — deferring to next round");
                         } else {
-                            warn!(
-                                seq = event.sequence,
-                                "Deferral queue full — dropping out-of-window event"
-                            );
+                            warn!(seq, "Deferral queue full — dropping out-of-window event");
                             self.stats.events_rejected += 1;
                         }
                         continue;
@@ -1233,11 +1278,12 @@ impl GossipProtocol {
                 // round — full validation, no shortcuts.
                 let mut queued = 0usize;
                 for event in batch.events.into_iter().take(SYNC_BATCH_LIMIT) {
-                    if self.rate_deferred.len() >= MAX_RATE_DEFERRED {
-                        break;
+                    // Repaired events are the gap-fillers closest to the
+                    // frontier; defer_event evicts far-future entries so they
+                    // are never starved by a saturated queue.
+                    if self.defer_event(Box::new(event), source) {
+                        queued += 1;
                     }
-                    self.rate_deferred.push_back((Box::new(event), source));
-                    queued += 1;
                 }
                 if queued > 0 {
                     self.stats.syncs_completed += 1;
@@ -1925,6 +1971,58 @@ mod tests {
             }
             other => panic!("expected sync Publish, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn test_defer_event_evicts_farthest_from_frontier() {
+        // The deferral queue must stay biased toward near-frontier events:
+        // when full, a low-sequence event displaces the highest-sequence
+        // one, and a far-future event is dropped rather than evicting a
+        // useful entry. This is the anti-deadlock invariant — repair
+        // gap-fillers must never be starved by a queue full of un-admittable
+        // far-future events.
+        let graph = Arc::new(RwLock::new(CausalGraph::new()));
+        let mut gossip = GossipProtocol::new(node(1), GossipConfig::default(), graph);
+        let creator = node(9);
+        let peer = PeerId::random();
+        let make = |seq: u64| {
+            Box::new(
+                Event::new(
+                    creator,
+                    seq,
+                    VectorClock::with_node(creator, seq + 1),
+                    None,
+                    None,
+                    vec![1],
+                )
+                .expect("event"),
+            )
+        };
+
+        // Saturate with far-future (high-sequence) out-of-window events.
+        for i in 0..MAX_RATE_DEFERRED as u64 {
+            assert!(gossip.defer_event(make(10_000 + i), peer));
+        }
+        assert_eq!(gossip.rate_deferred.len(), MAX_RATE_DEFERRED);
+
+        // A near-frontier event is admitted by displacing a far-future one.
+        assert!(
+            gossip.defer_event(make(5), peer),
+            "low-sequence event queued via eviction"
+        );
+        assert_eq!(gossip.rate_deferred.len(), MAX_RATE_DEFERRED, "queue stays bounded");
+        assert!(
+            gossip.rate_deferred.iter().any(|(e, _)| e.sequence == 5),
+            "near-frontier gap-filler retained"
+        );
+
+        // A farther-future event than anything queued is dropped, not swapped in.
+        assert!(
+            !gossip.defer_event(make(99_999), peer),
+            "farthest-from-frontier event dropped"
+        );
+        assert_eq!(gossip.rate_deferred.len(), MAX_RATE_DEFERRED);
+        assert!(!gossip.rate_deferred.iter().any(|(e, _)| e.sequence == 99_999));
     }
 
     // ── Task 3.2: Bootstrap Peer Tests ─────────────────────────────────


### PR DESCRIPTION
## 🚀 Description

Makes the bounded `rate_deferred` queue **priority-aware by distance-to-frontier**. When the queue is full, a lower-sequence (nearer-frontier) event now *displaces* the highest-sequence queued entry instead of being dropped; a farther-future event is dropped instead. Applied at all three deferral sites (rate-limited, out-of-window, and anti-entropy repair-batch ingest — the repair path also drops its early `break` so gap-fillers can evict).

## 💡 Motivation and Context

PR #325 raised repair throughput, but the 10k re-run still wedged the four workers at **59.1–65.1%** for the full 600 s window — a deadlock, not slow convergence. Live node logs pinned it exactly:

- repair was **active** (42 `requesting missing events`, 69 `serving repair batch`), but
- every batch queued **exactly `events=66`** of 1,024, and
- there were **2,666 `deferral queue full — dropping`** warnings.

Root cause is a priority inversion. The `rate_deferred` queue (cap 4,096) was FIFO with drop-on-full and no notion of how close an event is to its creator's frontier. A burst — amplified by mesh fan-out re-delivering the same events from four peers *before* the dedup check — saturates the queue with far-future, out-of-window events that **cannot be admitted until the gap below them fills**. Repair batches carrying the low-sequence gap-fillers are then starved of slots, so the frontier never advances and everything above stays permanently out-of-window.

Evicting the highest-sequence entry guarantees the queue always retains the most-admissible events, so the frontier can always move; the evicted far-future events are re-served by repair once the gap below them closes.

## ✅ How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [x] Manual testing

`test_defer_event_evicts_farthest_from_frontier` saturates the queue with far-future events, then asserts a near-frontier event is admitted by eviction (queue stays bounded, gap-filler retained) and a farther-future event is dropped rather than evicting a useful entry. Full gossip suite (36 tests) green; existing overflow/reorder tests unchanged (eviction only engages when the queue is full). `cargo clippy` clean, `cargo fmt` applied.

Live re-run of the 10k burst against this fix to follow — expected to converge the four workers to 100% within the run window instead of wedging at ~60%.

## 📝 Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## ➕ Additional Context

The eviction scan is O(n) and runs only while the queue is saturated (a few thousand integer comparisons); `swap_remove_back` keeps the removal O(1) since deferral order doesn't affect correctness (every entry is retried each round). Builds on PR #325 (throughput) — both are needed: #325 makes repair *serve* enough, this makes the receiver *admit* it.