### PR TITLE
docs: record the geo-distributed WAN campaign — the asterisk is gone

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,11 @@ The full loop — create wallet → challenge/login → registered DID with a 1,
   5-node mesh: a 10,000-event burst overwhelms live gossip, then repair
   recovers every event — **100% propagation + full quorum finality on
   all five nodes, zero loss, median convergence under a minute.**
+- **Proven on the real internet (2026-07-20)** — a 3-region WAN
+  validator network (Nuremberg / Ashburn / Singapore, RTTs up to
+  ~218 ms) sustained the same test: **100% propagation + full quorum
+  finality at 1k/5k/10k bursts, zero loss.** No more single-host
+  asterisk.
 - Formally specified: TLA+ models (`OmniaTwoLane`, `OmniaConsensus`,
   `OmniaCRDT`) model-checked in CI on every PR.
 

--- a/docs/reference/benchmark-gates.md
+++ b/docs/reference/benchmark-gates.md
@@ -2,7 +2,7 @@
 
 > Audience: Developers, CI Engineers
 > Context: 3-layer benchmark regression gate architecture, current baselines, and IAI instruction-count gates
-> Last Updated: 2026-07-19
+> Last Updated: 2026-07-20
 
 
 ## Local Reference Run — 2026-07-09 (v0.1.76+/dev)
@@ -457,9 +457,68 @@ chowns them when run as root. An unreadable key silently degrades to an
 ephemeral identity (`this_node_is_validator=false`) and finality stays
 at zero while propagation looks healthy.
 
+## Geo-Distributed WAN Results (2026-07-20) — first numbers without the single-host asterisk
+
+Executed per [docs/operations/geo-testnet.md](../operations/geo-testnet.md):
+three Hetzner CPX21 nodes, all Lane 0 validators, real internet paths.
+
+**Topology + measured RTT matrix:**
+
+| Node | Region | Role |
+|------|--------|------|
+| A | Nuremberg, EU (`nbg1`) | bootstrap + validator + ingress + bench host |
+| B | Ashburn, US-East (`ash`) | validator |
+| C | Singapore (`sin`) | validator |
+
+| Path | RTT min/avg/max (ms) |
+|------|----------------------|
+| A↔B | 98.7 / **98.8** / 99.1 |
+| A↔C | 159.3 / **160.3** / 163.8 |
+| B↔C | 217.6 / **217.9** / 218.8 |
+
+**Benchmark ladder — 100% propagation on every node at every rung:**
+
+| Rung | Events / conc. | Convergence A / B / C (s) | Finality | Peak RSS | Report |
+|------|---------------|---------------------------|----------|----------|--------|
+| 1 | 1,000 / 16 | 4.6 / 7.4 / 7.7 | full (all nodes) | 64 MB | `testnet-bench-20260720-020307.json` |
+| 2 | 5,000 / 64 | 12.4 / 91.9 / 273.1 | full (all nodes) | 110 MB | `testnet-bench-20260720-020803.json` |
+| 3 | **10,000 / 64** | **29.4 / 289.1 / 37.6** | **full (all nodes)** | 145 MB | `testnet-bench-20260720-021319.json` |
+
+(`finalized_total` is a cumulative counter — the nodes ran all three rungs
+without restart, so the reported 6,000 after rung 2 and 16,000 after rung 3
+equal the exact sum of all events submitted, identical on every node:
+**every event of every rung reached full quorum finality.**)
+
+**Reading:**
+
+- **The mesh holds on the real internet.** Steady-state gossip at WAN RTT
+  is barely distinguishable from single-host: the 1k rung converged
+  everywhere in under 8 s.
+- **Burst self-healing works across 99–218 ms paths.** The 5k and 10k
+  rungs overwhelm live gossip by design; anti-entropy repair recovered
+  every event and Lane 0 finalized all of it, with zero loss, on every
+  rung.
+- **The straggler alternates with path geometry**, exactly as the
+  contention model predicts: on 5k it was C (273 s), on 10k it was B
+  (289 s) — whichever node ends up chasing the tail over the worst path
+  (B↔C, 218 ms) pays repair-chain round-trips at real RTT while the
+  other laggard shares bandwidth. Median convergence stayed excellent
+  (10k: two of three nodes < 40 s). The known lever remains the
+  directed-repair fairness change (serve the lowest-frontier requester
+  first / unicast repair); correctness is not at stake.
+- **Resources are a non-issue:** peak 145 MB RSS on the ingress node at
+  10k — CPX21 (~€8/mo) has multiples of headroom.
+
+**Verified capacity (2026-07-20): 10,000-event bursts reach 100%
+propagation + full Lane 0 quorum finality on a 3-region WAN validator
+network (EU / US-East / Asia, RTTs up to ~218 ms) — zero loss; fast
+nodes converge in < 40 s, worst-case straggler ~5 min. This supersedes
+the single-host asterisk on all earlier multi-node results.**
+
 > Methodology: numbers include HTTP/JSON overhead and are NOT comparable
-> to the in-process hot-path numbers above. Single-host containers mean
-> near-zero RTT; a geo-distributed run will be slower.
+> to the in-process hot-path numbers above. Convergence is measured from
+> the bench host's single clock (polling all nodes over HTTP), so
+> cross-region clock skew does not affect the numbers.
 
 ## Historical Baselines
 

--- a/docs/reference/status.md
+++ b/docs/reference/status.md
@@ -2,7 +2,7 @@
 
 > 🎯 Audience: All
 > 🔗 Context: Granular tracking of technical requirements and completion
-> 📅 Last Updated: 2026-07-19
+> 📅 Last Updated: 2026-07-20
 
 This document tracks the granular requirements for the Omnia Protocol and their current implementation status.
 
@@ -27,6 +27,13 @@ This document tracks the granular requirements for the Omnia Protocol and their 
 > validator mesh — 100% propagation + full quorum finality on all five
 > nodes, median convergence under a minute.** Numbers + full diagnosis
 > arc: [benchmark-gates.md](./benchmark-gates.md).
+>
+> **2026-07-20:** the **geo-distributed WAN run is done** — 3 Lane 0
+> validators across Nuremberg / Ashburn / Singapore (RTTs 99/160/218 ms):
+> **100% propagation + full quorum finality at 1k, 5k, and 10k bursts,
+> zero loss.** The single-host asterisk on Omnia's network numbers is
+> gone. Topology, RTT matrix, and per-rung results:
+> [benchmark-gates.md](./benchmark-gates.md).
 
 ## 1. Core Protocol (The Substrate)
 
@@ -158,7 +165,7 @@ This document tracks the granular requirements for the Omnia Protocol and their 
 | **REQ-P4.2** | Solana Settlement Adapter                   | P1       | 🔄 Stub        |
 | **REQ-P4.3** | Celestia Settlement Adapter                 | P1       | 🔄 Stub        |
 | **REQ-P4.4** | Validator Network (multi-node)              | P0       | ✅ Completed — live multi-node Lane 0 validator network (quorum-signed finality measured; see [benchmark-gates.md](./benchmark-gates.md)) |
-| **REQ-P4.5** | Public Testnet Launch                       | P0       | 🔄 Live (multi-node, single host; geo-distributed rollout planned) |
+| **REQ-P4.5** | Public Testnet Launch                       | P0       | ✅ Completed — live multi-node network, measured geo-distributed across 3 regions (2026-07-20) |
 | **REQ-P4.6** | Dynamic Fee Mechanism (EIP-1559-style)      | P1       | 📋 Planned     |
 | **REQ-P4.7** | Documentation Sprint (Dashboard, ADRs, FAQ) | P2       | ✅ Completed   |
 | **REQ-P4.8** | VRF Spec Compliance (ADR-012)               | P2       | 📋 Deferred    |

--- a/wiki/Benchmarks.md
+++ b/wiki/Benchmarks.md
@@ -9,10 +9,11 @@ single-sample fast gates). The canonical, always-current record is
 
 ## Live-network results (July 2026, real QUIC/gossipsub mesh)
 
-The headline: **a 10,000-event single-source burst on the full 5-node
-validator mesh reached 100% propagation AND 10,000/10,000 Lane 0 BFT
-finality on every node — zero loss** (2026-07-19, single host; the
-geo-distributed re-run is the next milestone).
+The headline: **a 10,000-event burst reaches 100% propagation AND full
+Lane 0 BFT finality on every node — zero loss — both on a 5-node
+single-host mesh (2026-07-19) and on a real 3-region WAN validator
+network (2026-07-20): Nuremberg / Ashburn / Singapore, RTTs up to
+~218 ms.**
 
 | Burst | Topology | Propagation | Finality | Convergence |
 |---|---|---|---|---|
@@ -20,6 +21,9 @@ geo-distributed re-run is the next milestone).
 | 2,000 | 5-node mesh + Lane 0 | 100% ×5 | 2,000/2,000 | ~7–17 s |
 | 5,000 | 5-node mesh + Lane 0 | 100% ×5 | 5,000/5,000 | ~40–45 s |
 | **10,000** | **5-node mesh + Lane 0** | **100% ×5** | **10,000/10,000** | **median < 60 s** (stragglers to ~5 min) |
+| 1,000 | **3-region WAN** (99–218 ms RTT) | 100% ×3 | full quorum | < 8 s |
+| 5,000 | 3-region WAN | 100% ×3 | full quorum | 12 s–4.6 min |
+| **10,000** | **3-region WAN** | **100% ×3** | **full quorum** | **2 of 3 nodes < 40 s** (straggler ~4.8 min) |
 
 The 10k result is the interesting one: the burst deliberately overwhelms
 live gossip, and **anti-entropy repair recovers everything** — nodes
@@ -56,9 +60,10 @@ The docs are strict about never mixing the two.
 
 ## Honest caveats (we keep them attached)
 
-- All multi-node numbers so far are **single-host** (near-zero RTT). The
-  geo-distributed run across EU/US/Asia is the next recorded milestone —
-  runbook: [`docs/operations/geo-testnet.md`](https://github.com/Willow7737/omnia-protocol/blob/main/docs/operations/geo-testnet.md).
+- The WAN repair tail stretches with RTT: the straggling node on large
+  bursts pays repair-chain round-trips over the worst path (B↔C,
+  ~218 ms). Median convergence stays fast; the documented next lever is
+  directed (unicast) repair serving.
 - Large-burst convergence has a repair tail (stragglers up to ~5 min at
   10k); the comfort zone for sub-minute convergence is ~2,000–3,000 events
   per burst. Tail-tuning levers are documented.

--- a/wiki/FAQ.md
+++ b/wiki/FAQ.md
@@ -18,13 +18,14 @@ gatekeeping.
 
 Working and measured, today: the full consensus substrate; a live
 multi-node validator testnet with real BFT finality (10,000/10,000 events
-finalized across 5 validators in stress testing); anti-entropy
-self-healing; a shipped mobile wallet, web dashboard, and website; ZK
-proof generation with an Ethereum settlement adapter; TLA+ specs
-model-checked in CI.
+finalized across 5 validators in stress testing); a **geo-distributed
+3-region WAN run** (EU/US/Asia, RTTs to ~218 ms) with 100% propagation
+and full finality at 10k bursts; anti-entropy self-healing; a shipped
+mobile wallet, web dashboard, and website; ZK proof generation with an
+Ethereum settlement adapter; TLA+ specs model-checked in CI.
 
-Explicitly not done yet: geo-distributed deployment (runbook ready, run
-pending), external security audit, Bitcoin/Solana/Celestia adapters
+Explicitly not done yet: a permanently-running geo network (the WAN run
+was a measured campaign), external security audit, Bitcoin/Solana/Celestia adapters
 (stubs), proof-of-useful-work, conviction voting/delegation. The
 requirement-level truth lives in
 [`docs/reference/status.md`](https://github.com/Willow7737/omnia-protocol/blob/main/docs/reference/status.md)
@@ -36,8 +37,9 @@ and the [stub inventory](https://github.com/Willow7737/omnia-protocol/blob/main/
 Two different questions with two different answers, never mixed:
 **~12,000 ops/s** consensus hot path (single node, in-process, CI-gated),
 and on the **real network**, 10k-event bursts reach 100% propagation with
-full BFT finality on a 5-node mesh (median node convergence under a
-minute). Details and caveats: [Benchmarks](Benchmarks).
+full BFT finality — on a 5-node mesh (median convergence under a minute)
+and across a 3-region WAN with RTTs up to ~218 ms. Details and caveats:
+[Benchmarks](Benchmarks).
 
 ### Is it quantum-resistant?
 

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -24,6 +24,7 @@ ZK-rollup proofs.
 | What | Result |
 |---|---|
 | 10,000-event burst, 5-node validator mesh | **100% propagation + 10,000/10,000 BFT-finalized on every node — zero loss** |
+| 10,000-event burst, **3-region WAN** (EU/US/Asia, ≤218 ms RTT) | **100% propagation + full BFT finality on every node — zero loss** |
 | Consensus hot path (single node) | ~12,000 ops/s, ~25 µs finality p50 |
 | Burst self-healing | Anti-entropy repair recovers everything live gossip drops under overload |
 | Formal verification | TLA+ models (`OmniaTwoLane`, `OmniaConsensus`, `OmniaCRDT`) model-checked in CI on every PR |

--- a/worklog.md
+++ b/worklog.md
@@ -171,3 +171,10 @@ Stage Summary:
 - **Fix:** `max_transmit_size` → `MAX_SYNC_MESSAGE_BYTES` (2 MiB, matching the receive bound) via shared `build_gossipsub_config()`; sync publish failures escalated debug→warn + loud oversize guard; regression test pins transmit ≥ receive bound.
 - **Result (same day, verified binary):** 10k burst → **100% propagation + `finalized_total = 10,000` on every node.** Zero loss; the ~4,600-event tail self-healed entirely via anti-entropy. Honest caveat: tail repair took ~580 s (~one byte-budgeted batch per 10 s digest interval); tuning levers documented in benchmark-gates.md (chain `has_more` requests, shorter repair-active sync interval, bigger byte budget) — none needed for correctness.
 - **Lesson recorded:** a silently-dropped oversized message defeated four correct fixes in a row. Publish failures on control-plane topics are now WARN-level; size caps are asserted against each other in tests.
+
+## 2026-07-20 — Geo-distributed WAN campaign: the asterisk is gone
+
+- Executed `docs/operations/geo-testnet.md` as written: 3 Hetzner CPX21 Lane 0 validators — Nuremberg (bootstrap/ingress/bench) + Ashburn + Singapore. Measured RTT matrix: A↔B 98.8 ms, A↔C 160.3 ms, B↔C 217.9 ms.
+- **All three ladder rungs converged at 100% propagation with full quorum finality, zero loss**: 1k in <8 s everywhere; 5k (A 12.4 s / B 91.9 s / C 273.1 s); 10k (A 29.4 s / B 289.1 s / C 37.6 s). `finalized_total` identical on all nodes after every rung (cumulative counters — every submitted event finalized).
+- The straggler alternates with path geometry (C on 5k, B on 10k) — whichever node ends up chasing the tail over the 218 ms B↔C path pays repair-chain round-trips at real RTT. Matches the contention model from the 07-19 arc; the documented next lever is directed (unicast) repair serving. Peak RSS 145 MB — CPX21 has multiples of headroom.
+- Every status-bearing doc updated same day: benchmark-gates (new WAN section + superseding verified-capacity statement), status.md (REQ-P4.5 → Completed), README milestones, and the wiki (Home/Benchmarks/FAQ no longer say "geo pending").


### PR DESCRIPTION

2026-07-20: three Hetzner CPX21 Lane 0 validators across Nuremberg /
Ashburn / Singapore (measured RTTs 98.8 / 160.3 / 217.9 ms) ran the full
benchmark ladder from docs/operations/geo-testnet.md. ALL rungs: 100%
propagation + full quorum finality on every node, zero loss.

- 1k/16: converged everywhere in < 8 s (steady-state gossip at WAN RTT
  is barely distinguishable from single-host).
- 5k/64: A 12.4 s / B 91.9 s / C 273.1 s.
- 10k/64: A 29.4 s / B 289.1 s / C 37.6 s.
- finalized_total identical on all nodes after every rung (cumulative
  counters; every submitted event finalized).
- Straggler alternates with path geometry (C on 5k, B on 10k) —
  the tail-chasing node pays repair-chain round-trips over the worst
  path (B<->C ~218 ms); matches the 07-19 contention model. Known
  lever: directed (unicast) repair serving. Peak RSS 145 MB.

Updates:
- benchmark-gates.md: new "Geo-Distributed WAN Results" section with
  topology, RTT matrix, per-rung table, reading, and a superseding
  verified-capacity statement; clock-skew methodology note.
- status.md: 07-20 note; REQ-P4.5 Public Testnet Launch -> Completed.
- README.md: "Proven on the real internet" milestone bullet.
- wiki (Home/Benchmarks/FAQ): WAN row + no longer says "geo pending"
  (auto-publishes via wiki-sync).
- worklog.md: campaign entry.

