### PR TITLE
fix(network): raise gossipsub max_transmit_size — repair batches never fit in 64 KiB

### DIFF
--- a/docs/reference/benchmark-gates.md
+++ b/docs/reference/benchmark-gates.md
@@ -359,6 +359,31 @@ non-zero count in the checkout, and the images must be rebuilt with
 #328, the **verified capacity claim remains 5,000-event bursts** (100%
 propagation + full Lane 0 finality).
 
+**2026-07-19 13:13 UTC verified re-run — real root cause found:** the
+verification protocol was executed (checkout at the #328 merge commit,
+`solicited` count 25, genuine 186 s `--no-cache` recompile) and the wedge
+reproduced **identically**: both workers at exactly 5,392, zero movement
+over 600 s. With all three repair-path fixes provably in the binary, that
+exactness pointed away from timing entirely: `10,000 − 5,392 = 4,608 =
+MAX_RATE_DEFERRED (4,096) + MAX_SEQUENCE_GAP (512)` — queue/window
+geometry with **no repair delivery at all**. Inspection found the true
+root cause one layer down, in the transport: **gossipsub was running with
+its default 64 KiB `max_transmit_size`** (never configured). Repair
+batches from the tail-holding node serialize well past 64 KiB, so every
+`publish` failed with `MessageTooLarge` — logged only on the *serving*
+node as a generic warning nobody grepped — and no repair batch was ever
+delivered. The only repair that ever worked was small inter-worker deltas
+(the observed `events=66` batches ≈ 46 KB, just under the cap), which is
+why 5-node-mesh workers equalized with each other (~63–66%) but never
+recovered the tail, and identical-frontier star workers froze
+permanently. **Fix:** `max_transmit_size` raised to
+`MAX_SYNC_MESSAGE_BYTES` (2 MiB, matching the receive-side bound) via a
+shared `build_gossipsub_config()`; sync publish failures escalated from
+debug to warn plus a loud oversize guard. Regression test
+`test_gossipsub_transmit_size_carries_repair_batches` pins the cap to the
+receive bound. The four earlier repair-path fixes (#320, #325, #327,
+#328) remain necessary — they were all masked by this delivery failure.
+
 Operational note: validator keys mounted into the containers must be
 readable by uid 1000 (the container user) — `setup-validators.sh` now
 chowns them when run as root. An unreadable key silently degrades to an

--- a/omnia-network/src/gossip.rs
+++ b/omnia-network/src/gossip.rs
@@ -1174,8 +1174,21 @@ impl GossipProtocol {
         };
         let mut payload = vec![SYNC_WIRE_VERSION];
         payload.extend(bytes);
+        // Guard against building a message the transport (or a receiving
+        // peer) will reject. SYNC_BATCH_MAX_BYTES keeps batches well under
+        // this in practice; hitting it indicates a sizing bug, so it must be
+        // loud — an oversized sync message that vanishes silently is exactly
+        // how the 64 KiB transmit-cap wedge stayed invisible.
+        if payload.len() > MAX_SYNC_MESSAGE_BYTES {
+            warn!(
+                size = payload.len(),
+                max = MAX_SYNC_MESSAGE_BYTES,
+                "Sync message exceeds MAX_SYNC_MESSAGE_BYTES — not publishing"
+            );
+            return;
+        }
         if let Err(e) = self.publish_raw(SYNC_TOPIC, payload).await {
-            tracing::debug!("Sync publish failed: {e}");
+            warn!("Sync publish failed: {e}");
         }
     }
 

--- a/omnia-network/src/network.rs
+++ b/omnia-network/src/network.rs
@@ -233,6 +233,30 @@ impl Default for PeerScoreTracker {
 // ---------------------------------------------------------------------------
 
 /// Configure GossipSub peer scoring for Omnia's threat model.
+/// Build the gossipsub configuration shared by every Omnia node.
+///
+/// The transmit cap is raised above the libp2p default of 64 KiB: anti-entropy
+/// repair batches (up to `SYNC_BATCH_LIMIT` events, byte-budgeted to
+/// `SYNC_BATCH_MAX_BYTES`) and maximum-payload events both exceed 64 KiB, and
+/// with the default cap their publish fails with `MessageTooLarge` — so the
+/// repair path silently never delivered. Observed live as a permanent
+/// propagation wedge: workers frozen at ~54% after a 10k burst while
+/// "serving repair batch" logs looked healthy on the serving node (the
+/// failure surfaced only as a `Publish failed` warning in the server's own
+/// logs). The cap matches the receive-side bound
+/// [`crate::gossip::MAX_SYNC_MESSAGE_BYTES`], so anything a peer will accept
+/// can actually be sent.
+pub fn build_gossipsub_config() -> Result<gossipsub::Config, gossipsub::ConfigBuilderError> {
+    gossipsub::ConfigBuilder::default()
+        .validation_mode(ValidationMode::Strict)
+        .max_transmit_size(crate::gossip::MAX_SYNC_MESSAGE_BYTES)
+        .message_id_fn(|msg: &gossipsub::Message| {
+            let hash = blake3_hash_domain(b"omnia-commitment", &msg.data);
+            gossipsub::MessageId::from(hash.to_vec())
+        })
+        .build()
+}
+
 ///
 /// Returns `(PeerScoreParams, PeerScoreThresholds)` tuned for:
 /// - Heavy penalty for invalid messages (-150 per invalid delivery)
@@ -510,13 +534,7 @@ impl OmniaNetwork {
         let local_peer_id = PeerId::from(local_key.public());
 
         // ── GossipSub config ─────────────────────────────────────────
-        let gossipsub_config = gossipsub::ConfigBuilder::default()
-            .validation_mode(ValidationMode::Strict)
-            .message_id_fn(|msg: &gossipsub::Message| {
-                let hash = blake3_hash_domain(b"omnia-commitment", &msg.data);
-                gossipsub::MessageId::from(hash.to_vec())
-            })
-            .build()?;
+        let gossipsub_config = build_gossipsub_config()?;
 
         // ── Kademlia DHT config (H-4) ────────────────────────────────
         let stream_protocol = StreamProtocol::try_from_owned(config.dht_protocol.clone())
@@ -1136,5 +1154,23 @@ mod tests {
         // Multiaddr without /p2p suffix
         let addr_no_p2p: Multiaddr = "/ip4/1.2.3.4/udp/4001/quic-v1".parse().expect("valid multiaddr");
         assert!(extract_peer_id_from_multiaddr(&addr_no_p2p).is_none());
+    }
+
+    #[test]
+    fn test_gossipsub_transmit_size_carries_repair_batches() {
+        // The transmit cap must cover everything the receive side accepts —
+        // with the libp2p default (64 KiB), anti-entropy repair batches
+        // failed to publish (MessageTooLarge) and the repair path silently
+        // never delivered, wedging propagation after large bursts.
+        let config = build_gossipsub_config().expect("config builds");
+        assert_eq!(
+            config.max_transmit_size(),
+            crate::gossip::MAX_SYNC_MESSAGE_BYTES,
+            "transmit cap must match the sync receive cap"
+        );
+        assert!(
+            config.max_transmit_size() > crate::gossip::SYNC_BATCH_MAX_BYTES,
+            "a full byte-budgeted repair batch must fit in one message"
+        );
     }
 }


### PR DESCRIPTION
## 🚀 Description

Sets gossipsub's `max_transmit_size` to `MAX_SYNC_MESSAGE_BYTES` (2 MiB) — it was never configured, so every node ran with the **libp2p default of 64 KiB**. Extracted into a shared `build_gossipsub_config()`, escalated sync publish failures from `debug` to `warn` with a loud oversize guard, and added a regression test pinning the transmit cap to the receive-side bound.

## 💡 Motivation and Context

The **verified** 10k re-run (checkout at the #328 merge, `solicited` count 25, genuine 186 s `--no-cache` recompile) reproduced the propagation wedge *identically*: both workers at exactly 5,392 events, zero movement over 600 s. With all three repair-path fixes provably in the binary, the exactness pointed away from timing entirely: `10,000 − 5,392 = 4,608 = MAX_RATE_DEFERRED (4,096) + MAX_SEQUENCE_GAP (512)` — pure queue/window geometry with **no repair delivery at all**.

Root cause, one layer below everything fixed so far: anti-entropy repair batches from the tail-holding node serialize far past 64 KiB, so every `publish` failed with `MessageTooLarge` — surfaced only as a generic "Publish failed" warning on the *serving* node, which nobody grepped — and **no repair batch was ever delivered**. The only repair that ever worked was small inter-worker deltas (the observed `events=66` batches ≈ 46 KB, just under the cap): that's why 5-node-mesh workers equalized with each other at ~63–66% but never recovered the tail, and why identical-frontier star workers froze permanently at 5,392.

This also silently affected max-payload events (up to 1 MiB + envelope > 64 KiB) on the main event topic.

The four repair-path fixes (#320, #325, #327, #328) remain necessary and correct — they were all masked by this delivery failure.

## ✅ How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [x] Manual testing

`test_gossipsub_transmit_size_carries_repair_batches` asserts the built config's `max_transmit_size` equals `MAX_SYNC_MESSAGE_BYTES` and exceeds `SYNC_BATCH_MAX_BYTES` (a full byte-budgeted repair batch fits in one message). Full network crate suite: 142 passed, 0 failed. `cargo clippy` clean, `cargo fmt` applied.

The decisive validation is the live 10k re-run on this fix (protocol already established: verify commit + `--no-cache` rebuild) — with delivery unblocked, the serving node's batches should finally arrive and the workers should converge to 100%.

## 📝 Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## ➕ Additional Context

Records the full verified-run diagnosis in `benchmark-gates.md`. DoS note: the transmit cap only governs what *this* node will send; the receive path is already bounded by `MAX_SYNC_MESSAGE_BYTES` (checked before deserialization) and `MAX_PAYLOAD_SIZE` per event, so raising the transmit cap does not widen the attack surface beyond the existing receive bounds.