### PR TITLE
docs: record the 5-node 10k headline run + measured fast-drain numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,13 +71,14 @@ The full loop — create wallet → challenge/login → registered DID with a 1,
 - **5-node gossipsub mesh over QUIC** — 1,000-event bursts propagate to
   100% of nodes in ~10 s; 5,000-event bursts in ~40–45 s, zero loss.
 - **Real BFT finality (ADR-025 Lane 0)** — every event collects a
-  quorum of signed validator acks: 5,000/5,000 events finalized across
-  all 5 validators in the latest stress run.
-- **Self-healing anti-entropy** — nodes exchange frontier digests and
-  automatically repair any events lost to bounded-queue drops. Proven at
-  10k scale (2026-07-19): a 10,000-event burst overwhelms live gossip,
-  then repair recovers every event — **100% propagation and
-  10,000/10,000 Lane 0 finality on every node, zero loss.**
+  quorum of signed validator acks: **10,000/10,000 events finalized
+  across all 5 validators** in the latest stress run (2026-07-19).
+- **Self-healing anti-entropy with fast drain** — nodes exchange
+  frontier digests and repair any events lost to bounded-queue drops,
+  chaining repair batches while behind. Proven at 10k scale on the full
+  5-node mesh: a 10,000-event burst overwhelms live gossip, then repair
+  recovers every event — **100% propagation + full quorum finality on
+  all five nodes, zero loss, median convergence under a minute.**
 - Formally specified: TLA+ models (`OmniaTwoLane`, `OmniaConsensus`,
   `OmniaCRDT`) model-checked in CI on every PR.
 

--- a/docs/reference/benchmark-gates.md
+++ b/docs/reference/benchmark-gates.md
@@ -411,12 +411,45 @@ instead of waiting for the next digest; (2) shorten `sync_interval_ms`
 for repair-active peers; (3) raise `SYNC_BATCH_MAX_BYTES` toward the
 2 MiB transmit cap. None are required for correctness.
 
+**2026-07-19 14:38–14:51 UTC — `has_more` fast drain measured (PR #332),
+then the 5-node headline run:** with the fast drain deployed (repair
+batches chain one-per-round via `has_more` continuations; the server
+fast-serves any peer whose frontier advanced), the same 10k burst's
+repair tail collapsed **~12–16×**:
+
+- 3-node-measured run (14:38): workers converged at **36.4 s / 52.6 s**
+  (vs 604 s pre-drain) — tail-repair pace up from ~8 ev/s to ~500+ ev/s.
+- **5-node full-mesh headline run (14:51,
+  `testnet-bench-20260719-145059.json`)** — all five nodes measured,
+  every node `peers=4`, Lane 0 on all five:
+
+| node | dag Δ | prop % | converged (s) | finalized_total | RSS |
+|------|------:|-------:|--------------:|----------------:|----:|
+| 9090 (ingress) | 10,000 | 100.0 | 29.9 | 10,000 | 135 MB |
+| 9091 | 10,000 | 100.0 | 138.0 | 10,000 | 134 MB |
+| 9092 | 10,000 | 100.0 | 54.5 | 10,000 | 141 MB |
+| 9093 | 10,000 | 100.0 | 56.6 | 10,000 | 152 MB |
+| 9094 | 10,000 | 100.0 | 302.1 | 10,000 | 139 MB |
+
+Ingress: 10,000/10,000 accepted in 27.8 s (359 ev/s submit).
+`finalized_total = 10,000` independently confirmed on all five nodes
+after the run — **zero loss, full ≥4-of-5 quorum finality at 10k on the
+real 5-node QUIC/gossipsub validator mesh.**
+
+**Reading:** median convergence is now sub-minute; the spread (two
+stragglers at 138 s and 302 s) reflects repair contention — several
+behind nodes chasing overlapping deficits through the per-peer serve
+gates. Remaining (optional) tuning headroom: widen per-interval serve
+capacity when many peers are behind, and let caught-up workers serve
+more of the tail to each other. Correctness is not at stake — every
+straggler converges and finalizes.
+
 **Verified capacity (2026-07-19): 10,000-event bursts — 100% propagation
-+ 10,000/10,000 Lane 0 finality (3-node star, single host); 5,000-event
-bursts converge within ~45 s (5-node mesh). Sustained-rate guidance
-unchanged (~2,000–3,000 ev/s burst comfort zone for sub-minute
-convergence; larger bursts converge losslessly but ride the repair
-tail).**
++ 10,000/10,000 Lane 0 quorum finality on the full 5-node validator
+mesh (single host); median node convergence < 60 s, worst-case straggler
+~5 min. 5,000-event bursts converge within ~45 s. Sustained-rate
+guidance unchanged (~2,000–3,000 ev/s burst comfort zone; larger bursts
+converge losslessly with a repair tail).**
 
 Operational note: validator keys mounted into the containers must be
 readable by uid 1000 (the container user) — `setup-validators.sh` now

--- a/docs/reference/status.md
+++ b/docs/reference/status.md
@@ -21,9 +21,12 @@ This document tracks the granular requirements for the Omnia Protocol and their 
 > dropping every repair batch). Verified same day on a provably fresh
 > binary: **10,000-event bursts now reach 100% propagation AND
 > 10,000/10,000 Lane 0 quorum finality on every node — zero loss,
-> self-healed entirely by anti-entropy repair** (tail repair is
-> deliberate-paced, ~10 min; tuning levers documented). Numbers +
-> full diagnosis arc: [benchmark-gates.md](./benchmark-gates.md).
+> self-healed entirely by anti-entropy repair.** The `has_more` fast
+> drain (PR #332) then collapsed the repair tail ~12–16×, and the
+> headline run landed same day: **10k burst on the full 5-node
+> validator mesh — 100% propagation + full quorum finality on all five
+> nodes, median convergence under a minute.** Numbers + full diagnosis
+> arc: [benchmark-gates.md](./benchmark-gates.md).
 
 ## 1. Core Protocol (The Substrate)
 


### PR DESCRIPTION
## 🚀 Description

Records the 2026-07-19 14:51 UTC run on the **full 5-node validator mesh** (`testnet-bench-20260719-145059.json`): **10,000/10,000 propagated AND `finalized_total = 10,000` independently confirmed on all five nodes** — zero loss, full ≥4-of-5 quorum finality. Convergence 29.9 / 54.5 / 56.6 / 138.0 / 302.1 s (median sub-minute; the two stragglers reflect repair contention, documented as optional tuning headroom, not a correctness issue).

Also records the measured `has_more` fast-drain effect (PR #332): the 14:38 3-node-measured run converged workers at **36–53 s vs 604 s pre-drain** — a ~12–16× collapse of the repair tail (~8 ev/s → ~500+ ev/s).

- **`benchmark-gates.md`** — fast-drain before/after, the 5-node headline table, and the updated verified-capacity statement (10k lossless with full quorum finality on the 5-node mesh, median convergence < 60 s).
- **`status.md`** — the 07-19 note extended with the fast drain and the headline run.
- **`README.md`** — milestones upgraded: 10,000/10,000 finalized across all 5 validators; anti-entropy bullet now cites the 5-node 10k proof.

## 💡 Motivation and Context

This is the closing entry of the 10k stress arc: five stacked fixes (#325, #327, #328, #330, #332), each verified live, ending in a lossless, fully-finalized 10k burst on the real 5-node QUIC/gossipsub validator mesh. The docs now carry the attributable headline number.

## ✅ How Has This Been Tested?

- [ ] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [x] Manual testing

Docs-only. Numbers transcribed from `testnet-bench-20260719-145059.json` and the post-run finalized-metric check (all five nodes reporting 10,000).

## 📝 Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## ➕ Additional Context

Remaining optional levers for the straggler tail (138 s / 302 s): widen per-interval serve capacity when many peers are behind, and let caught-up workers serve more of the tail to each other. Neither affects correctness; both deserve their own measured change if pursued.