### PR TITLE
fix(shards): persist nonce before acknowledging it in memory (C8, #346)


### DIFF
--- a/shards/src/router.rs
+++ b/shards/src/router.rs
@@ -419,13 +419,24 @@ impl ShardRouter {
 
         // Only persist nonce and insert into in-memory map if operation succeeded
         if result.is_ok() {
-            self.last_nonces.insert(creator, payload.nonce);
-            // NEW-M7 fix: on save_incremental failure, halt the node instead
-            // of logging a warning. The previous code silently diverged — the
-            // in-memory nonce map had the new nonce but the persistent store
-            // didn't. On restart, the stale persisted nonce allowed replay of
-            // all post-failure events. Now we fail-closed: the node halts so
-            // the operator can fix the disk issue before more events are
+            // AUDIT-2026-07 C8 (#346): persist FIRST, acknowledge in memory
+            // only after persistence succeeds. The previous order inserted
+            // into `last_nonces` and then persisted — on save failure the
+            // node halted (NEW-M7 fail-closed), but memory had acknowledged
+            // a nonce that disk never recorded, so the memory/disk states
+            // straddling the halt disagreed. With persist-first, at every
+            // instant the durable store is at least as advanced as the
+            // in-memory map, so a restart can never resurrect a nonce
+            // acknowledgment that was not durable.
+            //
+            // Remaining (documented) gap: the shard-state mutation above
+            // still precedes nonce durability; closing that fully requires
+            // one transaction covering shard-state snapshot + nonce
+            // (tracked in #346).
+            //
+            // NEW-M7 fix retained: on save_incremental failure, halt the
+            // node instead of logging a warning — fail-closed, so the
+            // operator fixes the disk issue before more events are
             // processed.
             if let Err(e) = self.nonce_store.save_incremental(&creator, payload.nonce) {
                 tracing::error!(
@@ -445,6 +456,7 @@ impl ShardRouter {
                     e
                 );
             }
+            self.last_nonces.insert(creator, payload.nonce);
         }
 
         result
@@ -631,5 +643,17 @@ impl omnia_substrate::EventProcessor for MutexShardRouter {
             .lock()
             .map_err(|e| omnia_substrate::EventProcessorError::Internal(format!("ShardRouter mutex poisoned: {e}")))?;
         guard.process_event(event)
+    }
+}
+
+impl ShardRouter {
+    /// Read the in-memory acknowledged nonce for a creator.
+    ///
+    /// Hidden from docs: exists for the C8 (#346) persist-ordering
+    /// regression tests, which must observe that a failed nonce persist
+    /// never acknowledges in memory. Read-only; not a public API.
+    #[doc(hidden)]
+    pub fn last_acknowledged_nonce(&self, creator: &[u8; 32]) -> Option<u64> {
+        self.last_nonces.get(creator).copied()
     }
 }

--- a/shards/tests/replay_protection.rs
+++ b/shards/tests/replay_protection.rs
@@ -211,3 +211,62 @@ fn test_nonce_persistence_across_router_restart() {
         );
     }
 }
+
+// ---------------------------------------------------------------------------
+// AUDIT-2026-07 C8 (#346): persist-before-acknowledge ordering
+// ---------------------------------------------------------------------------
+
+/// A nonce store whose incremental save always fails — simulating a disk
+/// fault at the persistence boundary.
+struct FailingNonceStore;
+
+impl NonceStore for FailingNonceStore {
+    fn load(&self) -> Result<std::collections::HashMap<[u8; 32], u64>, omnia_shards::NonceStoreError> {
+        Ok(std::collections::HashMap::new())
+    }
+    fn save(&self, _: &std::collections::HashMap<[u8; 32], u64>) -> Result<(), omnia_shards::NonceStoreError> {
+        Err(omnia_shards::NonceStoreError::Redb("simulated disk fault".into()))
+    }
+    fn save_incremental(&self, _: &[u8; 32], _: u64) -> Result<(), omnia_shards::NonceStoreError> {
+        Err(omnia_shards::NonceStoreError::Redb("simulated disk fault".into()))
+    }
+}
+
+/// When nonce persistence fails, the node halts (fail-closed, NEW-M7) —
+/// and the in-memory map must NOT have acknowledged the nonce first.
+/// The pre-fix order inserted into memory before persisting, so the
+/// process that panicked had already acknowledged a nonce that disk
+/// never recorded.
+#[test]
+fn test_failed_nonce_persist_never_acknowledges_in_memory() {
+    use omnia_shards::FeeSchedule;
+    use std::panic::{catch_unwind, AssertUnwindSafe};
+
+    let mut router = ShardRouter::with_nonce_store(
+        FeeSchedule::zero(),
+        omnia_economics::QuotaSystem::default_system(),
+        Arc::new(FailingNonceStore),
+    );
+    router.register(Box::new(FinancialShard::new()));
+
+    let keypair = generate_keypair();
+    let creator = keypair.verifying_key().to_bytes();
+
+    let payload = ShardPayload {
+        shard_id: ShardId::financial(),
+        operation: ShardOp::Financial(FinancialOp::BalanceQuery { account: creator }),
+        nonce: 1,
+    };
+    let event = create_test_event_with_keypair(test_node(1), payload.to_bytes().unwrap(), &keypair);
+
+    // The route must panic (fail-closed on persistence failure)…
+    let outcome = catch_unwind(AssertUnwindSafe(|| router.route_event(&event)));
+    assert!(outcome.is_err(), "persistence failure must halt (fail-closed)");
+
+    // …and memory must NOT have acknowledged the nonce before the halt.
+    assert_eq!(
+        router.last_acknowledged_nonce(&creator),
+        None,
+        "in-memory nonce must not be acknowledged when persistence failed"
+    );
+}


### PR DESCRIPTION

AUDIT-2026-07 C8: process_event updated the in-memory last_nonces map
before save_incremental ran, so a persistence failure left memory
acknowledging a nonce that disk never recorded. The NEW-M7 fail-closed
panic halts the node on that failure, but the states straddling the
halt disagreed.

Reorder so save_incremental runs first and last_nonces.insert only
happens after persistence succeeds — the durable store is now always
at least as advanced as the in-memory map, so a restart can never
resurrect an acknowledgment that was not durable. The NEW-M7 panic is
retained unchanged.

Documented residual gap (kept open in #346): the shard-state mutation
still precedes nonce durability; closing it fully requires one
transaction covering shard-state snapshot + nonce.

Regression test: FailingNonceStore simulates a disk fault; the test
asserts the node panics AND the in-memory nonce stays unacknowledged.
Red-checked — the test fails on the old ordering.

