### PR TITLE
docs: bootstrap the GitHub wiki — 8 pages, repo-versioned, auto-published

### DIFF
--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -1,0 +1,57 @@
+# Publishes the repo's wiki/ directory to the GitHub wiki
+# (github.com/<repo>/wiki) whenever it changes on dev or main.
+#
+# Why sync from the repo instead of editing the wiki directly:
+#   - wiki pages go through normal PR review like everything else
+#   - the wiki can never silently drift from the repo state
+#   - history lives in one place
+#
+# One-time prerequisite: the wiki git repo only exists after the wiki has
+# been initialized once — if this job fails with "repository not found",
+# open the repo's Wiki tab in the GitHub UI, create any page (it will be
+# overwritten by the next sync), and re-run the workflow.
+#
+# If GITHUB_TOKEN is not accepted for the wiki push (rare org policies),
+# add a classic PAT with `repo` scope as the WIKI_TOKEN secret — the job
+# prefers it automatically when present.
+
+name: Sync Wiki
+
+on:
+  push:
+    branches: [dev, main]
+    paths:
+      - "wiki/**"
+      - ".github/workflows/wiki-sync.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: wiki-sync
+  cancel-in-progress: true
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Publish wiki/ to the wiki repository
+        env:
+          PUSH_TOKEN: ${{ secrets.WIKI_TOKEN != '' && secrets.WIKI_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          git clone "https://x-access-token:${PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.wiki.git" /tmp/wiki
+          rsync -a --delete --exclude .git wiki/ /tmp/wiki/
+          cd /tmp/wiki
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          if git diff --cached --quiet; then
+            echo "Wiki already up to date."
+            exit 0
+          fi
+          git commit -m "Sync wiki from ${GITHUB_REPOSITORY}@${GITHUB_SHA::9}"
+          git push

--- a/wiki/Architecture-Overview.md
+++ b/wiki/Architecture-Overview.md
@@ -1,0 +1,82 @@
+# Architecture Overview
+
+Omnia is a layered stack. Every layer below is implemented and tested in the
+repository today — this page is the map, the code is the territory.
+
+```
+┌──────────────────────────────────────────────────┐
+│  LAYER 5: Economics (UBC, Governance)            │
+├──────────────────────────────────────────────────┤
+│  LAYER 4: Identity (DIDs, Shamir, Biometrics)    │
+├──────────────────────────────────────────────────┤
+│  LAYER 3: Binding (Provenance, RF, Quantum)      │
+├──────────────────────────────────────────────────┤
+│  LAYER 2: Domain Shards (6 shards)               │
+├──────────────────────────────────────────────────┤
+│  LAYER 1: Substrate (Causal Graph Consensus)     │
+├──────────────────────────────────────────────────┤
+│  LAYER 0: ZK-Rollup Settlement (chain-agnostic)  │
+└──────────────────────────────────────────────────┘
+```
+
+## Layer 1 — The Substrate (the heart)
+
+Instead of a blockchain's single ordered chain, Omnia's substrate is a
+**causal graph**: every event names its parents, vector clocks capture
+"happened-before," and CRDTs make concurrent state merges deterministic.
+Consequences:
+
+- **Parallelism** — events that don't causally depend on each other commit
+  independently; there is no global sequencer to queue behind.
+- **Self-healing** — because state is CRDT-merged and the graph is
+  content-addressed, nodes that fall behind reconcile by exchanging
+  frontiers and re-fetching exactly what they miss (anti-entropy repair).
+- **BFT finality** — consensus finalizes cuts of the graph with Byzantine
+  fault tolerance (see [Two-Lane Consensus](Two-Lane-Consensus)).
+
+Crates: `omnia-primitives` (events, vector clocks), `omnia-consensus`
+(causal graph, finality), `omnia-network` (libp2p QUIC + gossipsub mesh,
+anti-entropy), `substrate` (the consensus round loop).
+
+## Layer 0 — Settlement without lock-in
+
+State transitions are proven with **Groth16 ZK proofs** (arkworks, BN254)
+and can settle on any L1 that verifies proofs and stores data — an Ethereum
+adapter (`OmniaRollup.sol`) exists today; Bitcoin/Solana/Celestia adapters
+are stubs by design. Omnia is a coordination layer, not another L1
+competing for your liquidity.
+
+## Layers 2–5 in one paragraph each
+
+- **Domain shards** — six typed shards (financial, identity, provenance, …)
+  route events by domain, with cross-shard messaging and per-shard fees.
+- **Binding** — append-only provenance logs tie physical objects and
+  real-world processes into the graph (RF fingerprints and quantum
+  commitments are the research edge here).
+- **Identity** — self-sovereign `did:omnia:` identities derived from
+  Ed25519 keys; social recovery via Shamir secret sharing (GF(256), AES-GCM
+  encrypted shares); verifiable credentials; AI-agent identities with typed
+  capabilities.
+- **Economics** — **Universal Basic Compute (UBC)**: every registered DID
+  receives a soulbound monthly quota of protocol capacity. Governance is
+  quadratic voting with integer decay. There is deliberately no speculative
+  token.
+
+## Security posture (selected)
+
+- Ed25519 (`verify_strict`) event signatures; BLAKE3 domain-separated
+  hashing everywhere.
+- Post-quantum: ML-KEM-768 (FIPS-203 algorithm) commitments.
+- Gradual slashing (Warning → Jail → Ejection), equivocation detection in
+  constant time.
+- `#![deny(unsafe_code)]`, zero production `unwrap()`, 34 typed error enums.
+- TLA+ specifications model-checked in CI on every pull request.
+
+## Where to go deeper
+
+| Topic | Canonical doc |
+|---|---|
+| Full blueprint | [`docs/reference/blueprint-reference.md`](https://github.com/Willow7737/omnia-protocol/blob/main/docs/reference/blueprint-reference.md) |
+| Trait boundaries / crate map | [`docs/architecture/`](https://github.com/Willow7737/omnia-protocol/tree/main/docs/architecture) |
+| Consensus design decisions | [ADR index](https://github.com/Willow7737/omnia-protocol/blob/main/docs/reference/adr-index.md) |
+| Requirement-level status | [`docs/reference/status.md`](https://github.com/Willow7737/omnia-protocol/blob/main/docs/reference/status.md) |

--- a/wiki/Benchmarks.md
+++ b/wiki/Benchmarks.md
@@ -1,0 +1,67 @@
+# Benchmarks
+
+Omnia's performance claims are **benchmark-gated**: CI fails if the hot
+path regresses (3-layer gate: deterministic IAI instruction counts,
+multi-sample criterion with bootstrap confidence intervals, and
+single-sample fast gates). The canonical, always-current record is
+[`docs/reference/benchmark-gates.md`](https://github.com/Willow7737/omnia-protocol/blob/main/docs/reference/benchmark-gates.md)
+— this page is the summary.
+
+## Live-network results (July 2026, real QUIC/gossipsub mesh)
+
+The headline: **a 10,000-event single-source burst on the full 5-node
+validator mesh reached 100% propagation AND 10,000/10,000 Lane 0 BFT
+finality on every node — zero loss** (2026-07-19, single host; the
+geo-distributed re-run is the next milestone).
+
+| Burst | Topology | Propagation | Finality | Convergence |
+|---|---|---|---|---|
+| 1,000 | 5-node mesh | 100% ×5 | full quorum | ~10 s |
+| 2,000 | 5-node mesh + Lane 0 | 100% ×5 | 2,000/2,000 | ~7–17 s |
+| 5,000 | 5-node mesh + Lane 0 | 100% ×5 | 5,000/5,000 | ~40–45 s |
+| **10,000** | **5-node mesh + Lane 0** | **100% ×5** | **10,000/10,000** | **median < 60 s** (stragglers to ~5 min) |
+
+The 10k result is the interesting one: the burst deliberately overwhelms
+live gossip, and **anti-entropy repair recovers everything** — nodes
+exchange frontier digests, fetch exactly what they miss in chained batches,
+and re-admit it through the full validation pipeline. Nothing is trusted,
+nothing is lost.
+
+## The 2026-07-19 diagnosis arc (why you can trust these numbers)
+
+Getting 10k to converge exposed and fixed **five stacked bottlenecks**,
+each masked by the next — serve-throughput limits, a deferral-queue
+priority inversion, a rate limiter throttling solicited repair, and finally
+the root cause: an unconfigured 64 KiB gossipsub transmit cap silently
+dropping every repair batch. Each fix landed with a locking regression
+test, and each was verified against a provably fresh binary before the next
+layer was touched. The full forensic narrative is in
+[`benchmark-gates.md`](https://github.com/Willow7737/omnia-protocol/blob/main/docs/reference/benchmark-gates.md)
+— kept deliberately, failures included, because a benchmark record you can
+audit is worth more than a highlight reel.
+
+## Hot-path numbers (single node, synchronous, CI-gated)
+
+| Metric | Baseline (v0.1.68) |
+|---|---|
+| Sustained consensus throughput | ~12,000 ops/s |
+| Finality latency p50 | ~25 µs |
+| DAG insert p50 | ~23 µs |
+| Event create + sign | ~22 µs |
+| ZK proof (basic circuit) | ~2.5 ms |
+
+These are in-process numbers — **not** comparable to the live-network
+numbers above, which include HTTP, JSON, signing, and real network I/O.
+The docs are strict about never mixing the two.
+
+## Honest caveats (we keep them attached)
+
+- All multi-node numbers so far are **single-host** (near-zero RTT). The
+  geo-distributed run across EU/US/Asia is the next recorded milestone —
+  runbook: [`docs/operations/geo-testnet.md`](https://github.com/Willow7737/omnia-protocol/blob/main/docs/operations/geo-testnet.md).
+- Large-burst convergence has a repair tail (stragglers up to ~5 min at
+  10k); the comfort zone for sub-minute convergence is ~2,000–3,000 events
+  per burst. Tail-tuning levers are documented.
+- ZK proving (~88 ms/event expanded circuit) is orders of magnitude slower
+  than consensus — by design it runs asynchronously and never blocks
+  finality.

--- a/wiki/FAQ.md
+++ b/wiki/FAQ.md
@@ -1,0 +1,77 @@
+# FAQ
+
+### Is Omnia a blockchain?
+
+No. It's a **causal graph** protocol: events reference their parents
+directly, so unrelated transactions never queue behind each other. There is
+no global chain, no miners, no sequencer. BFT finality comes from validator
+quorum certificates over the graph ([Two-Lane Consensus](Two-Lane-Consensus)).
+
+### Is there a token? Was there a sale?
+
+There is **no speculative token and there was no sale**. UBC (Universal
+Basic Compute) is a soulbound monthly quota of protocol capacity granted to
+every registered identity. The code is CC0 — public domain, no company
+gatekeeping.
+
+### What actually works today, versus roadmap?
+
+Working and measured, today: the full consensus substrate; a live
+multi-node validator testnet with real BFT finality (10,000/10,000 events
+finalized across 5 validators in stress testing); anti-entropy
+self-healing; a shipped mobile wallet, web dashboard, and website; ZK
+proof generation with an Ethereum settlement adapter; TLA+ specs
+model-checked in CI.
+
+Explicitly not done yet: geo-distributed deployment (runbook ready, run
+pending), external security audit, Bitcoin/Solana/Celestia adapters
+(stubs), proof-of-useful-work, conviction voting/delegation. The
+requirement-level truth lives in
+[`docs/reference/status.md`](https://github.com/Willow7737/omnia-protocol/blob/main/docs/reference/status.md)
+and the [stub inventory](https://github.com/Willow7737/omnia-protocol/blob/main/docs/stub-inventory.md)
+— the project tracks its own gaps publicly.
+
+### How fast is it, really?
+
+Two different questions with two different answers, never mixed:
+**~12,000 ops/s** consensus hot path (single node, in-process, CI-gated),
+and on the **real network**, 10k-event bursts reach 100% propagation with
+full BFT finality on a 5-node mesh (median node convergence under a
+minute). Details and caveats: [Benchmarks](Benchmarks).
+
+### Is it quantum-resistant?
+
+Partially, by design: ML-KEM-768 (the FIPS-203 algorithm) is used for
+quantum commitments today, and the signature scheme is migration-planned
+(see the crypto-migration reference in `docs/reference/`). Ed25519 remains
+the event-signature workhorse for now.
+
+### Can it really settle on any chain?
+
+The architecture is settlement-agnostic (ZK proofs + data availability are
+the only requirements of the settlement layer). Ethereum settlement exists
+(`OmniaRollup.sol` with a Groth16 verifier); other adapters are interface
+stubs awaiting implementation. "Agnostic" describes the design boundary,
+not a claim that every adapter exists.
+
+### How can I verify any of these claims?
+
+Everything is reproducible: `cargo test --workspace` (1,300+ tests),
+`docker compose up` a testnet and run `scripts/testnet-bench.sh` yourself,
+read the benchmark record including its failure forensics
+([Benchmarks](Benchmarks)), or model-check the TLA+ specs. Distrust and
+verify — the repo is built for it.
+
+### How do I contribute?
+
+[`CONTRIBUTING.md`](https://github.com/Willow7737/omnia-protocol/blob/main/CONTRIBUTING.md).
+Development happens on the `dev` branch through PRs with a 22-check CI
+gate. Security reports: see
+[`SECURITY.md`](https://github.com/Willow7737/omnia-protocol/blob/main/SECURITY.md)
+(there's a bounty program).
+
+### Who is behind this?
+
+An open project by [Willow7737](https://github.com/Willow7737) with
+AI-assisted engineering, developed fully in the open — every decision is an
+ADR, every claim is a benchmark, every gap is in the stub inventory.

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -1,0 +1,75 @@
+# Getting Started
+
+Three paths, fastest first.
+
+## 1. Just talk to the live testnet (30 seconds)
+
+No install — the public multi-node testnet is running now:
+
+```bash
+curl https://78.47.43.136.sslip.io/api/v1/node/info
+```
+
+Swagger UI for the full REST API is served at the same host. For the wallet
+experience, see [Wallet & Ecosystem](Wallet-and-Ecosystem).
+
+## 2. Run a local node (5 minutes with Docker)
+
+```bash
+git clone https://github.com/Willow7737/omnia-protocol
+cd omnia-protocol
+docker compose -f docker/docker-compose.testnet.yml up -d --build
+curl -s http://localhost:9090/api/v1/node/info | python3 -m json.tool
+```
+
+That starts a 3-node local testnet (bootstrap + 2 peers) with health
+checks. To make the nodes **Lane 0 validators** with real BFT finality:
+
+```bash
+NODES=3 ./scripts/setup-validators.sh   # generates keys + docker/.env
+docker compose -f docker/docker-compose.testnet.yml up -d --build
+```
+
+Then benchmark it (live progress bars included):
+
+```bash
+OMNIA_JWT_SECRET=$(grep ^OMNIA_JWT_SECRET= docker/.env | cut -d= -f2-) \
+  ./scripts/testnet-bench.sh --events 1000 --concurrency 16
+```
+
+## 3. Build from source
+
+Requirements: Rust ≥ 1.91 (MSRV), `protobuf-compiler`, `pkg-config`,
+`libssl-dev`.
+
+```bash
+git clone https://github.com/Willow7737/omnia-protocol
+cd omnia-protocol
+cargo build --release -p omnia-node --no-default-features --features full
+cargo test --workspace          # 1,300+ tests
+./target/release/omnia-node --help
+```
+
+Feature flags matter — `full` enables ZK proving (arkworks), `light` is the
+minimal node. The matrix is documented in
+[`docs/building/feature-matrix.md`](https://github.com/Willow7737/omnia-protocol/blob/main/docs/building/feature-matrix.md).
+
+## Key environment variables
+
+| Variable | Purpose |
+|---|---|
+| `OMNIA_JWT_SECRET` | HMAC secret for API JWTs (required) |
+| `OMNIA_LANE0_VALIDATORS` | Comma list of `<hex-pubkey>:<stake>` — enables Lane 0 finality; identical on every node |
+| `OMNIA_NODE_KEY_FILE` | Persistent Ed25519 validator key (raw 32 bytes) |
+| `OMNIA_BOOTSTRAP_NODES` | Multiaddr(s) to dial on startup, e.g. `/ip4/1.2.3.4/udp/4001/quic-v1` |
+| `OMNIA_HTTP_PORT` | REST API + metrics port |
+| `OMNIA_RATE_LIMIT_RPS` | Per-client API rate limit (raise for benchmarks) |
+
+Full deployment reference:
+[`docs/operations/`](https://github.com/Willow7737/omnia-protocol/tree/main/docs/operations).
+
+## Where next
+
+- Join or reproduce the real network: [Testnet Guide](Testnet-Guide)
+- Understand what you just ran: [Architecture Overview](Architecture-Overview)
+- Contribute: [`CONTRIBUTING.md`](https://github.com/Willow7737/omnia-protocol/blob/main/CONTRIBUTING.md)

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,0 +1,58 @@
+# Omnia Protocol
+
+**The Universal Coordination Layer for Reality** — a settlement-agnostic
+protocol that replaces trust with mathematics, using causal graph consensus
+(DAG + vector clocks + CRDTs) for parallel transaction processing.
+
+> 🟢 **Live right now:** a multi-node Lane 0 validator testnet at
+> [`78.47.43.136.sslip.io`](https://78.47.43.136.sslip.io/api/v1/node/info),
+> a shipped [mobile wallet](https://github.com/Willow7737/Omnia-Wallet),
+> a [web dashboard](https://github.com/Willow7737/omnia-protocol-interface),
+> and a [website](https://github.com/Willow7737/omnia-web).
+
+## Why Omnia?
+
+Blockchains serialize the world into one global queue. Omnia doesn't: events
+form a **causal graph**, so transactions that don't depend on each other are
+processed in parallel, and consensus finalizes the graph — not a chain. The
+protocol is **settlement-agnostic**: it can settle to Ethereum, Bitcoin,
+Solana, or any L1 with data availability and proof verification, via
+ZK-rollup proofs.
+
+## Headline numbers (measured live, July 2026)
+
+| What | Result |
+|---|---|
+| 10,000-event burst, 5-node validator mesh | **100% propagation + 10,000/10,000 BFT-finalized on every node — zero loss** |
+| Consensus hot path (single node) | ~12,000 ops/s, ~25 µs finality p50 |
+| Burst self-healing | Anti-entropy repair recovers everything live gossip drops under overload |
+| Formal verification | TLA+ models (`OmniaTwoLane`, `OmniaConsensus`, `OmniaCRDT`) model-checked in CI on every PR |
+
+Full methodology and history: [Benchmarks](Benchmarks).
+
+## Start here
+
+| You are… | Go to |
+|---|---|
+| New and curious | [What Is Omnia](Architecture-Overview) |
+| A developer who wants a node running | [Getting Started](Getting-Started) |
+| An operator joining/running the testnet | [Testnet Guide](Testnet-Guide) |
+| Interested in the consensus design | [Two-Lane Consensus](Two-Lane-Consensus) |
+| A wallet user | [Wallet & Ecosystem](Wallet-and-Ecosystem) |
+| Skeptical (good!) | [Benchmarks](Benchmarks) and [FAQ](FAQ) |
+
+## Project facts
+
+- **License:** CC0 (public domain) — no token sale, no company gatekeeping.
+- **Language:** Rust (MSRV 1.91), ~86,000 lines, 1,300+ tests,
+  `#![deny(unsafe_code)]`.
+- **Status:** Phase 6 (Public Testnet) — multi-node validator network live;
+  geo-distributed rollout and external audit next.
+- **Repository:** [Willow7737/omnia-protocol](https://github.com/Willow7737/omnia-protocol)
+
+> **Note on freshness:** this wiki is a guided entry point. The canonical,
+> always-current references live in the repository under
+> [`docs/`](https://github.com/Willow7737/omnia-protocol/tree/main/docs) —
+> every page here links to its source of truth. The wiki itself is
+> version-controlled in the repo (`wiki/`) and auto-published, so edits go
+> through normal pull-request review.

--- a/wiki/Testnet-Guide.md
+++ b/wiki/Testnet-Guide.md
@@ -1,0 +1,70 @@
+# Testnet Guide
+
+The Omnia testnet is a real QUIC/gossipsub mesh of Lane 0 validator nodes —
+the same code path as production, no simulation.
+
+## Topologies in the repo
+
+| Compose file | Shape | Use for |
+|---|---|---|
+| `docker/docker-compose.testnet.yml` | 3 nodes on one host (bootstrap + 2) | Quick local testnet |
+| `docker/docker-compose.yml` + `docker-compose.lane0.yml` | 5-node worker mesh + validator overlay | The full single-host benchmark topology |
+| `docker/docker-compose.wan.yml` | 1 node per host, host networking | **Geo-distributed** testnet across real regions |
+
+## Standing up a validator testnet (single host)
+
+```bash
+git clone https://github.com/Willow7737/omnia-protocol && cd omnia-protocol
+NODES=5 ./scripts/setup-validators.sh        # keys + OMNIA_LANE0_VALIDATORS + .env
+docker compose -f docker/docker-compose.yml -f docker/docker-compose.lane0.yml up -d --build
+```
+
+`setup-validators.sh` generates a persistent Ed25519 keypair per node and
+writes the identical validator set into `docker/.env` — every node must
+agree on `OMNIA_LANE0_VALIDATORS` byte-for-byte or acks are rejected as
+"unknown validator."
+
+**The classic gotcha:** containers run as uid 1000. If validator keys are
+root-owned with `go-rwx`, the node silently falls back to an ephemeral
+identity (`this_node_is_validator=false` in logs) and finality stays at
+zero while propagation looks healthy. The script chowns for you when run as
+root; re-check after copying keys between machines.
+
+## Benchmarking
+
+```bash
+OMNIA_JWT_SECRET=$(grep ^OMNIA_JWT_SECRET= docker/.env | cut -d= -f2-) \
+  ./scripts/testnet-bench.sh \
+  --nodes http://localhost:9090,http://localhost:9091,http://localhost:9092,http://localhost:9093,http://localhost:9094 \
+  --events 10000 --concurrency 64 --timeout 600
+```
+
+The script submits load to the first node, then measures propagation on
+**all** listed nodes via Prometheus metrics, with a live progress line
+(elapsed timer, slowest-node bar, per-node percentages) so long repair
+tails are visibly moving. It writes a JSON report to `bench-results/`.
+
+What the metrics mean:
+
+- `omnia_dag_events_total` — events inserted into this node's DAG
+  (propagation).
+- `omnia_node_events_finalized_total` — events with a Lane 0 quorum
+  certificate (BFT finality). Trails propagation by moments; certificates
+  are grow-only, so it never decreases.
+- `omnia_node_peers_connected` — mesh health; N-1 on a full mesh.
+
+## Going geo-distributed
+
+The full operator runbook — provisioning, firewall rules, key
+distribution, RTT-matrix capture, the 1k→5k→10k benchmark ladder, and a
+troubleshooting table — is
+[`docs/operations/geo-testnet.md`](https://github.com/Willow7737/omnia-protocol/blob/main/docs/operations/geo-testnet.md).
+
+## Troubleshooting (short version)
+
+| Symptom | First check |
+|---|---|
+| `peers=0` | UDP 4001 reachability; `OMNIA_BOOTSTRAP_NODES` multiaddr |
+| Finality 0, propagation fine | Key permissions (uid 1000) or validator-set mismatch |
+| Propagation stuck at a flat % | Read the anti-entropy repair logs; compare with the diagnosis arc in [`benchmark-gates.md`](https://github.com/Willow7737/omnia-protocol/blob/main/docs/reference/benchmark-gates.md) |
+| HTTP 429 during benchmarks | Raise `OMNIA_RATE_LIMIT_RPS` (default 10) |

--- a/wiki/Two-Lane-Consensus.md
+++ b/wiki/Two-Lane-Consensus.md
@@ -1,0 +1,49 @@
+# Two-Lane Consensus (ADR-025)
+
+Omnia finalizes events on two lanes with different trust requirements —
+because most of the world's coordination doesn't need full BFT agreement,
+and making everything pay for it is why blockchains are slow.
+
+## Lane 0 — Consensusless fast path
+
+For operations whose validity is **self-evident given the causal graph**
+(UBC quota spends, transfers with clear provenance), Omnia uses
+**quorum-acknowledged finality without ordering consensus**:
+
+1. A validator sees an event, validates it fully, and broadcasts a signed
+   acknowledgment.
+2. Acks accumulate in a **grow-only CRDT certificate** (a G-Set — order
+   cannot matter, duplicates cannot matter, nothing can be retracted).
+3. When acks representing **> 2/3 of validator stake** exist, the event is
+   final. No leader, no rounds, no view changes.
+
+This is the lane that finalized **10,000/10,000 events across all 5
+validators** in the July 2026 stress runs. Validator-set changes are
+epoch-fenced and themselves authorized through Lane 1.
+
+## Lane 1 — DAG-native BFT for contested state
+
+State that can genuinely conflict (governance, validator-set changes,
+anything where two honest nodes could disagree) goes through full BFT
+consensus over the causal graph — an AlephBFT-inspired famous-witness
+commit rule that finalizes graph cuts deterministically.
+
+## Why this split is sound
+
+- Lane 0's certificate is a CRDT: any two nodes that see the same acks
+  compute the same finality, in any order, with no coordination.
+- The quorum threshold makes conflicting Lane 0 finality impossible with
+  < 1/3 Byzantine stake — the same bound as the BFT lane.
+- Formally specified: `formal-verification/OmniaTwoLane.tla` models both
+  lanes plus the epoch fence, and is **model-checked by TLC in CI on every
+  pull request**, alongside `OmniaConsensus.tla` and `OmniaCRDT.tla`.
+- Adversarially tested: a property-based "consensus arena" drives
+  withholding, reordering, duplication, forgery, and rotation-schedule
+  attacks against Lane 0 in CI.
+
+## Reading list
+
+- [ADR-025 — Two-Lane Consensus](https://github.com/Willow7737/omnia-protocol/blob/main/docs/adr/ADR-025-two-lane-consensus.md) (the decision record)
+- [`substrate/src/lane0.rs`](https://github.com/Willow7737/omnia-protocol/blob/main/substrate/src/lane0.rs) (the implementation)
+- [`formal-verification/`](https://github.com/Willow7737/omnia-protocol/tree/main/formal-verification) (the TLA+ specs)
+- [Benchmarks](Benchmarks) (what it measures like on a real network)

--- a/wiki/Wallet-and-Ecosystem.md
+++ b/wiki/Wallet-and-Ecosystem.md
@@ -1,0 +1,57 @@
+# Wallet & Ecosystem
+
+Omnia is not just a protocol repo — it ships with a working client
+ecosystem, all live against the public testnet node.
+
+## 📱 Omnia Wallet (mobile, v1 shipped)
+
+**Repo:** [Willow7737/Omnia-Wallet](https://github.com/Willow7737/Omnia-Wallet)
+(Flutter, Android/iOS)
+
+- **Dual-mode auth** — true self-custody (an Ed25519 key generated and
+  stored on-device signs a challenge; the key never leaves the phone) or
+  convenience sign-in (Google/GitHub/email via Supabase, which mints node
+  JWTs through an edge function).
+- **Self-sovereign identity** — your DID is derived from your public key
+  (`did:omnia:` + `sha256(pubkey)[..32]`), identically on device and node,
+  pinned by a cross-repo test vector.
+- **The full loop works today:** create wallet → challenge/login →
+  registered DID with a 1,000 UBC monthly quota → send → history, with
+  per-transaction detail including **Lane 0 finality status** and signing
+  provenance.
+- Plus: governance voting, QR send/receive with request-amounts, address
+  book, biometric app lock, in-app notifications, and a team news feed.
+
+## 🖥️ Web dashboard
+
+**Repo:** [Willow7737/omnia-protocol-interface](https://github.com/Willow7737/omnia-protocol-interface)
+(Next.js + Supabase) — node stats, events, balances, governance in the
+browser.
+
+## 🌐 Website
+
+**Repo:** [Willow7737/omnia-web](https://github.com/Willow7737/omnia-web)
+
+## The node API the clients speak
+
+Public REST API on the testnet node (Swagger UI at the node root):
+
+| Endpoint | Purpose |
+|---|---|
+| `POST /api/v1/auth/challenge` → `POST /api/v1/auth/login` | Self-custody login: sign a single-use nonce (`"omnia-auth:" + nonce`), get a JWT |
+| `POST /api/v1/auth/register` | Idempotent DID registration for externally-minted JWTs |
+| `GET /api/v1/economics/balance/:did` | Balance, monthly quota, epoch |
+| `POST /api/v1/economics/transfer` | UBC transfer (emits an on-graph event with Lane 0 finality) |
+| `GET /api/v1/economics/transfers` | History with `event_id` + `lane0_final` |
+| `GET /api/v1/node/info` | Node identity, Lane 0 stats, peers |
+
+Security properties worth knowing: nonces are single-use with a short TTL,
+signed messages are domain-separated (`omnia-auth:`), signatures verified
+with `verify_strict`, and the node derives your DID from the *verified*
+key — never from request bodies.
+
+## A note on UBC
+
+UBC (Universal Basic Compute) is **soulbound protocol capacity, not a
+speculative token**. Every registered DID receives a monthly quota. There
+was no token sale and the entire protocol is CC0 public domain.

--- a/wiki/_Footer.md
+++ b/wiki/_Footer.md
@@ -1,0 +1,1 @@
+📚 Canonical docs live in [`docs/`](https://github.com/Willow7737/omnia-protocol/tree/main/docs) · This wiki is version-controlled in [`wiki/`](https://github.com/Willow7737/omnia-protocol/tree/main/wiki) and auto-published — edit via pull request, not the wiki UI · Omnia Protocol is CC0 public domain

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -1,0 +1,17 @@
+**[🏠 Home](Home)**
+
+**Learn**
+- [Architecture Overview](Architecture-Overview)
+- [Two-Lane Consensus](Two-Lane-Consensus)
+- [Benchmarks](Benchmarks)
+- [FAQ](FAQ)
+
+**Do**
+- [Getting Started](Getting-Started)
+- [Testnet Guide](Testnet-Guide)
+- [Wallet & Ecosystem](Wallet-and-Ecosystem)
+
+**Reference**
+- [Repo docs/](https://github.com/Willow7737/omnia-protocol/tree/main/docs)
+- [ADR index](https://github.com/Willow7737/omnia-protocol/blob/main/docs/reference/adr-index.md)
+- [Status tracker](https://github.com/Willow7737/omnia-protocol/blob/main/docs/reference/status.md)


### PR DESCRIPTION
## 🚀 Description

The repository wiki has been empty since day one. This PR adds a complete first edition — and keeps it **in the repo** (`wiki/`), published to the actual GitHub wiki by a new `wiki-sync.yml` workflow, so wiki pages go through normal PR review and can never silently drift from repo state.

**The 8 pages:**
- **Home** — what Omnia is, headline measured numbers, role-based entry table
- **Architecture-Overview** — the layer map, one honest paragraph per layer, security posture, deep links into `docs/`
- **Two-Lane-Consensus** — ADR-025 for newcomers: Lane 0 quorum-ack CRDT finality, Lane 1 DAG BFT, why the split is sound, TLA+ pointers
- **Getting-Started** — live-node curl in 30 s, Docker testnet in 5 min, from-source build, key env vars
- **Testnet-Guide** — the three compose topologies, validator setup, the uid-1000 key gotcha, benchmarking, metrics glossary, troubleshooting
- **Benchmarks** — live-network results including the 10k/5-node milestone, the five-bottleneck diagnosis arc presented as a trust argument, hot-path numbers kept strictly separate from network numbers, caveats attached
- **Wallet-and-Ecosystem** — wallet/dashboard/website, the node auth contract, UBC-is-not-a-token
- **FAQ** — the skeptic's page: what works vs. roadmap, and how to independently verify every claim
- Plus `_Sidebar` navigation and a `_Footer` directing edits to PRs.

**`.github/workflows/wiki-sync.yml`** publishes `wiki/` to `<repo>.wiki.git` on any change to it (dev/main, plus manual dispatch). Prefers a `WIKI_TOKEN` secret when present, falls back to `GITHUB_TOKEN`.

## 💡 Motivation and Context

An empty wiki tab reads as an abandoned project — exactly wrong for a repo heading into investor review. Writing the wiki as repo files rather than via the wiki UI means review, history, and freshness guarantees come for free, and the wiki inherits the docs-refresh discipline already established for `docs/`.

## ✅ How Has This Been Tested?

- [ ] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [x] Manual testing

Workflow YAML validated. Content cross-checked against `README.md`, `docs/reference/status.md`, and `docs/reference/benchmark-gates.md` as of the #333 merge — every number and status claim traces to a canonical doc, and each page links to its source of truth.

## 📝 Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## ➕ Additional Context

**One-time step after merge:** if the wiki git repo has never been initialized, the first sync run may fail with "repository not found" — open the repo's Wiki tab once, create any placeholder page (the next sync overwrites it), and re-run the workflow from the Actions tab. This is a GitHub platform quirk, documented in the workflow header.