### PR TITLE
fix(adapters): ZK rollup proves non-empty batches; real settlement ABI (AUDIT-2026-07 C3)

### DIFF
--- a/omnia-adapters/contracts/ethereum/OmniaRollup.sol
+++ b/omnia-adapters/contracts/ethereum/OmniaRollup.sol
@@ -167,6 +167,11 @@ contract OmniaRollup {
     // -----------------------------------------------------------------------
 
     event StateUpdated(bytes32 indexed oldRoot, bytes32 indexed newRoot, uint256 batchIndex);
+    /// @notice Binds the keccak hash of the posted batch calldata to the
+    ///         SNARK-proven Poseidon event commitment for the same batch,
+    ///         so off-chain verifiers can associate data availability with
+    ///         the proof (AUDIT-2026-07 C3, #341).
+    event BatchDataBound(bytes32 indexed dataHash, bytes32 indexed eventCommitment, uint256 batchIndex);
     event Deposited(address indexed sender, bytes32 indexed l2Did, uint256 amount);
     event WithdrawalRequested(address indexed recipient, bytes32 indexed l2Did, uint256 amount);
     event WithdrawalFinalized(address indexed recipient, uint256 amount);
@@ -247,9 +252,18 @@ contract OmniaRollup {
             require(uint256(stateRoot) == _publicInputs[0], "Old root mismatch");
             // Bind: new state root must match the proposed root
             require(uint256(_newStateRoot) == _publicInputs[1], "New root mismatch");
-            // Bind batch data to event commitment
-            bytes32 dataCommitment = keccak256(_batchData);
-            require(uint256(dataCommitment) == _publicInputs[2], "Batch data commitment mismatch");
+            // AUDIT-2026-07 C3 (#341): _publicInputs[2] is the POSEIDON
+            // Merkle event commitment, and it is already bound by the SNARK
+            // verification below — the previous check here required
+            // keccak256(_batchData) == _publicInputs[2], equating a keccak
+            // hash with a Poseidon root. Finding such a preimage is
+            // infeasible, so every 3-input submission reverted and the
+            // settlement path was non-functional. The contract cannot
+            // recompute Poseidon affordably on-chain; instead, data
+            // availability is bound by emitting the keccak of the posted
+            // calldata alongside the proven event commitment (see
+            // BatchDataBound below) so off-chain verifiers can associate
+            // the two.
         } else if (_publicInputs.length == 1) {
             // RollupCircuit: single public input is the new state root.
             // Contract still binds old root against its own state.
@@ -264,6 +278,9 @@ contract OmniaRollup {
         require(verifyProof(_proofA, _proofB, _proofC, _publicInputs), "Invalid proof");
         bytes32 oldRoot = stateRoot;
         stateRoot = _newStateRoot;
+        if (_publicInputs.length >= 3) {
+            emit BatchDataBound(keccak256(_batchData), bytes32(_publicInputs[2]), batchIndex);
+        }
         emit StateUpdated(oldRoot, _newStateRoot, batchIndex++);
     }
 

--- a/omnia-adapters/src/operator.rs
+++ b/omnia-adapters/src/operator.rs
@@ -6,10 +6,15 @@
 //! it works with any [`SettlementLayer`] implementor.
 
 use crate::circuit::ExpandedRollupCircuit;
+use crate::merkle::{build_poseidon_merkle_tree, fr_to_hash, hash_to_fr};
+use crate::poseidon::poseidon_hash_offchain;
 use crate::prover::{self, ProverError, ProvingKey, VerifyingKey};
 use crate::settlement::{SettlementError, SettlementLayer};
+use ark_bn254::Fr;
+use ark_ff::Zero;
 use omnia_consensus::CausalGraph;
 use omnia_primitives::Event;
+use std::collections::HashMap;
 use std::sync::Arc;
 use thiserror::Error;
 use tokio::sync::RwLock;
@@ -28,11 +33,33 @@ pub enum RollupError {
     Prover(#[from] ProverError),
 }
 
-/// Cached Groth16 trusted setup keys.
+/// The output of proving one batch: the serialized Groth16 proof plus
+/// the public values it binds (AUDIT-2026-07 C3, #341).
+pub struct ProvenBatch {
+    /// Serialized Groth16 proof.
+    pub proof_bytes: Vec<u8>,
+    /// ZK state root before the batch (32 big-endian bytes).
+    pub zk_old_root: [u8; 32],
+    /// ZK state root after the batch (32 big-endian bytes).
+    pub zk_new_root: [u8; 32],
+    /// ZK state root after the batch, as a field element.
+    pub zk_new_root_fr: Fr,
+    /// Poseidon Merkle event commitment (32 bytes).
+    pub event_commitment: [u8; 32],
+}
+
+/// Cached Groth16 trusted setup keys for one circuit shape.
 struct TrustedSetupCache {
     proving_key: ProvingKey,
     verifying_key: VerifyingKey,
 }
+
+/// Circuit shape: (number of events, Merkle proof depth). The trusted
+/// setup is shape-specific — a key generated for one shape cannot prove
+/// a circuit of another shape (AUDIT-2026-07 C3, #341: the old code
+/// cached a single setup for `event_count.max(1)` and reused it for
+/// every batch size).
+type CircuitShape = (usize, usize);
 
 /// L2 batch operator. Collects finalized events, builds batches,
 /// generates Groth16 proofs, and posts to the configured settlement layer.
@@ -45,8 +72,20 @@ pub struct RollupOperator {
     settlement: Box<dyn SettlementLayer>,
     batch_size: usize,
     last_batched_index: usize,
-    /// Cached trusted setup keys, initialized on first use.
-    setup_cache: Option<TrustedSetupCache>,
+    /// Cached trusted setup keys, one per circuit shape.
+    setup_cache: HashMap<CircuitShape, TrustedSetupCache>,
+    /// The rollup's ZK state root: a Poseidon fold-chain over event
+    /// hashes, matching the circuit's state-transition constraint
+    /// `root[i+1] = Poseidon(root[i], event_hash[i])` (AUDIT-2026-07 C3,
+    /// #341). Starts at `Fr::zero()` — the rollup genesis root, which
+    /// must equal the L1 contract's `_initialStateRoot`. This is the
+    /// root the settlement layer tracks; the causal graph's BLAKE3
+    /// state root is a different (unprovable) construction and is used
+    /// for logging only.
+    zk_state_root: Fr,
+    /// Shape of the last generated proof (events, depth) — exposed so
+    /// callers can locate the matching verifying key.
+    last_proof_shape: Option<CircuitShape>,
 }
 
 impl RollupOperator {
@@ -62,8 +101,16 @@ impl RollupOperator {
             settlement,
             batch_size,
             last_batched_index: 0,
-            setup_cache: None,
+            setup_cache: HashMap::new(),
+            zk_state_root: Fr::zero(),
+            last_proof_shape: None,
         }
+    }
+
+    /// The current ZK state root as 32 big-endian bytes (the value the
+    /// L1 contract tracks).
+    pub fn zk_state_root_bytes(&self) -> [u8; 32] {
+        fr_to_hash(&self.zk_state_root)
     }
 
     /// Run one batch cycle: collect → build → prove → post.
@@ -75,36 +122,42 @@ impl RollupOperator {
             return Ok(());
         }
 
-        // 2. Compute old_root and apply events within the same write lock
-        //    to prevent TOCTOU race condition (old_root must be read while
-        //    holding the write lock to guarantee atomicity).
+        // 2. Apply events to the causal graph (its BLAKE3 state root is a
+        //    different construction from the provable ZK root — logged for
+        //    diagnostics only; see `zk_state_root`).
+        // Events collected by `collect_events` already live in the graph
+        // (they were read FROM it) — re-inserting them is a duplicate.
+        // The old code errored out here on every non-empty batch; it was
+        // masked because proof generation rejected non-empty batches
+        // first (AUDIT-2026-07 C3, #341). Insert only events the graph
+        // does not already contain.
         let mut graph = self.graph.write().await;
-        let old_root = graph.state_root();
-        // Apply events to compute new state root
         for event in &events {
-            graph
-                .insert(event.clone())
-                .map_err(|e| RollupError::Serialization(format!("Failed to insert event into causal graph: {e}")))?;
+            if graph.get(&event.id).is_none() {
+                graph.insert(event.clone()).map_err(|e| {
+                    RollupError::Serialization(format!("Failed to insert event into causal graph: {e}"))
+                })?;
+            }
         }
-        let new_root = graph.state_root();
         drop(graph);
-        if old_root == new_root {
-            tracing::warn!("operator: old_root == new_root after batch application — state may not have changed");
-        }
 
         // 3. Build batch data
         let batch_data = self.build_batch_data(&events)?;
 
-        // 5. Generate real Groth16 proof
-        let proof_bytes = self.generate_proof(&old_root, &new_root, events.len())?;
+        // 4. Generate a real Groth16 proof over the batch (AUDIT-2026-07
+        //    C3, #341): the circuit's public inputs are the Poseidon
+        //    fold-chain roots (zk_old, zk_new) and the Poseidon Merkle
+        //    event commitment — all computed from real witnesses.
+        let proven = self.generate_proof(&events)?;
 
         tracing::info!(
-            "[{}] Generated Groth16 proof: {} bytes",
+            "[{}] Generated Groth16 proof: {} bytes ({} events)",
             self.settlement.chain_id(),
-            proof_bytes.len()
+            proven.proof_bytes.len(),
+            events.len()
         );
 
-        // 6. Post to settlement layer
+        // 5. Post to settlement layer
         let tx_ref = self.settlement.post_batch(&batch_data).await?;
         tracing::info!(
             "[{}] Batch posted: {} events, tx: {}",
@@ -113,12 +166,18 @@ impl RollupOperator {
             &tx_ref[..tx_ref.len().min(16)]
         );
 
-        // 7. Verify proof on L1 (for monitoring)
-        let valid = self.settlement.verify_proof(&old_root, &new_root, &proof_bytes).await?;
+        // 6. Verify proof on L1 (for monitoring) against the ZK roots the
+        //    proof actually binds.
+        let valid = self
+            .settlement
+            .verify_proof(&proven.zk_old_root, &proven.zk_new_root, &proven.proof_bytes)
+            .await?;
         if !valid {
             tracing::warn!("[{}] Proof verification returned false", self.settlement.chain_id());
         }
 
+        // 7. Advance the rollup state only after the batch is posted.
+        self.zk_state_root = proven.zk_new_root_fr;
         self.last_batched_index += events.len();
         Ok(())
     }
@@ -146,95 +205,116 @@ impl RollupOperator {
         postcard::to_allocvec(events).map_err(|e| RollupError::Serialization(e.to_string()))
     }
 
-    /// Generate a Groth16 proof for a state transition.
+    /// Generate a Groth16 proof for a batch of events (AUDIT-2026-07 C3,
+    /// #341 — the pipeline can now prove NON-EMPTY batches).
     ///
-    /// Creates or retrieves the cached trusted setup, builds the circuit,
-    /// creates the proof, and serializes it to bytes.
-    fn generate_proof(
-        &mut self,
-        _old_root: &[u8; 32],
-        _new_root: &[u8; 32],
-        event_count: usize,
-    ) -> Result<Vec<u8>, RollupError> {
-        // Initialize trusted setup on first use.
-        // Use ExpandedRollupCircuit for the setup since it provides stronger
-        // security guarantees (Merkle path verification, state transition constraints).
-        let merkle_depth = 8; // Default Merkle tree depth for setup
-        if self.setup_cache.is_none() {
-            tracing::info!("Generating trusted setup for ExpandedRollupCircuit (first use)");
-            let (pk, vk) = prover::generate_trusted_setup_expanded(event_count.max(1), merkle_depth)?;
-            tracing::info!("Trusted setup complete");
-            self.setup_cache = Some(TrustedSetupCache {
+    /// Builds the full witness set the `ExpandedRollupCircuit` requires:
+    ///
+    /// - **event hashes**: `hash_to_fr(event.id)` for each event;
+    /// - **operation types**: a fixed in-range tag (0) — the circuit
+    ///   enforces the range and the payload binding; semantic per-shard
+    ///   operation tagging is tracked follow-up;
+    /// - **payload hashes**: `Poseidon(event_hash, op_type)`, the exact
+    ///   binding the circuit enforces;
+    /// - **event commitment + Merkle proofs**: from
+    ///   [`build_poseidon_merkle_tree`] over the event IDs (the same
+    ///   Poseidon the circuit verifies paths with);
+    /// - **intermediate roots**: the Poseidon fold chain
+    ///   `root[i+1] = Poseidon(root[i], event_hash[i])` starting from the
+    ///   operator's current `zk_state_root`.
+    ///
+    /// The trusted setup is cached **per circuit shape** (events, depth):
+    /// a Groth16 key proves exactly one constraint-system shape.
+    fn generate_proof(&mut self, events: &[Event]) -> Result<ProvenBatch, RollupError> {
+        let zk_err = |e: crate::poseidon::ZkError| RollupError::Prover(ProverError::CircuitError(e.to_string()));
+
+        // Witnesses: event hashes and payload bindings.
+        let event_hashes: Vec<Fr> = events.iter().map(|e| hash_to_fr(&e.id)).collect();
+        let operation_types: Vec<Fr> = events.iter().map(|_| Fr::zero()).collect();
+        let payload_hashes: Vec<Fr> = event_hashes
+            .iter()
+            .map(|h| poseidon_hash_offchain(*h, Fr::zero()).map_err(zk_err))
+            .collect::<Result<_, _>>()?;
+
+        // Event commitment: Poseidon Merkle tree over event IDs.
+        let ids: Vec<[u8; 32]> = events.iter().map(|e| e.id).collect();
+        let (commitment_bytes, merkle_proofs) = build_poseidon_merkle_tree(&ids)
+            .map_err(|e| RollupError::Prover(ProverError::CircuitError(e.to_string())))?;
+        let event_commitment = hash_to_fr(&commitment_bytes);
+
+        // Intermediate roots: the Poseidon fold chain from the current
+        // rollup state root.
+        let mut intermediate_roots = Vec::with_capacity(events.len() + 1);
+        intermediate_roots.push(self.zk_state_root);
+        for h in &event_hashes {
+            let prev = *intermediate_roots
+                .last()
+                .ok_or_else(|| RollupError::Prover(ProverError::CircuitError("empty fold chain".into())))?;
+            intermediate_roots.push(poseidon_hash_offchain(prev, *h).map_err(zk_err)?);
+        }
+        let zk_old_root_fr = self.zk_state_root;
+        let zk_new_root_fr = *intermediate_roots
+            .last()
+            .ok_or_else(|| RollupError::Prover(ProverError::CircuitError("empty fold chain".into())))?;
+
+        // Trusted setup for this exact circuit shape.
+        let merkle_depth = merkle_proofs.first().map(|p| p.siblings.len()).unwrap_or(0);
+        let shape: CircuitShape = (events.len(), merkle_depth);
+        if let std::collections::hash_map::Entry::Vacant(entry) = self.setup_cache.entry(shape) {
+            tracing::info!(
+                events = shape.0,
+                depth = shape.1,
+                "Generating trusted setup for ExpandedRollupCircuit shape"
+            );
+            let (pk, vk) = prover::generate_trusted_setup_expanded(shape.0, shape.1)?;
+            entry.insert(TrustedSetupCache {
                 proving_key: pk,
                 verifying_key: vk,
             });
         }
 
-        // Build ExpandedRollupCircuit from actual state roots.
-        //
-        // P0-3 fix: from_state_roots() uses placeholder zero witnesses for
-        // all per-event constraints (Merkle paths, state transitions, etc.).
-        // For event_count > 0, the circuit is UNSATISFIABLE — proof creation
-        // will fail. We guard against this here and return a clear error
-        // instead of producing a proof that can never succeed.
-        //
-        // TODO: Wire ExpandedRollupCircuit::from_batch() with real Merkle
-        // proofs (from build_poseidon_merkle_tree) and intermediate state
-        // roots. This requires the operator to track per-event witness data
-        // during batch accumulation. See circuit.rs:589-687 for the
-        // constructor and circuit.rs:420-496 for from_batch().
-        if event_count > 0 {
-            tracing::error!(
-                event_count = event_count,
-                "ZK rollup: non-empty batch proof not yet implemented — \
-                 ExpandedRollupCircuit::from_state_roots uses placeholder \
-                 zero witnesses that make the circuit unsatisfiable. \
-                 Wire ExpandedRollupCircuit::from_batch with real witness data."
-            );
-            return Err(RollupError::Prover(ProverError::CircuitError(
-                "Non-empty batch proof not yet implemented — witness data is \
-                 placeholder zeros. Use ExpandedRollupCircuit::from_batch with \
-                 real Merkle proofs and intermediate state roots."
-                    .to_string(),
-            )));
-        }
-
-        let circuit = ExpandedRollupCircuit::from_state_roots(
-            *_old_root,
-            *_new_root,
-            event_count as u64,
-            *_old_root, // expected_old = old (verifier independently knows this)
-            *_new_root, // expected_new = new (verifier checks this matches on-chain)
+        let circuit = ExpandedRollupCircuit::from_batch(
+            zk_old_root_fr,
+            zk_new_root_fr,
+            event_hashes,
+            operation_types,
+            payload_hashes,
+            event_commitment,
+            merkle_proofs,
+            intermediate_roots,
         );
         let pub_input = circuit
             .public_input()
             .map_err(|e| RollupError::Prover(ProverError::CircuitError(e.to_string())))?;
 
-        // SAFETY: setup_cache is guaranteed Some by the initialization block above.
-        // Using ok_or_else avoids unwrap/expect while the error path is unreachable.
-        let cache = self.setup_cache.as_ref().ok_or_else(|| {
+        let cache = self.setup_cache.get(&shape).ok_or_else(|| {
             RollupError::Prover(ProverError::SetupFailed(
                 "trusted setup cache not initialized (logic error)".into(),
             ))
         })?;
 
-        // Create proof
-        tracing::debug!("Creating Groth16 proof for {} events", event_count);
+        tracing::debug!("Creating Groth16 proof for {} events", events.len());
         let proof_obj = prover::create_expanded_proof(circuit, &cache.proving_key)?;
-
-        // Serialize proof to bytes
         let proof_bytes = prover::serialize_proof(&proof_obj)?;
 
-        // Self-verify for sanity check
+        // Self-verify before posting anything: a proof that fails here
+        // must never advance state or reach the settlement layer.
         let valid = prover::verify_proof(&cache.verifying_key, &pub_input, &proof_obj)?;
-
-        if valid {
-            tracing::info!("Self-verification of proof succeeded");
-        } else {
-            tracing::warn!("Self-verification of proof FAILED");
+        if !valid {
+            return Err(RollupError::Prover(ProverError::CircuitError(
+                "self-verification of generated proof failed".into(),
+            )));
         }
+        tracing::info!("Self-verification of proof succeeded");
+        self.last_proof_shape = Some(shape);
 
-        Ok(proof_bytes)
+        Ok(ProvenBatch {
+            proof_bytes,
+            zk_old_root: fr_to_hash(&zk_old_root_fr),
+            zk_new_root: fr_to_hash(&zk_new_root_fr),
+            zk_new_root_fr,
+            event_commitment: commitment_bytes,
+        })
     }
 
     /// Get the chain ID of the current settlement adapter.
@@ -247,10 +327,10 @@ impl RollupOperator {
         self.last_batched_index
     }
 
-    /// Get a reference to the cached verifying key, if available.
-    ///
-    /// Returns `None` if the trusted setup has not been performed yet.
+    /// Get a reference to the verifying key for the most recent proof's
+    /// circuit shape, if a proof has been generated.
     pub fn verifying_key(&self) -> Option<&VerifyingKey> {
-        self.setup_cache.as_ref().map(|c| &c.verifying_key)
+        let shape = self.last_proof_shape?;
+        self.setup_cache.get(&shape).map(|c| &c.verifying_key)
     }
 }

--- a/omnia-adapters/src/prover.rs
+++ b/omnia-adapters/src/prover.rs
@@ -182,6 +182,39 @@ pub fn verify_proof(vk: &VerifyingKey, public_inputs: &[ark_bn254::Fr], proof: &
     Groth16::<Bn254>::verify(vk, public_inputs, proof).map_err(|e| ProverError::VerificationFailed(e.to_string()))
 }
 
+/// Convert an arkworks Groth16 proof into the EVM calldata layout used by
+/// `OmniaRollup.submitBatch` (AUDIT-2026-07 C3, #341).
+///
+/// Field elements are 32-byte big-endian words. The G2 point follows the
+/// contract's documented layout `[[x.c0, x.c1], [y.c0, y.c1]]`
+/// (c0 = real part), matching arkworks' `Fq2` representation.
+pub fn proof_to_evm(proof: &Proof) -> crate::settlement::EvmProof {
+    use ark_ff::{BigInteger, PrimeField};
+
+    fn fq_to_word(fq: &ark_bn254::Fq) -> [u8; 32] {
+        let bytes = fq.into_bigint().to_bytes_be();
+        let mut word = [0u8; 32];
+        let len = bytes.len().min(32);
+        word[32 - len..].copy_from_slice(&bytes[..len]);
+        word
+    }
+
+    crate::settlement::EvmProof {
+        a: [fq_to_word(&proof.a.x), fq_to_word(&proof.a.y)],
+        b: [
+            [fq_to_word(&proof.b.x.c0), fq_to_word(&proof.b.x.c1)],
+            [fq_to_word(&proof.b.y.c0), fq_to_word(&proof.b.y.c1)],
+        ],
+        c: [fq_to_word(&proof.c.x), fq_to_word(&proof.c.y)],
+    }
+}
+
+/// Convert circuit public inputs (`Fr` elements) into 32-byte big-endian
+/// EVM words for `submitBatch`'s `uint256[] publicInputs`.
+pub fn public_inputs_to_evm(inputs: &[ark_bn254::Fr]) -> Vec<[u8; 32]> {
+    inputs.iter().map(crate::merkle::fr_to_hash).collect()
+}
+
 /// Serialize a Groth16 proof to bytes.
 ///
 /// Uses canonical serialization from `ark_serialize`.

--- a/omnia-adapters/src/settlement/ethereum/live.rs
+++ b/omnia-adapters/src/settlement/ethereum/live.rs
@@ -12,7 +12,7 @@
 
 use crate::merkle::MerkleProof;
 use crate::settlement::ethereum::EthereumConfig;
-use crate::settlement::{FinalityProof, SettlementAdapter, SettlementError, TxHash};
+use crate::settlement::{EvmProof, FinalityProof, SettlementAdapter, SettlementError, TxHash};
 use tokio::sync::OnceCell;
 
 // ---------------------------------------------------------------------------
@@ -20,7 +20,7 @@ use tokio::sync::OnceCell;
 // ---------------------------------------------------------------------------
 
 #[cfg(feature = "ethereum-live")]
-use alloy::primitives::{Address, B256};
+use alloy::primitives::{Address, Bytes, B256, U256};
 #[cfg(feature = "ethereum-live")]
 use alloy::providers::{Provider, ProviderBuilder};
 #[cfg(feature = "ethereum-live")]
@@ -37,9 +37,14 @@ alloy::sol! {
     r#"[
         {
             "type": "function",
-            "name": "submitRoot",
+            "name": "submitBatch",
             "inputs": [
-                {"name": "newStateRoot", "type": "bytes32"}
+                {"name": "_newStateRoot", "type": "bytes32"},
+                {"name": "_proofA", "type": "uint256[2]"},
+                {"name": "_proofB", "type": "uint256[2][2]"},
+                {"name": "_proofC", "type": "uint256[2]"},
+                {"name": "_publicInputs", "type": "uint256[]"},
+                {"name": "_batchData", "type": "bytes"}
             ],
             "outputs": [],
             "stateMutability": "nonpayable"
@@ -64,6 +69,16 @@ alloy::sol! {
             "inputs": [
                 {"name": "oldRoot", "type": "bytes32", "indexed": true},
                 {"name": "newRoot", "type": "bytes32", "indexed": true},
+                {"name": "batchIndex", "type": "uint256", "indexed": false}
+            ],
+            "anonymous": false
+        },
+        {
+            "type": "event",
+            "name": "BatchDataBound",
+            "inputs": [
+                {"name": "dataHash", "type": "bytes32", "indexed": true},
+                {"name": "eventCommitment", "type": "bytes32", "indexed": true},
                 {"name": "batchIndex", "type": "uint256", "indexed": false}
             ],
             "anonymous": false
@@ -149,23 +164,58 @@ impl EthereumSettlementAdapter {
 #[async_trait::async_trait]
 impl SettlementAdapter for EthereumSettlementAdapter {
     async fn submit_root(&self, root: [u8; 32]) -> Result<TxHash, SettlementError> {
+        // AUDIT-2026-07 C3 (#341): the previous implementation called a
+        // `submitRoot(bytes32)` function that DOES NOT EXIST on the
+        // OmniaRollup contract (its ABI was hand-written and wrong), so
+        // every live submission failed. The contract's only state-advancing
+        // entry point is `submitBatch`, which requires a Groth16 proof —
+        // use `submit_batch_with_proof`. This method now fails closed
+        // instead of encoding a call to a nonexistent function.
+        let _ = root;
+        Err(SettlementError::ContractError(
+            "OmniaRollup has no submitRoot function — submit proofs via submit_batch_with_proof              (AUDIT-2026-07 C3, #341)"
+                .to_string(),
+        ))
+    }
+
+    async fn submit_batch_with_proof(
+        &self,
+        new_root: [u8; 32],
+        proof: &EvmProof,
+        public_inputs: &[[u8; 32]],
+        batch_data: &[u8],
+    ) -> Result<TxHash, SettlementError> {
         let provider = self.build_provider().await?;
         let contract = OmniaRollup::new(self.contract_address, provider);
 
-        let new_state_root = B256::from(root);
+        let word = |w: &[u8; 32]| U256::from_be_bytes(*w);
+        let proof_a = [word(&proof.a[0]), word(&proof.a[1])];
+        let proof_b = [
+            [word(&proof.b[0][0]), word(&proof.b[0][1])],
+            [word(&proof.b[1][0]), word(&proof.b[1][1])],
+        ];
+        let proof_c = [word(&proof.c[0]), word(&proof.c[1])];
+        let inputs: Vec<U256> = public_inputs.iter().map(word).collect();
 
-        let builder = contract.submitRoot(new_state_root);
-        let builder = builder.gas(self.config.gas_limit);
+        let builder = contract
+            .submitBatch(
+                B256::from(new_root),
+                proof_a,
+                proof_b,
+                proof_c,
+                inputs,
+                Bytes::copy_from_slice(batch_data),
+            )
+            .gas(self.config.gas_limit);
 
         let pending_tx = builder
             .send()
             .await
-            .map_err(|e| SettlementError::TxFailed(format!("submitRoot send failed: {e}")))?;
+            .map_err(|e| SettlementError::TxFailed(format!("submitBatch send failed: {e}")))?;
 
         let tx_hash = *pending_tx.tx_hash();
         let hash_bytes: [u8; 32] = tx_hash.into();
 
-        // Wait for confirmations
         let receipt = pending_tx
             .with_required_confirmations(self.config.confirmation_blocks)
             .get_receipt()
@@ -176,7 +226,7 @@ impl SettlementAdapter for EthereumSettlementAdapter {
             Ok(TxHash(hash_bytes))
         } else {
             Err(SettlementError::TxFailed(format!(
-                "submitRoot transaction reverted: 0x{}",
+                "submitBatch transaction reverted: 0x{}",
                 hex::encode(hash_bytes)
             )))
         }

--- a/omnia-adapters/src/settlement/mod.rs
+++ b/omnia-adapters/src/settlement/mod.rs
@@ -62,6 +62,26 @@ pub use ethereum::EthereumSettlementAdapter;
 // SettlementAdapter trait (hybrid architecture core)
 // ---------------------------------------------------------------------------
 
+/// A Groth16 proof in EVM calldata layout (AUDIT-2026-07 C3, #341):
+/// 32-byte big-endian words matching `OmniaRollup.submitBatch`'s
+/// `uint256[2] a`, `uint256[2][2] b`, `uint256[2] c` parameters. The G2
+/// component layout is `[[x.c0, x.c1], [y.c0, y.c1]]` (c0 = real part),
+/// as documented on the contract.
+///
+/// Feature-neutral by design (plain bytes, no arkworks types) so the
+/// settlement trait can carry it regardless of which prover features are
+/// enabled. Produced by `prover::proof_to_evm` under the `arkworks`
+/// feature.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EvmProof {
+    /// G1 point A: [x, y].
+    pub a: [[u8; 32]; 2],
+    /// G2 point B: [[x.c0, x.c1], [y.c0, y.c1]].
+    pub b: [[[u8; 32]; 2]; 2],
+    /// G1 point C: [x, y].
+    pub c: [[u8; 32]; 2],
+}
+
 /// A pluggable settlement adapter for the hybrid architecture.
 ///
 /// This is the core trait that the Omnia Protocol depends on for
@@ -99,6 +119,28 @@ pub trait SettlementAdapter: Send + Sync {
     ///
     /// Returns a transaction hash identifying the submission.
     async fn submit_root(&self, root: [u8; 32]) -> Result<TxHash, SettlementError>;
+
+    /// Submit a batch with its Groth16 proof and public inputs
+    /// (AUDIT-2026-07 C3, #341) — the real settlement path for contracts
+    /// that verify proofs on-chain (`OmniaRollup.submitBatch`).
+    ///
+    /// `public_inputs` are 32-byte big-endian words; for the
+    /// `ExpandedRollupCircuit` they are
+    /// `[old_state_root, new_state_root, event_commitment]`.
+    ///
+    /// The default implementation fails closed for adapters whose
+    /// settlement layer has no proof-verifying entry point.
+    async fn submit_batch_with_proof(
+        &self,
+        _new_root: [u8; 32],
+        _proof: &EvmProof,
+        _public_inputs: &[[u8; 32]],
+        _batch_data: &[u8],
+    ) -> Result<TxHash, SettlementError> {
+        Err(SettlementError::ContractError(
+            "this settlement adapter does not support proof-carrying batch submission".to_string(),
+        ))
+    }
 
     /// Fetch a finality proof for a previously submitted transaction.
     ///

--- a/omnia-adapters/tests/rollup_nonempty_batch.rs
+++ b/omnia-adapters/tests/rollup_nonempty_batch.rs
@@ -1,0 +1,155 @@
+//! AUDIT-2026-07 C3 (#341) regression tests: the ZK rollup pipeline must
+//! prove NON-EMPTY batches.
+//!
+//! Before the fix, `RollupOperator::generate_proof` returned `Err` for any
+//! batch with `event_count > 0` — `ExpandedRollupCircuit::from_state_roots`
+//! used placeholder zero witnesses, making the circuit unsatisfiable, so
+//! the entire L2 → L1 settlement path could only "prove" empty batches.
+//! These tests exercise the full collect → witness → prove → self-verify →
+//! post cycle with real events and real Groth16 proofs.
+//!
+//! Requires the `arkworks` feature (CI runs it in the feature matrix):
+//!     cargo test -p omnia-adapters --features arkworks --test rollup_nonempty_batch
+#![cfg(feature = "arkworks")]
+#![allow(clippy::unwrap_used)]
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use omnia_adapters::operator::RollupOperator;
+use omnia_adapters::proof_bundle::ProofBundle;
+use omnia_adapters::settlement::{SettlementError, SettlementLayer};
+use omnia_consensus::CausalGraph;
+use omnia_primitives::{Event, VectorClock};
+use tokio::sync::RwLock;
+
+/// A test settlement layer that accepts everything and records calls.
+struct RecordingSettlement {
+    posted: AtomicUsize,
+    verified: AtomicUsize,
+}
+
+#[async_trait::async_trait]
+impl SettlementLayer for RecordingSettlement {
+    fn chain_id(&self) -> &'static str {
+        "test-recording"
+    }
+
+    async fn post_batch(&self, batch_data: &[u8]) -> Result<String, SettlementError> {
+        assert!(!batch_data.is_empty(), "batch data must not be empty");
+        self.posted.fetch_add(1, Ordering::SeqCst);
+        Ok(format!("tx-{}", self.posted.load(Ordering::SeqCst)))
+    }
+
+    async fn verify_proof(
+        &self,
+        old_root: &[u8; 32],
+        new_root: &[u8; 32],
+        proof: &[u8],
+    ) -> Result<bool, SettlementError> {
+        assert_ne!(old_root, new_root, "a non-empty batch must advance the ZK root");
+        assert!(!proof.is_empty(), "proof bytes must not be empty");
+        self.verified.fetch_add(1, Ordering::SeqCst);
+        Ok(true)
+    }
+
+    async fn latest_state_root(&self) -> Result<[u8; 32], SettlementError> {
+        Ok([0u8; 32])
+    }
+
+    async fn deposit(&self, _did: &str, _amount: u64) -> Result<String, SettlementError> {
+        Err(SettlementError::NotImplemented("test adapter".into()))
+    }
+
+    async fn request_withdrawal(&self, _did: &str, _amount: u64) -> Result<String, SettlementError> {
+        Err(SettlementError::NotImplemented("test adapter".into()))
+    }
+
+    async fn submit_batch(&self, _bundle: &ProofBundle) -> Result<String, SettlementError> {
+        Err(SettlementError::NotImplemented("test adapter".into()))
+    }
+}
+
+/// Build a graph pre-loaded with `n` chained events from one creator.
+fn graph_with_events(n: u64) -> Arc<RwLock<CausalGraph>> {
+    let creator = [7u8; 32];
+    let mut graph = CausalGraph::new();
+    let mut prev: Option<[u8; 32]> = None;
+    for seq in 0..n {
+        let mut vc = VectorClock::new();
+        for _ in 0..=seq {
+            vc.increment(creator).unwrap();
+        }
+        let event = Event::new(creator, seq, vc, prev, None, format!("payload-{seq}").into_bytes()).unwrap();
+        prev = Some(event.id);
+        graph.insert(event).unwrap();
+    }
+    Arc::new(RwLock::new(graph))
+}
+
+/// THE C3 regression: a batch of real events produces a real Groth16
+/// proof that self-verifies, is posted, and advances the ZK state root.
+/// On the old code this failed with "Non-empty batch proof not yet
+/// implemented".
+#[tokio::test]
+async fn nonempty_batch_proves_and_posts() {
+    let graph = graph_with_events(3);
+    let settlement = Box::new(RecordingSettlement {
+        posted: AtomicUsize::new(0),
+        verified: AtomicUsize::new(0),
+    });
+
+    let mut operator = RollupOperator::new(graph, settlement, 8);
+    let genesis_root = operator.zk_state_root_bytes();
+
+    operator.run_batch().await.expect("non-empty batch must prove and post");
+
+    assert_eq!(operator.last_batched_index(), 3, "all 3 events must be batched");
+    assert_ne!(
+        operator.zk_state_root_bytes(),
+        genesis_root,
+        "ZK state root must advance after a batch"
+    );
+    assert!(operator.verifying_key().is_some(), "setup must be cached for the shape");
+}
+
+/// Consecutive batches chain: batch 2 starts from batch 1's ZK root, and
+/// each advances the root (the fold chain is stateful across batches).
+#[tokio::test]
+async fn consecutive_batches_chain_the_zk_root() {
+    let graph = graph_with_events(4);
+    let settlement = Box::new(RecordingSettlement {
+        posted: AtomicUsize::new(0),
+        verified: AtomicUsize::new(0),
+    });
+
+    // batch_size 2 → two batches of two events.
+    let mut operator = RollupOperator::new(graph, settlement, 2);
+
+    operator.run_batch().await.expect("batch 1");
+    let root_after_1 = operator.zk_state_root_bytes();
+
+    operator.run_batch().await.expect("batch 2");
+    let root_after_2 = operator.zk_state_root_bytes();
+
+    assert_eq!(operator.last_batched_index(), 4);
+    assert_ne!(root_after_1, root_after_2, "each batch must advance the root");
+}
+
+/// Empty graph → run_batch is a clean no-op (no proof, no post, no root
+/// movement).
+#[tokio::test]
+async fn empty_batch_is_a_noop() {
+    let graph = Arc::new(RwLock::new(CausalGraph::new()));
+    let settlement = Box::new(RecordingSettlement {
+        posted: AtomicUsize::new(0),
+        verified: AtomicUsize::new(0),
+    });
+
+    let mut operator = RollupOperator::new(graph, settlement, 8);
+    let genesis_root = operator.zk_state_root_bytes();
+
+    operator.run_batch().await.expect("empty batch is a no-op");
+    assert_eq!(operator.last_batched_index(), 0);
+    assert_eq!(operator.zk_state_root_bytes(), genesis_root);
+}


### PR DESCRIPTION
## Summary

**AUDIT-2026-07 C3** (#341, mainnet blocker) — the L2 → L1 settlement pipeline was **completely non-functional**, from three compounding bugs, plus a fourth the new tests exposed:

1. `operator.rs` returned `Err` for **any** batch with `event_count > 0` — `from_state_roots` used placeholder zero witnesses, making the circuit unsatisfiable; only empty batches could be "proven".
2. `live.rs` declared an alloy ABI for `submitRoot(bytes32)` — **a function that doesn't exist** on `OmniaRollup`; every live submission failed at the ABI level.
3. `OmniaRollup.submitBatch` required `keccak256(batchData) == publicInputs[2]`, but that input is a **Poseidon** Merkle root — the preimage is infeasible, so every 3-input submission reverted.
4. *(found while testing)* `run_batch` re-inserted events it had just collected **from** the graph → `DuplicateEvent` on every non-empty batch (masked because bug 1 errored first).

## Changes

**Operator** (`operator.rs`) — real witness wiring via `ExpandedRollupCircuit::from_batch`:
- Event hashes (`hash_to_fr(event.id)`), payload bindings `Poseidon(event_hash, op_type)`, the Poseidon Merkle **event commitment** + per-event inclusion proofs (`build_poseidon_merkle_tree`), and the Poseidon **fold-chain** intermediate roots `root[i+1] = Poseidon(root[i], event_hash[i])`.
- The operator now tracks the rollup's **ZK state root** (genesis `Fr::zero`, matching the contract's initial root). The causal graph's BLAKE3 root is a different, unprovable construction — logged only, never fed to the proof path.
- Trusted setup cached **per circuit shape** `(events, depth)` — a Groth16 key proves exactly one constraint-system shape; the old single cache silently reused one key for every batch size.
- Failed self-verification is now a hard error (never post an invalid proof); state advances only after posting.

**Proof export** (`prover.rs`): `proof_to_evm` / `public_inputs_to_evm` — Groth16 proof in the contract's calldata layout (32-byte BE words; G2 as `[[x.c0,x.c1],[y.c0,y.c1]]` per the contract's documented convention).

**Settlement** (`settlement/mod.rs`, `live.rs`):
- Feature-neutral `EvmProof` + defaulted `submit_batch_with_proof` trait method (fails closed for adapters without on-chain verification).
- `live.rs` ABI **regenerated from the actual contract** (`submitBatch`, `stateRoot`, `batchIndex`, both events); `submit_batch_with_proof` wires proof points + public inputs + batch data; `submit_root` now fails closed with a clear error instead of encoding a call to a nonexistent function.

**Contract** (`OmniaRollup.sol`): removed the unsatisfiable keccak==Poseidon `require`. The event commitment is already bound by the SNARK verification itself; data availability is bound by the new `BatchDataBound(dataHash, eventCommitment, batchIndex)` event pairing the calldata keccak with the proven Poseidon commitment. (Contract redeployment required — flagged for the deployment checklist.)

## Testing

- **`nonempty_batch_proves_and_posts`** — 3 real events → real Groth16 proof, self-verified, posted, ZK root advances. On the old code this exact flow fails with "Non-empty batch proof not yet implemented" (the guard the audit flagged).
- **`consecutive_batches_chain_the_zk_root`** — the fold chain is stateful across batches.
- **`empty_batch_is_a_noop`**.
- Full `omnia-adapters` suite: 149 tests green (arkworks). `--all-features` check passes (includes the alloy live path). Both CI clippy gates, feature-enabled clippy, `cargo doc -D warnings`, `fmt` all clean.

## Remaining scope (stays on #341 or follow-up)

- Semantic per-shard operation tagging (op_type is a fixed in-range 0 today; the circuit enforces range + payload binding regardless).
- On-chain redeploy of the fixed contract + a live end-to-end run against a testnet RPC.