### PR TITLE
perf(gossip): has_more fast drain + live benchmark progress

### DIFF
--- a/omnia-network/src/gossip.rs
+++ b/omnia-network/src/gossip.rs
@@ -346,15 +346,29 @@ pub struct GossipProtocol {
     /// When this node last sent an anti-entropy event request (rate gate).
     last_sync_request: Instant,
     /// When this node last served an anti-entropy repair batch to a given
-    /// peer (per-peer rate gate).
+    /// peer, plus the requester's frontier total at that serve (per-peer
+    /// rate gate with progress-aware fast drain).
     ///
     /// A single global timer let one requester monopolize the interval:
     /// with N peers behind, only one received a repair batch per
     /// `sync_interval_ms`, so a large deficit took N times longer to heal.
     /// Gating per source lets the server answer every requesting peer once
-    /// per interval. Bounded by [`MAX_SYNC_RESPONSE_PEERS`] with stale-entry
-    /// pruning so a churning network cannot grow it without limit.
-    last_sync_response: HashMap<PeerId, Instant>,
+    /// per interval. The stored frontier total additionally lets a
+    /// *progressing* peer be served again immediately: a follow-up request
+    /// whose `since` frontier is strictly ahead of the last served one
+    /// proves the previous batch was admitted, so it is a genuine `has_more`
+    /// continuation, not a replay — throttling it to the interval made a
+    /// 10k-burst tail drain at one batch per 10 s (~10 minutes). Bounded by
+    /// [`MAX_SYNC_RESPONSE_PEERS`] with stale-entry pruning so a churning
+    /// network cannot grow it without limit.
+    last_sync_response: HashMap<PeerId, (Instant, u64)>,
+    /// Set when an anti-entropy repair batch arrived with `has_more`: after
+    /// the current processing round admits the batch, send a follow-up
+    /// request immediately (with the advanced frontier) instead of waiting
+    /// for the next peer digest. This chains batch-per-round while behind,
+    /// collapsing tail-repair time from one batch per `sync_interval_ms`
+    /// to one batch per processing round.
+    sync_continuation: bool,
 }
 
 /// Cap on the per-peer [`GossipProtocol::last_sync_response`] map. When
@@ -416,6 +430,7 @@ impl GossipProtocol {
             // Empty per-peer map: absence means "never served this peer",
             // so the first request from any peer is answered immediately.
             last_sync_response: HashMap::new(),
+            sync_continuation: false,
         }
     }
 
@@ -1059,6 +1074,28 @@ impl GossipProtocol {
             tracing::debug!(depth, "Rate-limit deferral queue draining");
         }
 
+        // Fast drain: a repair batch this round carried has_more, and its
+        // events have now been admitted (frontier advanced). Chain the next
+        // request immediately with the fresh frontier — the serving peer's
+        // progress-aware gate recognizes the advanced frontier and answers
+        // without waiting for the interval. Bypasses the local digest-driven
+        // request gate deliberately; `last_sync_request` is still stamped so
+        // digest-triggered requests stay paced.
+        if self.sync_continuation && self.network_cmd_tx.is_some() {
+            self.sync_continuation = false;
+            let frontier = self.graph.read().await.frontier().clone();
+            self.last_sync_request = Instant::now();
+            tracing::info!("Anti-entropy: has_more continuation — requesting next repair batch now");
+            let request = GossipMessage::Request(EventRequest {
+                known_events: Vec::new(),
+                limit: SYNC_BATCH_LIMIT,
+                since: frontier,
+            });
+            self.publish_sync_message(&request).await;
+        } else {
+            self.sync_continuation = false;
+        }
+
         Ok(inserted_ids)
     }
 
@@ -1194,7 +1231,7 @@ impl GossipProtocol {
 
     /// Record that a repair batch was just served to `source`, pruning the
     /// per-peer response map if it has grown past [`MAX_SYNC_RESPONSE_PEERS`].
-    fn record_sync_response(&mut self, source: PeerId) {
+    fn record_sync_response(&mut self, source: PeerId, since_total: u64) {
         let now = Instant::now();
         if self.last_sync_response.len() >= MAX_SYNC_RESPONSE_PEERS && !self.last_sync_response.contains_key(&source) {
             let stale = self
@@ -1202,9 +1239,9 @@ impl GossipProtocol {
                 .sync_interval_ms
                 .saturating_mul(u64::from(STALE_SYNC_RESPONSE_INTERVALS));
             self.last_sync_response
-                .retain(|_, t| (t.elapsed().as_millis() as u64) < stale);
+                .retain(|_, (t, _)| (t.elapsed().as_millis() as u64) < stale);
         }
-        self.last_sync_response.insert(source, now);
+        self.last_sync_response.insert(source, (now, since_total));
     }
 
     /// Handle one message received on [`SYNC_TOPIC`].
@@ -1256,9 +1293,21 @@ impl GossipProtocol {
             GossipMessage::Request(request) => {
                 // Rate-gate served batches to one per sync interval *per
                 // requesting peer*, so one requester can't monopolize the
-                // interval and starve the others.
-                if let Some(last) = self.last_sync_response.get(&source) {
-                    if last.elapsed().as_millis() < interval {
+                // interval and starve the others — EXCEPT when the requester
+                // has provably progressed: a `since` frontier strictly ahead
+                // of the one we last served proves the previous batch was
+                // admitted, so this is a genuine has_more continuation and
+                // is served immediately (fast drain). A stalled or replayed
+                // frontier still waits out the interval, so the gate's DoS
+                // property is preserved: a peer can never extract more than
+                // one batch per interval without advancing.
+                let since_total: u64 = request
+                    .since
+                    .nodes()
+                    .fold(0u64, |acc, n| acc.saturating_add(request.since.get(n)));
+                if let Some((last, last_total)) = self.last_sync_response.get(&source) {
+                    let progressed = since_total > *last_total;
+                    if !progressed && last.elapsed().as_millis() < interval {
                         return;
                     }
                 }
@@ -1306,7 +1355,7 @@ impl GossipProtocol {
                 if missing.is_empty() {
                     return;
                 }
-                self.record_sync_response(source);
+                self.record_sync_response(source, since_total);
                 tracing::info!(
                     peer = ?source,
                     events = missing.len(),
@@ -1339,7 +1388,18 @@ impl GossipProtocol {
                     self.stats.syncs_completed += 1;
                     self.stats.total_events_in_syncs += queued as u64;
                     self.stats.total_syncs += 1;
-                    tracing::info!(events = queued, "Anti-entropy: queued repair batch for admission");
+                    tracing::info!(
+                        events = queued,
+                        has_more = batch.has_more,
+                        "Anti-entropy: queued repair batch for admission"
+                    );
+                    // Fast drain: the server has more we're missing. After
+                    // this round admits the batch, request the next one
+                    // immediately with the advanced frontier instead of
+                    // waiting up to sync_interval_ms for the next digest.
+                    if batch.has_more {
+                        self.sync_continuation = true;
+                    }
                 }
             }
             GossipMessage::Ack(_) => {}
@@ -2117,6 +2177,106 @@ mod tests {
             "unsolicited event blocked by the rate limiter"
         );
         assert_eq!(gossip.rate_deferred.len(), 1, "unsolicited event re-deferred, not lost");
+    }
+
+    #[tokio::test]
+    async fn test_sync_has_more_batch_triggers_immediate_continuation() {
+        use tokio::sync::mpsc;
+
+        // A repair batch flagged has_more must chain a follow-up request in
+        // the same processing round (with the post-admission frontier), not
+        // wait up to sync_interval_ms for the next digest — that pacing made
+        // a 10k tail drain take ~10 minutes.
+        let graph = Arc::new(RwLock::new(CausalGraph::new()));
+        let config = GossipConfig {
+            sync_interval_ms: 60_000,
+            ..Default::default()
+        };
+        let mut gossip = GossipProtocol::new(node(1), config, graph);
+        let (cmd_tx, mut cmd_rx) = mpsc::channel(8);
+        gossip.network_cmd_tx = Some(cmd_tx);
+
+        let (creator, chain) = signed_chain(3);
+        let batch = GossipMessage::Events(EventBatch {
+            events: chain,
+            has_more: true,
+            tip_clock: VectorClock::with_node(creator, 3),
+        });
+        gossip.handle_sync_message(sync_wire(&batch), PeerId::random()).await;
+        gossip.process_pending_events().await.expect("process");
+        assert_eq!(gossip.graph().read().await.len(), 3, "batch admitted");
+
+        let mut continuation = None;
+        while let Ok(NetworkCommand::Publish { topic, data }) = cmd_rx.try_recv() {
+            assert_eq!(topic, SYNC_TOPIC);
+            if let GossipMessage::Request(req) = decode_sync(&data) {
+                continuation = Some(req);
+            }
+        }
+        let req = continuation.expect("continuation request sent despite long sync interval");
+        assert_eq!(
+            req.since.get(&creator),
+            3,
+            "continuation carries the post-admission frontier"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_sync_server_fast_serves_progressing_peer() {
+        use tokio::sync::mpsc;
+
+        // A peer whose `since` frontier advanced past the last served one is
+        // answered immediately (has_more continuation); a peer re-sending
+        // the same frontier stays gated to one batch per interval.
+        let graph = Arc::new(RwLock::new(CausalGraph::new()));
+        let (creator, chain) = signed_chain(6);
+        {
+            let mut g = graph.write().await;
+            for ev in &chain {
+                g.insert(ev.clone()).expect("insert");
+            }
+        }
+        let config = GossipConfig {
+            sync_interval_ms: 60_000,
+            ..Default::default()
+        };
+        let mut gossip = GossipProtocol::new(node(1), config, graph);
+        let (cmd_tx, mut cmd_rx) = mpsc::channel(8);
+        gossip.network_cmd_tx = Some(cmd_tx);
+        let peer = PeerId::random();
+
+        let request = |since: VectorClock| {
+            sync_wire(&GossipMessage::Request(EventRequest {
+                known_events: Vec::new(),
+                limit: SYNC_BATCH_LIMIT,
+                since,
+            }))
+        };
+        let served = |rx: &mut mpsc::Receiver<NetworkCommand>| -> Option<usize> {
+            match rx.try_recv() {
+                Ok(NetworkCommand::Publish { data, .. }) => match decode_sync(&data) {
+                    GossipMessage::Events(b) => Some(b.events.len()),
+                    _ => None,
+                },
+                _ => None,
+            }
+        };
+
+        // First request: empty frontier, served everything.
+        gossip.handle_sync_message(request(VectorClock::new()), peer).await;
+        assert_eq!(served(&mut cmd_rx), Some(6), "first request served");
+
+        // Progressed frontier (entry 3 > 0): served immediately in-interval.
+        gossip
+            .handle_sync_message(request(VectorClock::with_node(creator, 3)), peer)
+            .await;
+        assert_eq!(served(&mut cmd_rx), Some(3), "progressing peer fast-served");
+
+        // Same frontier again (no progress): gated for the interval.
+        gossip
+            .handle_sync_message(request(VectorClock::with_node(creator, 3)), peer)
+            .await;
+        assert!(served(&mut cmd_rx).is_none(), "stalled frontier stays gated");
     }
 
     // ── Task 3.2: Bootstrap Peer Tests ─────────────────────────────────

--- a/scripts/testnet-bench.sh
+++ b/scripts/testnet-bench.sh
@@ -116,6 +116,22 @@ echo "🚀 Submitting $EVENTS events to $TARGET (concurrency $CONCURRENCY)..."
 RESULTS_TMP=$(mktemp)
 trap 'rm -f "$RESULTS_TMP"' EXIT
 
+# Live submission progress: one updating line so a long submit never looks
+# stuck. Runs in the background while xargs fires requests; killed after.
+SUB_START=$(date +%s)
+(
+  while :; do
+    n=$(wc -l < "$RESULTS_TMP" 2>/dev/null || echo 0)
+    pct=$(( EVENTS > 0 ? n * 100 / EVENTS : 0 ))
+    filled=$(( pct * 24 / 100 )); (( filled > 24 )) && filled=24
+    bar=$(printf '%*s' "$filled" '' | tr ' ' '#')$(printf '%*s' $(( 24 - filled )) '' | tr ' ' '-')
+    printf '\r\033[K  🚀 [%s] %d/%d (%d%%)  %ds elapsed' \
+      "$bar" "$n" "$EVENTS" "$pct" $(( $(date +%s) - SUB_START ))
+    sleep 1
+  done
+) &
+SUB_PROG_PID=$!
+
 START_NS=$(date +%s%N)
 seq 1 "$EVENTS" | xargs -P "$CONCURRENCY" -I {} sh -c '
   code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 15 \
@@ -126,6 +142,9 @@ seq 1 "$EVENTS" | xargs -P "$CONCURRENCY" -I {} sh -c '
   echo "$code"
 ' >> "$RESULTS_TMP"
 END_NS=$(date +%s%N)
+kill "$SUB_PROG_PID" 2>/dev/null || true
+wait "$SUB_PROG_PID" 2>/dev/null || true
+printf '\r\033[K'
 
 OK_COUNT=$(grep -c "^2" "$RESULTS_TMP" || true)
 THROTTLED=$(grep -c "^429$" "$RESULTS_TMP" || true)
@@ -148,25 +167,47 @@ fi
 echo ""
 echo "⏳ Waiting for propagation (timeout ${TIMEOUT}s)..."
 declare -A CONVERGED_AT
-DEADLINE=$(( $(date +%s) + TIMEOUT ))
+WAIT_START=$(date +%s)
+DEADLINE=$(( WAIT_START + TIMEOUT ))
 while :; do
   now=$(date +%s)
   all_done=1
+  min_pct=100
+  status=""
   for url in "${NODE_URLS[@]}"; do
-    [[ -n "${CONVERGED_AT[$url]:-}" ]] && continue
+    port="${url##*:}"
+    if [[ -n "${CONVERGED_AT[$url]:-}" ]]; then
+      status+="  ${port}:100%"
+      continue
+    fi
     delta=$(( $(dag_total "$url") - BASELINE[$url] ))
     if (( delta >= OK_COUNT )); then
       CONVERGED_AT[$url]=$(awk -v s="$START_NS" -v e="$(date +%s%N)" 'BEGIN{printf "%.2f", (e-s)/1e9}')
+      printf '\r\033[K'
       echo "  ✅ $url converged (+$delta) at ${CONVERGED_AT[$url]}s"
+      status+="  ${port}:100%"
     else
       all_done=0
+      pct=$(( OK_COUNT > 0 ? delta * 100 / OK_COUNT : 0 ))
+      status+="  ${port}:${pct}%"
+      (( pct < min_pct )) && min_pct=$pct
     fi
   done
-  (( all_done )) && break
+  if (( all_done )); then
+    printf '\r\033[K'
+    break
+  fi
   if (( now >= DEADLINE )); then
+    printf '\r\033[K'
     echo "  ⚠️  Timeout — reporting partial propagation."
     break
   fi
+  # Live status line: elapsed timer, slowest-node progress bar, per-node %.
+  # Redrawn in place so a slow repair tail is visibly moving, never "stuck".
+  elapsed=$(( now - WAIT_START ))
+  filled=$(( min_pct * 24 / 100 )); (( filled > 24 )) && filled=24
+  bar=$(printf '%*s' "$filled" '' | tr ' ' '#')$(printf '%*s' $(( 24 - filled )) '' | tr ' ' '-')
+  printf '\r\033[K  ⏱  %4ds/%ds  [%s]%s' "$elapsed" "$TIMEOUT" "$bar" "$status"
   sleep 2
 done
 


### PR DESCRIPTION
## 🚀 Description

Two things, both born from the 10k milestone run:

**1. `has_more` fast drain** — the tail-repair tuning lever documented in `benchmark-gates.md`:
- **Receiver:** a repair batch flagged `has_more` sets a `sync_continuation` flag; at the end of that same processing round — once the batch is admitted and the frontier has advanced — the node sends a follow-up request immediately with the fresh frontier, instead of waiting up to `sync_interval_ms` for the next digest. One batch per round while behind.
- **Server:** the per-peer response gate becomes **progress-aware** — `last_sync_response` now stores `(Instant, since_total)`. A request whose frontier is strictly ahead of the last served one proves the previous batch was admitted, so it's a genuine continuation and is served immediately. A stalled or replayed frontier still waits out the interval, preserving the gate's DoS property: no peer can extract more than one batch per interval *without advancing*.

**2. Live benchmark progress** (`scripts/testnet-bench.sh`) — long phases no longer sit silent:
- Submission shows a live updating line: progress bar, submitted count/percent, elapsed seconds.
- The propagation wait redraws an in-place status line every poll: `⏱ elapsed/timeout  [slowest-node bar]  9091:61% 9092:60% …` — a slow repair tail is visibly moving instead of looking stuck for 10 minutes.
- Per-node "converged" lines, the final summary table, and the JSON report are unchanged.

## 💡 Motivation and Context

The 10k burst now converges losslessly (post-#330), but the ~4,600-event tail drained at ~8 ev/s — one byte-budgeted repair batch per 10 s digest interval — taking ~10 minutes, during which the benchmark printed nothing. Expected effect of the fast drain: one batch per ~1 s consensus round while behind, collapsing the tail by roughly 10–60×. The progress UI makes whatever remains visibly alive.

## ✅ How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [x] Manual testing

- `test_sync_has_more_batch_triggers_immediate_continuation` — with a 60 s sync interval, a `has_more` batch still produces a chained request in the same round, carrying the post-admission frontier.
- `test_sync_server_fast_serves_progressing_peer` — a progressed frontier is fast-served in-interval; re-sending the same frontier stays gated.
- Full network crate suite: 144 passed, 0 failed. `cargo clippy` clean, `cargo fmt` applied, `bash -n` clean on the script.

The live validation is the next 10k run: the tail should drain in roughly a minute with the progress bar visibly climbing.

## 📝 Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## ➕ Additional Context

Wire format untouched — `has_more` and `EventRequest.since` already existed; this changes only scheduling on both ends, so mixed-version nodes interoperate (an old server just gates continuations to the interval; an old client just doesn't chain). Benchmark-gates gets the measured before/after numbers once the next 10k run lands.