### PR TITLE
fix(shards): cross-shard messages require source-shard attestation (AUDIT-2026-07 C4)

### DIFF
--- a/shards/src/cross_shard.rs
+++ b/shards/src/cross_shard.rs
@@ -1,16 +1,48 @@
-//! Cross-shard messaging protocol
+//! Cross-shard messaging protocol.
 //!
-//! Cross-shard messages allow one shard to communicate with another through
-//! the causal graph. The key insight is that cross-shard messages leverage
-//! the same vector clock mechanism that the substrate uses for causal
-//! ordering — if Shard A sends a message to Shard B, the vector clock
-//! captures the dependency, ensuring that B processes the message only
-//! after A's state transition is causally confirmed.
+//! Cross-shard messages let one shard drive an operation on another. The
+//! causal graph's vector clocks order them; the **attestation** below is
+//! what *authorizes* them.
+//!
+//! # AUDIT-2026-07 C4 (#342): authentication is not authorization
+//!
+//! The previous design carried a `causal_proof` vector clock set by the
+//! message creator and a `source_signature` verified against
+//! `event.creator_pubkey` — **both attacker-controlled**. Any
+//! authenticated user could create an event carrying a cross-shard message
+//! claiming any source shard produced any operation, sign it with their own
+//! key, and the router accepted it: the signature checked out (it was the
+//! attacker's own key) and the causal proof was self-referential. Cross-
+//! shard messaging had authentication but no authorization.
+//!
+//! The fix: a cross-shard message must carry an **attestation** — a
+//! signature by the *source shard's registered validator-set key* over a
+//! commitment to the source shard's state transition
+//! (`source_shard, target_shard, source_event_id, source_state_root,
+//! payload, causal_proof`). The router verifies the attestation against the
+//! key registered for `source_shard` (see
+//! `ShardRouter::register_shard_attestation_key`), **not** against whoever
+//! created the carrying event. A user who does not hold the source shard's
+//! attestation key cannot forge a message from that shard.
+//!
+//! The registered key is a node-operator/genesis action, deliberately not
+//! reachable from consensus payloads — the same fail-closed registry
+//! pattern used for the ZK circuit registry (C9). In production the
+//! attestation key is the source shard's validator-set aggregate key (the
+//! threshold-BLS group key from C2); this module verifies an Ed25519
+//! attestation, which a single-signer or threshold-adapter validator set
+//! produces. A full IBC-style relay (per-shard validator DKG, state-root
+//! binding to committed source state, timeouts/acks) is tracked follow-up
+//! on #342; this closes the authorization hole that made messages
+//! forgeable.
 
 use omnia_substrate::VectorClock;
 use serde::{Deserialize, Serialize};
 
 use crate::shard::ShardId;
+
+/// Domain separator for the cross-shard attestation commitment.
+const ATTESTATION_DOMAIN: &[u8] = b"OMNIA-CROSS-SHARD-ATTESTATION-V1";
 
 /// A message sent from one shard to another through the causal graph.
 ///
@@ -26,48 +58,82 @@ pub struct CrossShardMessage {
     pub target_shard: ShardId,
     /// Serialized operation for the target shard to execute.
     pub payload: Vec<u8>,
+    /// The source shard's event that produced this operation. Binds the
+    /// attestation to a specific source-shard state transition so it
+    /// cannot be replayed for a different one.
+    #[serde(default)]
+    pub source_event_id: [u8; 32],
+    /// The source shard's state root after applying the originating
+    /// operation. Part of the attested commitment.
+    #[serde(default)]
+    pub source_state_root: [u8; 32],
     /// Vector clock proving the source operation happened before this message.
     pub causal_proof: VectorClock,
-    /// Optional cryptographic signature from the source shard's signing key.
-    /// When present, the router verifies this signature before processing
-    /// the cross-shard message. When None, the message is rejected in
-    /// production (accepted only in test builds for backward compat).
+    /// Attestation signature by the source shard's registered validator-set
+    /// key over [`attestation_commitment`](Self::attestation_commitment).
+    /// The router rejects the message if this is absent or does not verify
+    /// against the key registered for `source_shard`.
     #[serde(default)]
     pub source_signature: Option<Vec<u8>>,
 }
 
 impl CrossShardMessage {
-    /// Create a new cross-shard message.
-    pub fn new(source_shard: ShardId, target_shard: ShardId, payload: Vec<u8>, causal_proof: VectorClock) -> Self {
+    /// Create a new, unattested cross-shard message.
+    ///
+    /// Production callers must then call [`attest`](Self::attest) with the
+    /// source shard's validator-set keypair before sending; the receiving
+    /// router rejects any message whose attestation is missing or does not
+    /// verify against the registered source-shard key.
+    pub fn new(
+        source_shard: ShardId,
+        target_shard: ShardId,
+        payload: Vec<u8>,
+        source_event_id: [u8; 32],
+        source_state_root: [u8; 32],
+        causal_proof: VectorClock,
+    ) -> Self {
         Self {
             source_shard,
             target_shard,
             payload,
+            source_event_id,
+            source_state_root,
             causal_proof,
-            // P0-6 fix: default to unsigned. Production callers must call
-            // `sign` (or set this field directly) to attach an
-            // Ed25519 signature over the payload before sending; otherwise
-            // the receiving router will reject the message.
             source_signature: None,
         }
     }
 
-    /// Sign this cross-shard message with the given Ed25519 keypair.
+    /// The commitment the source shard's validator-set key attests to.
     ///
-    /// Signs over `payload || causal_proof.to_bytes()` — the same data
-    /// that `verify_source_signature` checks. The signature is stored
-    /// in `source_signature`.
-    pub fn sign(&mut self, keypair: &omnia_substrate::crypto::NodeKeypair) {
-        use ed25519_dalek::Signer;
-
-        let mut signed_data = Vec::new();
-        signed_data.extend_from_slice(&self.payload);
+    /// Binds every authorization-relevant field: the source and target
+    /// shards, the originating source event and its resulting state root,
+    /// the payload, and the causal proof. Domain-separated so an
+    /// attestation cannot be repurposed as any other kind of signature.
+    pub fn attestation_commitment(&self) -> [u8; 32] {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(ATTESTATION_DOMAIN);
+        hasher.update(&self.source_shard.0);
+        hasher.update(&self.target_shard.0);
+        hasher.update(&self.source_event_id);
+        hasher.update(&self.source_state_root);
+        hasher.update(&(self.payload.len() as u64).to_le_bytes());
+        hasher.update(&self.payload);
         if let Ok(proof_bytes) = self.causal_proof.to_bytes() {
-            signed_data.extend_from_slice(&proof_bytes);
+            hasher.update(&(proof_bytes.len() as u64).to_le_bytes());
+            hasher.update(&proof_bytes);
         }
+        *hasher.finalize().as_bytes()
+    }
 
-        // NodeKeypair is ed25519_dalek::SigningKey
-        let sig: ed25519_dalek::Signature = keypair.sign(&signed_data);
+    /// Attest this message with the source shard's validator-set keypair.
+    ///
+    /// Signs [`attestation_commitment`](Self::attestation_commitment). The
+    /// public half of this keypair must be registered for `source_shard`
+    /// on the receiving router (`register_shard_attestation_key`), or the
+    /// message will be rejected.
+    pub fn attest(&mut self, keypair: &omnia_substrate::crypto::NodeKeypair) {
+        use ed25519_dalek::Signer;
+        let sig: ed25519_dalek::Signature = keypair.sign(&self.attestation_commitment());
         self.source_signature = Some(sig.to_bytes().to_vec());
     }
 
@@ -75,15 +141,21 @@ impl CrossShardMessage {
     ///
     /// Returns `true` if `source_vc` (the vector clock at the source shard
     /// when the originating operation was applied) happened before the
-    /// `target_vc` (the current vector clock at the target shard).
+    /// `target_vc` (the current vector clock at the target shard). This is
+    /// an *ordering* check — authorization is
+    /// [`verify_attestation`](Self::verify_attestation).
     pub fn verify_causality(&self, source_vc: &VectorClock, target_vc: &VectorClock) -> bool {
         source_vc.happened_before(target_vc)
     }
 
-    /// Verify the source signature on this cross-shard message.
-    /// Returns true if the signature is valid, false otherwise.
-    /// Returns false if no signature is present.
-    pub fn verify_source_signature(&self, source_pubkey: &[u8; 32]) -> bool {
+    /// Verify the attestation against the source shard's **registered**
+    /// validator-set public key.
+    ///
+    /// This is the authorization check the router performs. `source_key`
+    /// must be the key the router has registered for `self.source_shard` —
+    /// never the carrying event's creator key. Returns `false` if the
+    /// attestation is absent, malformed, or does not verify.
+    pub fn verify_attestation(&self, source_key: &[u8; 32]) -> bool {
         use ed25519_dalek::{Signature, Verifier, VerifyingKey};
         let sig = match &self.source_signature {
             Some(s) if s.len() == 64 => match Signature::from_slice(s) {
@@ -92,18 +164,10 @@ impl CrossShardMessage {
             },
             _ => return false,
         };
-        let pk = match VerifyingKey::from_bytes(source_pubkey) {
+        let pk = match VerifyingKey::from_bytes(source_key) {
             Ok(pk) => pk,
             Err(_) => return false,
         };
-        // NEW-C1 fix: sign over BOTH payload AND causal_proof (not just payload).
-        // The previous code only signed self.payload, allowing an attacker to
-        // swap causal_proof without invalidating the signature.
-        let mut signed_data = Vec::new();
-        signed_data.extend_from_slice(&self.payload);
-        if let Ok(proof_bytes) = self.causal_proof.to_bytes() {
-            signed_data.extend_from_slice(&proof_bytes);
-        }
-        pk.verify(&signed_data, &sig).is_ok()
+        pk.verify(&self.attestation_commitment(), &sig).is_ok()
     }
 }

--- a/shards/src/fee_schedule.rs
+++ b/shards/src/fee_schedule.rs
@@ -108,6 +108,8 @@ mod tests {
             ShardId::financial(),
             ShardId::identity(),
             vec![1, 2, 3],
+            [0u8; 32],
+            [0u8; 32],
             VectorClock::new(),
         )
     }

--- a/shards/src/router.rs
+++ b/shards/src/router.rs
@@ -54,6 +54,14 @@ pub struct ShardRouter {
     quota: QuotaSystem,
     /// Persistent nonce store — survives restarts for replay protection.
     nonce_store: Arc<dyn NonceStore>,
+    /// AUDIT-2026-07 C4 (#342): registered validator-set attestation key
+    /// per source shard. A cross-shard message is authorized only if its
+    /// attestation verifies against the key registered here for its
+    /// `source_shard`. Populated by node-operator/genesis config via
+    /// [`register_shard_attestation_key`](Self::register_shard_attestation_key)
+    /// — deliberately not reachable from consensus payloads, so no network
+    /// participant can register a key for a shard they do not control.
+    shard_attestation_keys: HashMap<ShardId, [u8; 32]>,
 }
 
 impl ShardRouter {
@@ -69,6 +77,7 @@ impl ShardRouter {
             fee_schedule,
             quota,
             nonce_store: Arc::new(InMemoryNonceStore::new()),
+            shard_attestation_keys: HashMap::new(),
         }
     }
 
@@ -84,6 +93,7 @@ impl ShardRouter {
             fee_schedule: FeeSchedule::zero(),
             quota: QuotaSystem::default_system(),
             nonce_store: Arc::new(InMemoryNonceStore::new()),
+            shard_attestation_keys: HashMap::new(),
         }
     }
 
@@ -131,6 +141,7 @@ impl ShardRouter {
             fee_schedule,
             quota,
             nonce_store,
+            shard_attestation_keys: HashMap::new(),
         }
     }
 
@@ -154,6 +165,7 @@ impl ShardRouter {
             fee_schedule,
             quota,
             nonce_store,
+            shard_attestation_keys: HashMap::new(),
         })
     }
 
@@ -166,6 +178,25 @@ impl ShardRouter {
     pub fn register(&mut self, shard: Box<dyn Shard>) {
         let id = shard.shard_id();
         self.shards.insert(id, shard);
+    }
+
+    /// Register the validator-set attestation key for a source shard
+    /// (AUDIT-2026-07 C4, #342).
+    ///
+    /// Cross-shard messages claiming to originate from `shard_id` are
+    /// authorized only if their attestation verifies against `pubkey`.
+    /// This is a node-operator/genesis action; it must be driven from
+    /// trusted configuration or startup code, never from a consensus
+    /// payload — otherwise a network participant could register a key for
+    /// a shard they do not control and forge that shard's messages.
+    /// Re-registering overwrites the previous key (key rotation).
+    pub fn register_shard_attestation_key(&mut self, shard_id: ShardId, pubkey: [u8; 32]) {
+        self.shard_attestation_keys.insert(shard_id, pubkey);
+    }
+
+    /// The registered attestation key for a source shard, if any.
+    pub fn shard_attestation_key(&self, shard_id: &ShardId) -> Option<&[u8; 32]> {
+        self.shard_attestation_keys.get(shard_id)
     }
 
     /// Route an event to the appropriate shard based on the payload.
@@ -213,44 +244,47 @@ impl ShardRouter {
 
     /// Route a cross-shard message to its target shard.
     fn route_cross_shard(&mut self, event: &Event, msg: &CrossShardMessage) -> Result<(), ShardError> {
-        // NEW-C1 fix: the previous F-13 fix checked signature PRESENCE
-        // (is_none()) but never called verify_source_signature(). Any
-        // Some(random_bytes) passed. Now we:
-        //   1. Reject if source_signature is None (all builds, not just
-        //      production — there is no legitimate reason to accept
-        //      unsigned cross-shard messages in any build)
-        //   2. Verify the signature against the event creator's public key
+        // AUDIT-2026-07 C4 (#342): AUTHORIZATION, not just authentication.
         //
-        // The event creator's pubkey is the node that originated the
-        // cross-shard message. In a multi-node setup, a per-shard signing
-        // key registry would be more correct, but for now the event
-        // creator's key is the right authority to check.
+        // The old code verified `source_signature` against
+        // `event.creator_pubkey` — the creator of the CARRYING event, who
+        // can be any authenticated user. So any user could forge a message
+        // "from" any source shard by signing it with their own key. The
+        // causal_proof was likewise attacker-set and only checked against
+        // the attacker's own event.
         //
-        // Tests that need to send unsigned cross-shard messages should
-        // sign them with a test keypair and embed the signature.
-        if msg.source_signature.is_none() {
+        // Now the message must carry an attestation by the SOURCE SHARD's
+        // registered validator-set key, verified against the key this
+        // router has registered for `msg.source_shard`. A user who does
+        // not hold that key cannot forge a message from that shard.
+        //
+        //   1. The source shard must have a registered attestation key. An
+        //      unregistered source shard cannot originate cross-shard
+        //      messages (fail closed).
+        //   2. The attestation must verify against that registered key over
+        //      the message's state-transition commitment.
+        let source_key = self.shard_attestation_keys.get(&msg.source_shard).ok_or_else(|| {
             tracing::error!(
                 source_shard = ?msg.source_shard,
                 target_shard = ?msg.target_shard,
-                "cross-shard message rejected — no source_signature"
+                "cross-shard message rejected — source shard has no registered attestation key"
             );
-            return Err(ShardError::ValidationFailed(
-                "cross-shard message missing source_signature".into(),
-            ));
-        }
+            ShardError::ValidationFailed(format!(
+                "cross-shard message rejected: source shard {:?} has no registered attestation key",
+                msg.source_shard
+            ))
+        })?;
 
-        // NEW-C1 fix: actually verify the signature, not just check presence.
-        // The event creator's public key is the authority that should have
-        // signed the cross-shard message.
-        if !msg.verify_source_signature(&event.creator_pubkey) {
+        if !msg.verify_attestation(source_key) {
             tracing::error!(
                 source_shard = ?msg.source_shard,
                 target_shard = ?msg.target_shard,
-                creator = ?&event.creator_pubkey[..4],
-                "cross-shard message rejected — source_signature verification failed"
+                "cross-shard message rejected — attestation does not verify against the registered source-shard key"
             );
             return Err(ShardError::ValidationFailed(
-                "cross-shard message source_signature verification failed".into(),
+                "cross-shard message rejected: attestation does not verify against the \
+                 registered source-shard validator-set key"
+                    .into(),
             ));
         }
 

--- a/shards/tests/cross_shard.rs
+++ b/shards/tests/cross_shard.rs
@@ -154,6 +154,8 @@ fn test_cross_shard_message_causality() {
         ShardId::financial(),
         ShardId::identity(),
         vec![1, 2, 3],
+        [0u8; 32],
+        [0u8; 32],
         source_vc.clone(),
     );
 

--- a/shards/tests/cross_shard_authorization.rs
+++ b/shards/tests/cross_shard_authorization.rs
@@ -1,0 +1,175 @@
+#![allow(clippy::unwrap_used)]
+//! AUDIT-2026-07 C4 (#342) regression tests: cross-shard messages must be
+//! AUTHORIZED by the source shard's registered validator-set key, not just
+//! authenticated by whoever created the carrying event.
+//!
+//! The vulnerability: `route_cross_shard` verified `source_signature`
+//! against `event.creator_pubkey` — the creator of the carrying event, who
+//! can be any authenticated user. So any user could forge a message "from"
+//! any source shard by signing it with their own key. These tests lock the
+//! forgery out and confirm the legitimate (registered-key) path still works.
+
+use omnia_shards::{CrossShardMessage, FinancialShard, IdentityShard, ShardId, ShardOp, ShardPayload, ShardRouter};
+use omnia_substrate::{crypto::generate_keypair, Event, NodeId, NodeKeypair, VectorClock};
+
+fn test_node(id: u8) -> NodeId {
+    let mut node = [0u8; 32];
+    node[0] = id;
+    node
+}
+
+/// A valid inner operation for the identity source shard.
+fn identity_create_did_op(keypair: &NodeKeypair) -> Vec<u8> {
+    postcard::to_allocvec(&ShardOp::Identity(omnia_shards::IdentityOp::CreateDid {
+        document: omnia_shards::DidDocument::new(
+            format!("did:omnia:{}", hex::encode(keypair.verifying_key().to_bytes())),
+            keypair.verifying_key().to_bytes(),
+            0,
+        ),
+    }))
+    .unwrap()
+}
+
+/// Build a router with the financial + identity shards and route a
+/// cross-shard message (source = identity) inside an event created by
+/// `event_creator`. `configure` runs after registration so a test can
+/// register (or not) the source shard's attestation key.
+fn route_message(
+    msg: CrossShardMessage,
+    event_creator: &NodeKeypair,
+    configure: impl FnOnce(&mut ShardRouter),
+) -> Result<(), omnia_shards::ShardError> {
+    let mut router = ShardRouter::new_without_fees();
+    router.register(Box::new(FinancialShard::new()));
+    router.register(Box::new(IdentityShard::new()));
+    configure(&mut router);
+
+    // Event vc dominates the message's causal_proof (test_node(2), 1) so the
+    // causality check passes and routing reaches the authorization check.
+    let mut vc = VectorClock::with_node(test_node(1), 1);
+    vc.merge(&VectorClock::with_node(test_node(2), 1));
+    let payload = ShardPayload {
+        shard_id: ShardId::financial(),
+        operation: ShardOp::CrossShard(msg),
+        nonce: 1,
+    }
+    .to_bytes()
+    .unwrap();
+    let mut event = Event::new(test_node(1), 0, vc, None, None, payload).unwrap();
+    event.sign_with_keypair(event_creator).unwrap();
+    router.route_event(&event)
+}
+
+fn base_message(source_op: Vec<u8>) -> CrossShardMessage {
+    CrossShardMessage::new(
+        ShardId::identity(),
+        ShardId::identity(),
+        source_op,
+        [0u8; 32],
+        [0u8; 32],
+        VectorClock::with_node(test_node(2), 1),
+    )
+}
+
+/// THE C4 regression: an attacker who is a normal authenticated user
+/// attests a message "from" the identity shard with their OWN key. The
+/// identity shard's registered attestation key is a DIFFERENT key, so the
+/// forgery is rejected. On the old code this was accepted because the
+/// signature was checked against the attacker's own event-creator key.
+#[test]
+fn forged_message_signed_by_event_creator_is_rejected() {
+    let attacker = generate_keypair();
+    let legit_shard_key = generate_keypair();
+
+    let mut msg = base_message(identity_create_did_op(&attacker));
+    msg.attest(&attacker); // attacker signs with their own key
+
+    let result = route_message(msg, &attacker, |router| {
+        // The real identity-shard key is registered — NOT the attacker's.
+        router.register_shard_attestation_key(ShardId::identity(), legit_shard_key.verifying_key().to_bytes());
+    });
+
+    let err = result.expect_err("a message not attested by the registered key must be rejected");
+    assert!(
+        err.to_string().contains("does not verify against the"),
+        "rejection must be the attestation check, got: {err}"
+    );
+}
+
+/// If the source shard has no registered attestation key at all, the
+/// message is rejected fail-closed — an unregistered shard cannot
+/// originate cross-shard messages.
+#[test]
+fn message_from_unregistered_source_shard_is_rejected() {
+    let attacker = generate_keypair();
+    let mut msg = base_message(identity_create_did_op(&attacker));
+    msg.attest(&attacker);
+
+    let result = route_message(msg, &attacker, |_router| {
+        // Deliberately register nothing.
+    });
+    let err = result.expect_err("unregistered source shard must be rejected");
+    assert!(
+        err.to_string().contains("no registered attestation key"),
+        "rejection must be the missing-key check, got: {err}"
+    );
+}
+
+/// A message with no attestation at all is rejected even when the source
+/// shard key is registered.
+#[test]
+fn unattested_message_is_rejected() {
+    let shard_key = generate_keypair();
+    let creator = generate_keypair();
+    let msg = base_message(identity_create_did_op(&shard_key)); // never attested
+
+    let result = route_message(msg, &creator, |router| {
+        router.register_shard_attestation_key(ShardId::identity(), shard_key.verifying_key().to_bytes());
+    });
+    assert!(result.is_err(), "unattested cross-shard message must be rejected");
+}
+
+/// The legitimate path: the message is attested by the identity shard's
+/// registered validator-set key. Authorization passes and the message is
+/// routed to the target shard for processing — even though the carrying
+/// event was created by a *different* key.
+#[test]
+fn message_attested_by_registered_key_is_authorized() {
+    let shard_key = generate_keypair();
+    let event_creator = generate_keypair();
+
+    // The inner DID op is owned by the event creator (the identity shard
+    // enforces owner == event.creator_pubkey downstream); the message is
+    // ATTESTED by the source shard's registered key. Both facts hold at
+    // once: authorization comes from the shard key, the op's own owner
+    // check from the event creator.
+    let mut msg = base_message(identity_create_did_op(&event_creator));
+    msg.attest(&shard_key);
+
+    let result = route_message(msg, &event_creator, |router| {
+        router.register_shard_attestation_key(ShardId::identity(), shard_key.verifying_key().to_bytes());
+    });
+    assert!(
+        result.is_ok(),
+        "a message attested by the registered source-shard key must be authorized, got: {result:?}"
+    );
+}
+
+/// Tampering with the payload after attestation invalidates the
+/// attestation (the commitment binds the payload).
+#[test]
+fn tampering_payload_after_attestation_is_rejected() {
+    let shard_key = generate_keypair();
+
+    let mut msg = base_message(identity_create_did_op(&shard_key));
+    msg.attest(&shard_key);
+    // Swap the payload for a different (still valid) op after signing.
+    let other = generate_keypair();
+    msg.payload = identity_create_did_op(&other);
+
+    let result = route_message(msg, &shard_key, |router| {
+        router.register_shard_attestation_key(ShardId::identity(), shard_key.verifying_key().to_bytes());
+    });
+    let err = result.expect_err("payload tampering must invalidate the attestation");
+    assert!(err.to_string().contains("does not verify against the"), "got: {err}");
+}

--- a/shards/tests/fee_enforcement.rs
+++ b/shards/tests/fee_enforcement.rs
@@ -197,6 +197,9 @@ fn test_cross_shard_fee_deduction() {
     let mut router = ShardRouter::new(schedule, quota);
     router.register(Box::new(FinancialShard::new()));
     router.register(Box::new(IdentityShard::new()));
+    // C4 (#342): register the SOURCE shard's validator-set attestation key.
+    // The message must be attested by this key, not the event creator's.
+    router.register_shard_attestation_key(ShardId::identity(), keypair.verifying_key().to_bytes());
 
     let mut msg = CrossShardMessage::new(
         ShardId::identity(),
@@ -209,20 +212,14 @@ fn test_cross_shard_fee_deduction() {
             ),
         }))
         .expect("serialization should work"),
+        [0u8; 32],
+        [0u8; 32],
         // causal_proof must be non-empty AND happened-before the event's vc.
-        // The test event's vc is VectorClock::with_node(creator, 1), so we
-        // use vc with count 0 at the same node — empty entry doesn't qualify,
-        // so we use a different node with count 1, then merge — but the
-        // simplest valid proof is just a non-zero count strictly less than
-        // the event's. Use the creator with count 0... actually is_empty()
-        // returns true for {node: 0}. Use a separate node with count 1
-        // and a target vc that has count >= 1 for that node.
         VectorClock::with_node(test_node(2), 1),
     );
 
-    // NEW-C1 fix: sign the cross-shard message with the event creator's
-    // keypair. The router now requires a valid source_signature.
-    msg.sign(&keypair);
+    // C4 (#342): attest with the SOURCE shard's registered validator-set key.
+    msg.attest(&keypair);
 
     // The default test event uses VectorClock::with_node(creator, 1) which
     // doesn't include test_node(2). For happened_before to return true,
@@ -263,18 +260,21 @@ fn test_cross_shard_insufficient_balance() {
     let mut router = ShardRouter::new(schedule, quota);
     router.register(Box::new(FinancialShard::new()));
     router.register(Box::new(IdentityShard::new()));
+    router.register_shard_attestation_key(ShardId::financial(), keypair.verifying_key().to_bytes());
 
     let mut msg = CrossShardMessage::new(
         ShardId::financial(),
         ShardId::identity(),
         vec![1, 2, 3],
+        [0u8; 32],
+        [0u8; 32],
         // Provide a valid causal_proof so the test exercises the fee path
         // rather than the (now-enforced) causality check.
         VectorClock::with_node(test_node(2), 1),
     );
 
-    // NEW-C1 fix: sign the cross-shard message.
-    msg.sign(&keypair);
+    // C4 (#342): attest with the source shard's registered validator-set key.
+    msg.attest(&keypair);
 
     let payload = ShardPayload {
         shard_id: ShardId::financial(),


### PR DESCRIPTION
## Summary

**AUDIT-2026-07 C4** (#342, mainnet blocker) — cross-shard messaging had **authentication but no authorization**. `route_cross_shard` verified `source_signature` against `event.creator_pubkey` — the creator of the *carrying* event, who can be **any authenticated user** — and the `causal_proof` vector clock was set by the message creator and only checked against that same attacker-controlled event. So any authenticated user could forge a cross-shard message claiming any source shard produced any operation, sign it with their own key, and have it accepted. The multi-shard composition story collapsed.

## Fix — authorization by the source shard's registered validator-set key

- **`CrossShardMessage`** now carries `source_event_id` + `source_state_root` and an **attestation** (`source_signature`) over a domain-separated commitment binding `source_shard, target_shard, source_event_id, source_state_root, payload, causal_proof` (`attestation_commitment` / `attest` / `verify_attestation`). The old `sign` / `verify_source_signature` methods — which took an arbitrary, attacker-chosen pubkey — are gone.
- **`ShardRouter`** gains a per-source-shard attestation-key registry (`register_shard_attestation_key`), a node-operator/genesis action **deliberately not reachable from consensus payloads** (the same fail-closed registry pattern proven in the C9 ZK circuit registry). `route_cross_shard` now looks up the key registered for `msg.source_shard` and verifies the attestation against **that** key — never the carrying event's creator. An unregistered source shard cannot originate cross-shard messages (fail closed). The causal-ordering check is retained as defense-in-depth.

In production the attestation key is the source shard's validator-set aggregate key (the **threshold-BLS group key from C2**); this module verifies an Ed25519 attestation, which a single-signer or threshold-adapter validator set produces.

## Testing (`shards/tests/cross_shard_authorization.rs`)

- **`forged_message_signed_by_event_creator_is_rejected`** — THE regression: an attacker attesting with their own key is rejected because the registered identity-shard key is different. (Accepted on the old code.)
- **`message_from_unregistered_source_shard_is_rejected`** — fail closed.
- **`unattested_message_is_rejected`**.
- **`message_attested_by_registered_key_is_authorized`** — the legit path routes to the target even though a *different* key created the carrying event.
- **`tampering_payload_after_attestation_is_rejected`** — the commitment binds the payload.

Full `omnia-shards` suite green (192 tests); node builds; both CI clippy gates + `cargo doc -D warnings` + `fmt` clean.

## Scope — #342 stays open for the full relay

This closes the **authorization hole** (the forgeable-message vulnerability). The audit's full remediation — an IBC-style relay with per-shard validator DKG, binding `source_state_root` to the actual committed source-shard state, and timeouts/acks — is the largest single effort in the audit and is tracked as follow-up on #342. This PR is the security-critical core: messages can no longer be forged by non-holders of the source shard's key.