### PR TITLE
fix(consensus): governance-authorized, persistent slashing undo (AUDIT-2026-07 C6)

### DIFF
--- a/omnia-consensus/src/lib.rs
+++ b/omnia-consensus/src/lib.rs
@@ -59,7 +59,10 @@ pub use slashing::{
     SlashingEventType, SlashingState, SlashingStore, SlashingStoreError, DEFAULT_EJECTION_THRESHOLD,
     DEFAULT_SLASH_THRESHOLD,
 };
-pub use slashing_undo::{SlashingUndoError, SlashingUndoManager, SlashingUndoRecord, SlashingUndoRequest};
+pub use slashing_undo::{
+    GovernanceAuthority, GovernanceSignature, SlashingUndoError, SlashingUndoManager, SlashingUndoRecord,
+    SlashingUndoRequest,
+};
 pub use thread_pool::{ValidationPool, ValidationResult, ValidationTask};
 pub use vector_clock_index::{VectorClockIndex, VectorClockIndexStats};
 

--- a/omnia-consensus/src/slashing.rs
+++ b/omnia-consensus/src/slashing.rs
@@ -273,6 +273,43 @@ pub struct SlashingState {
     pub typed_offense_history: HashMap<NodeId, Vec<SlashOffense>>,
     /// Currently jailed validators.
     pub jail_registry: HashMap<NodeId, JailState>,
+    /// AUDIT-2026-07 C6 (#344): rate-limit state for governance undo —
+    /// last round an undo was applied per validator. Persisted here (not
+    /// in the undo manager's memory) so a restart cannot reset the rate
+    /// limit and allow the one-undo-per-interval cap to be bypassed.
+    #[serde(default)]
+    pub last_undo_round: HashMap<NodeId, u64>,
+    /// AUDIT-2026-07 C6 (#344): permanent audit log of applied governance
+    /// undos, persisted in the same store/transaction as the slash-point
+    /// changes so it cannot diverge from them across a restart.
+    #[serde(default)]
+    pub undo_audit_log: Vec<SlashingUndoRecord>,
+}
+
+/// A permanent audit record of a slashing undo that was applied
+/// (AUDIT-2026-07 C6, #344).
+///
+/// Lives here (rather than in `slashing_undo`) so it can be a field of
+/// [`SlashingState`] and persisted atomically with the slash-point change.
+/// Re-exported from `slashing_undo` for backward compatibility.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SlashingUndoRecord {
+    /// The validator whose slash was reversed.
+    pub validator_id: NodeId,
+    /// The governance proposal hash that authorized the undo.
+    pub proposal_hash: [u8; 32],
+    /// Slash points before the undo.
+    pub points_before: u64,
+    /// Slash points after the undo.
+    pub points_after: u64,
+    /// The round at which the original slash was recorded.
+    pub slashed_round: u64,
+    /// The round at which the undo was applied.
+    pub undo_round: u64,
+    /// Timestamp of the undo (unix epoch seconds).
+    pub timestamp: u64,
+    /// The reason for the undo.
+    pub reason: String,
 }
 
 impl Default for SlashingState {
@@ -285,6 +322,8 @@ impl Default for SlashingState {
             offense_history: HashMap::new(),
             typed_offense_history: HashMap::new(),
             jail_registry: HashMap::new(),
+            last_undo_round: HashMap::new(),
+            undo_audit_log: Vec::new(),
         }
     }
 }
@@ -845,6 +884,8 @@ impl SlashingEngine {
             offense_history: HashMap::new(),
             typed_offense_history: HashMap::new(),
             jail_registry: HashMap::new(),
+            last_undo_round: HashMap::new(),
+            undo_audit_log: Vec::new(),
         };
         Self {
             state: Arc::new(RwLock::new(state)),
@@ -932,6 +973,8 @@ impl SlashingEngine {
                     offense_history: HashMap::new(),
                     typed_offense_history: HashMap::new(),
                     jail_registry: HashMap::new(),
+                    last_undo_round: HashMap::new(),
+                    undo_audit_log: Vec::new(),
                 }
             }
         };
@@ -1451,6 +1494,101 @@ impl SlashingEngine {
                 Err(SlashingStoreError::UndoNoOffenseHistory(prefix))
             }
         }
+    }
+
+    /// The round at which the last governance undo was applied for `node`
+    /// (AUDIT-2026-07 C6, #344) — read from persisted state, so it survives
+    /// restarts.
+    pub fn last_undo_round(&self, node: &NodeId) -> Option<u64> {
+        let state = self.state.read().unwrap_or_else(|e| {
+            tracing::error!(error = %e, "last_undo_round — lock poisoned");
+            std::process::abort()
+        });
+        state.last_undo_round.get(node).copied()
+    }
+
+    /// The full persisted governance-undo audit log (AUDIT-2026-07 C6, #344).
+    pub fn undo_audit_log(&self) -> Vec<SlashingUndoRecord> {
+        let state = self.state.read().unwrap_or_else(|e| {
+            tracing::error!(error = %e, "undo_audit_log — lock poisoned");
+            std::process::abort()
+        });
+        state.undo_audit_log.clone()
+    }
+
+    /// Apply a governance undo atomically: decrement the last offense's
+    /// points, record the audit entry, and stamp the rate-limit round —
+    /// all in a single state mutation persisted in one store transaction
+    /// (AUDIT-2026-07 C6, #344).
+    ///
+    /// Authorization is the caller's responsibility
+    /// ([`SlashingUndoManager::apply_undo`](crate::slashing_undo::SlashingUndoManager::apply_undo)
+    /// verifies a governance multi-signature before calling this). This
+    /// method only enforces atomic persistence.
+    #[allow(clippy::too_many_arguments)]
+    pub fn record_undo(
+        &mut self,
+        node: &NodeId,
+        current_round: u64,
+        slashed_round: u64,
+        undo_round: u64,
+        proposal_hash: [u8; 32],
+        reason: String,
+    ) -> Result<SlashingUndoRecord, SlashingStoreError> {
+        let mut state = self.state.write().unwrap_or_else(|e| {
+            tracing::error!(error = %e, "record_undo — lock poisoned");
+            std::process::abort()
+        });
+        let snapshot = state.clone();
+
+        let entries = match state.offense_history.get_mut(node) {
+            Some(entries) if !entries.is_empty() => entries,
+            _ => {
+                let mut prefix = [0u8; 4];
+                prefix.copy_from_slice(&node[..4]);
+                return Err(SlashingStoreError::UndoNoOffenseHistory(prefix));
+            }
+        };
+        let last_offense_points = entries.pop().expect("entries is non-empty per guard above");
+        if let Some(typed_history) = state.typed_offense_history.get_mut(node) {
+            typed_history.pop();
+        }
+        let points_before = state.slash_points.get(node).copied().unwrap_or(0);
+        let points_after = points_before.saturating_sub(last_offense_points);
+        state.slash_points.insert(*node, points_after);
+
+        let record = SlashingUndoRecord {
+            validator_id: *node,
+            proposal_hash,
+            points_before,
+            points_after,
+            slashed_round,
+            undo_round,
+            timestamp: std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_secs())
+                .unwrap_or(0),
+            reason,
+        };
+
+        // Rate-limit round and audit entry are updated in the SAME state
+        // object, then persisted in ONE store write below — so a crash
+        // can never leave the point decrement durable while the rate-limit
+        // stamp is lost (which is exactly what let the limit be bypassed).
+        state.last_undo_round.insert(*node, current_round);
+        state.undo_audit_log.push(record.clone());
+
+        drop(state);
+        if let Err(e) = self.persist_state() {
+            tracing::error!(error = %e, "Failed to persist slashing state after record_undo — rolling back");
+            let mut state = self.state.write().unwrap_or_else(|e| {
+                tracing::error!(error = %e, "record_undo rollback — lock poisoned");
+                std::process::abort()
+            });
+            *state = snapshot;
+            return Err(e);
+        }
+        Ok(record)
     }
 
     /// Export the current slashing state as a [`SlashingState`] snapshot.

--- a/omnia-consensus/src/slashing_undo.rs
+++ b/omnia-consensus/src/slashing_undo.rs
@@ -33,12 +33,23 @@
 use crate::slashing::SlashingEngine;
 use omnia_primitives::NodeId;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 use thiserror::Error;
+
+// AUDIT-2026-07 C6 (#344): the audit record now lives in `slashing` so it
+// can be persisted inside `SlashingState`. Re-exported here for the
+// existing public path `slashing_undo::SlashingUndoRecord`.
+pub use crate::slashing::SlashingUndoRecord;
+
+/// Domain separator for the governance-undo authorization commitment.
+const UNDO_COMMITMENT_DOMAIN: &[u8] = b"OMNIA-SLASHING-UNDO-GOV-V1";
 
 /// Errors that can occur during governance-based slashing undo operations.
 #[derive(Error, Debug)]
 pub enum SlashingUndoError {
+    /// The undo request was not authorized by a governance quorum
+    /// (AUDIT-2026-07 C6, #344).
+    #[error("governance authorization failed: {0}")]
+    Unauthorized(String),
     /// The rate limit for undos on this validator has been exceeded.
     #[error("rate limit: last undo for validator {validator_prefix:?} was at round {last_round}, current round {current_round}, minimum interval {min_interval}", last_round = last_round, current_round = current_round, min_interval = min_interval)]
     RateLimitExceeded {
@@ -77,72 +88,129 @@ pub struct SlashingUndoRequest {
     pub proposal_hash: [u8; 32],
     /// A human-readable reason for the undo.
     pub reason: String,
+    /// AUDIT-2026-07 C6 (#344): governance authorization — signatures by
+    /// registered governance keys over [`authorization_commitment`]. The
+    /// undo is applied only if at least the [`GovernanceAuthority`]'s
+    /// threshold of distinct valid signatures is present. Without this the
+    /// old code applied any undo from anyone with API access.
+    ///
+    /// [`authorization_commitment`]: SlashingUndoRequest::authorization_commitment
+    #[serde(default)]
+    pub governance_signatures: Vec<GovernanceSignature>,
 }
 
-/// A permanent audit record of a slashing undo that was applied.
-///
-/// Every undo operation is recorded for transparency and accountability.
-/// These records cannot be deleted and are available for audit queries.
+/// A single governance signature over a slashing-undo authorization
+/// commitment (AUDIT-2026-07 C6, #344).
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SlashingUndoRecord {
-    /// The validator whose slash was reversed.
-    pub validator_id: NodeId,
-    /// The governance proposal hash that authorized the undo.
-    pub proposal_hash: [u8; 32],
-    /// Slash points before the undo.
-    pub points_before: u64,
-    /// Slash points after the undo.
-    pub points_after: u64,
-    /// The round at which the original slash was recorded.
-    pub slashed_round: u64,
-    /// The round at which the undo was applied.
-    pub undo_round: u64,
-    /// Timestamp of the undo (unix epoch seconds).
-    pub timestamp: u64,
-    /// The reason for the undo.
-    pub reason: String,
+pub struct GovernanceSignature {
+    /// Index of the signing key in the [`GovernanceAuthority`] key set.
+    pub key_index: u32,
+    /// The 64-byte Ed25519 signature over the authorization commitment.
+    pub signature: Vec<u8>,
 }
 
-/// Manager for governance-based slashing undo operations.
+impl SlashingUndoRequest {
+    /// The message governance keys sign to authorize this undo.
+    ///
+    /// Binds the target validator, the slashed and undo rounds, the
+    /// proposal hash, and the reason — so a signature for one undo cannot
+    /// be replayed to authorize a different one.
+    pub fn authorization_commitment(&self) -> [u8; 32] {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(UNDO_COMMITMENT_DOMAIN);
+        hasher.update(&self.validator_id);
+        hasher.update(&self.slashed_round.to_le_bytes());
+        hasher.update(&self.undo_round.to_le_bytes());
+        hasher.update(&self.proposal_hash);
+        hasher.update(&(self.reason.len() as u64).to_le_bytes());
+        hasher.update(self.reason.as_bytes());
+        *hasher.finalize().as_bytes()
+    }
+}
+
+/// The registered set of governance keys and the quorum threshold that
+/// must sign a slashing-undo request (AUDIT-2026-07 C6, #344).
 ///
-/// Tracks undo requests and applies them to the slashing engine. Maintains
-/// an audit log of all applied undos and enforces rate limits.
+/// This is a node-operator/genesis configuration — the governance key set
+/// is trusted state, established out of band, not settable from a
+/// consensus payload. In production the keys are the governance council's
+/// public keys (or a threshold-BLS group), and the threshold is the
+/// council's supermajority.
+#[derive(Debug, Clone)]
+pub struct GovernanceAuthority {
+    keys: Vec<[u8; 32]>,
+    threshold: usize,
+}
+
+impl GovernanceAuthority {
+    /// Create a governance authority from a set of Ed25519 verifying keys
+    /// and a signing threshold (`1 <= threshold <= keys.len()`).
+    pub fn new(keys: Vec<[u8; 32]>, threshold: usize) -> Result<Self, SlashingUndoError> {
+        if keys.is_empty() || threshold == 0 || threshold > keys.len() {
+            return Err(SlashingUndoError::Unauthorized(format!(
+                "invalid governance authority: {} keys, threshold {threshold}",
+                keys.len()
+            )));
+        }
+        Ok(Self { keys, threshold })
+    }
+
+    /// Verify that `signatures` contain at least `threshold` valid,
+    /// distinct-key Ed25519 signatures over `commitment`.
+    pub fn verify(&self, commitment: &[u8; 32], signatures: &[GovernanceSignature]) -> bool {
+        use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+        let mut seen = std::collections::HashSet::new();
+        let mut valid = 0usize;
+        for gs in signatures {
+            let idx = gs.key_index as usize;
+            if idx >= self.keys.len() || !seen.insert(idx) {
+                continue; // out of range, or a duplicate key — does not count
+            }
+            let sig = match gs
+                .signature
+                .as_slice()
+                .try_into()
+                .map(|b: [u8; 64]| Signature::from_bytes(&b))
+            {
+                Ok(s) => s,
+                Err(_) => continue,
+            };
+            let pk = match VerifyingKey::from_bytes(&self.keys[idx]) {
+                Ok(pk) => pk,
+                Err(_) => continue,
+            };
+            if pk.verify(commitment, &sig).is_ok() {
+                valid += 1;
+                if valid >= self.threshold {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    /// The configured quorum threshold.
+    pub fn threshold(&self) -> usize {
+        self.threshold
+    }
+}
+
+/// Manager for governance-authorized, persistently-rate-limited slashing
+/// undo operations (AUDIT-2026-07 C6, #344).
 ///
-/// # Example
+/// Authorization: an undo is applied only if its request carries at least
+/// the [`GovernanceAuthority`] threshold of valid governance signatures.
+/// A manager built without an authority rejects every undo (fail closed) —
+/// the old code applied any undo from anyone with API access.
 ///
-/// ```
-/// use omnia_consensus::slashing_undo::{SlashingUndoManager, SlashingUndoRequest};
-/// use omnia_consensus::slashing::{SlashingEngine, SlashOffense};
-///
-/// let mut slashing = SlashingEngine::new_in_memory(500, 2000);
-/// let mut undo_mgr = SlashingUndoManager::new();
-///
-/// let mut node = [0u8; 32];
-/// node[0] = 42;
-///
-/// // Record an offense
-/// slashing.register_validator(node, 10_000);
-/// slashing.record_offense(node, SlashOffense::LivenessViolation);
-/// assert_eq!(slashing.slash_points_of(&node), 100);
-///
-/// // Governance undoes the slash
-/// let request = SlashingUndoRequest {
-///     validator_id: node,
-///     slashed_round: 50,
-///     undo_round: 100,
-///     proposal_hash: [1u8; 32],
-///     reason: "Software bug caused false positive".to_string(),
-/// };
-///
-/// let record = undo_mgr.apply_undo(&mut slashing, request, 100).unwrap();
-/// assert_eq!(slashing.slash_points_of(&node), 0);
-/// assert_eq!(undo_mgr.audit_log().len(), 1);
-/// ```
+/// Rate limiting & audit: the last-undo round and the audit log live in the
+/// [`SlashingEngine`]'s persisted state, so a restart cannot reset them and
+/// bypass the one-undo-per-interval cap. This manager holds only policy
+/// (the governance authority and the interval), no mutable undo state.
 pub struct SlashingUndoManager {
-    /// Audit log of all applied undos.
-    audit_log: Vec<SlashingUndoRecord>,
-    /// Rate-limiting: maps validator → last undo round.
-    last_undo_round: HashMap<NodeId, u64>,
+    /// Governance keys + threshold that must authorize each undo. `None`
+    /// means no undo can be authorized (fail closed).
+    governance: Option<GovernanceAuthority>,
     /// Minimum round interval between undos for the same validator.
     min_undo_interval: u64,
 }
@@ -151,58 +219,73 @@ pub struct SlashingUndoManager {
 const DEFAULT_MIN_UNDO_INTERVAL: u64 = 1000;
 
 impl SlashingUndoManager {
-    /// Create a new undo manager with the default rate-limiting interval.
+    /// Create an undo manager with **no** governance authority.
+    ///
+    /// Such a manager rejects every undo (fail closed). Use
+    /// [`with_governance`](Self::with_governance) to authorize undos.
     pub fn new() -> Self {
         Self {
-            audit_log: Vec::new(),
-            last_undo_round: HashMap::new(),
+            governance: None,
             min_undo_interval: DEFAULT_MIN_UNDO_INTERVAL,
         }
     }
 
-    /// Create a new undo manager with a custom rate-limiting interval.
-    ///
-    /// # Arguments
-    ///
-    /// * `min_undo_interval` — Minimum number of rounds between successive
-    ///   undos for the same validator.
-    pub fn with_interval(min_undo_interval: u64) -> Self {
+    /// Create an undo manager authorized by the given governance authority.
+    pub fn with_governance(governance: GovernanceAuthority) -> Self {
         Self {
-            audit_log: Vec::new(),
-            last_undo_round: HashMap::new(),
+            governance: Some(governance),
+            min_undo_interval: DEFAULT_MIN_UNDO_INTERVAL,
+        }
+    }
+
+    /// Create an undo manager with a governance authority and a custom
+    /// rate-limit interval.
+    pub fn with_governance_and_interval(governance: GovernanceAuthority, min_undo_interval: u64) -> Self {
+        Self {
+            governance: Some(governance),
             min_undo_interval,
         }
     }
 
-    /// Apply a slashing undo request.
+    /// Set (or replace) the governance authority.
+    pub fn set_governance(&mut self, governance: GovernanceAuthority) {
+        self.governance = Some(governance);
+    }
+
+    /// Apply a governance-authorized slashing undo.
     ///
-    /// Decrements the target validator's slash points by the amount of
-    /// the last recorded offense (tracked via offense history) and records the undo in the
-    /// audit log. Enforces the rate limit — at most one undo per validator
-    /// per `min_undo_interval` rounds.
-    ///
-    /// # Arguments
-    ///
-    /// * `slashing` — The [`SlashingEngine`] to apply the undo to.
-    /// * `request` — The [`SlashingUndoRequest`] from governance.
-    /// * `current_round` — The current consensus round (for rate limiting).
-    ///
-    /// # Returns
-    ///
-    /// A [`SlashingUndoRecord`] on success, or an error string on failure.
+    /// Verifies the request's governance signatures against the configured
+    /// [`GovernanceAuthority`], enforces the persisted rate limit, then
+    /// applies the undo and records it **atomically** via
+    /// [`SlashingEngine::record_undo`] (rate-limit stamp + audit entry +
+    /// point decrement in one persisted transaction).
     ///
     /// # Errors
-    ///
-    /// - Rate limit exceeded: too soon since last undo for this validator.
-    /// - The validator has no offense history to undo.
+    /// - [`SlashingUndoError::Unauthorized`] — no governance authority is
+    ///   configured, or the request lacks a valid signing quorum.
+    /// - [`SlashingUndoError::RateLimitExceeded`] — too soon since the last
+    ///   undo for this validator (checked against persisted state).
+    /// - [`SlashingUndoError::UndoFailed`] — the engine could not apply or
+    ///   persist the undo.
     pub fn apply_undo(
         &mut self,
         slashing: &mut SlashingEngine,
         request: SlashingUndoRequest,
         current_round: u64,
     ) -> Result<SlashingUndoRecord, SlashingUndoError> {
-        // Rate limit check
-        if let Some(&last_round) = self.last_undo_round.get(&request.validator_id) {
+        // 1. Governance authorization (AUDIT-2026-07 C6, #344).
+        let authority = self.governance.as_ref().ok_or_else(|| {
+            SlashingUndoError::Unauthorized("no governance authority configured — undo refused".to_string())
+        })?;
+        if !authority.verify(&request.authorization_commitment(), &request.governance_signatures) {
+            return Err(SlashingUndoError::Unauthorized(format!(
+                "insufficient valid governance signatures (need {})",
+                authority.threshold()
+            )));
+        }
+
+        // 2. Rate limit — read from PERSISTED state so restarts can't reset it.
+        if let Some(last_round) = slashing.last_undo_round(&request.validator_id) {
             if current_round.saturating_sub(last_round) < self.min_undo_interval {
                 let mut prefix = [0u8; 4];
                 prefix.copy_from_slice(&request.validator_id[..4]);
@@ -215,75 +298,52 @@ impl SlashingUndoManager {
             }
         }
 
-        let points_before = slashing.slash_points_of(&request.validator_id);
-
-        // Apply the undo via the slashing engine
-        slashing
-            .undo_slash(&request.validator_id)
-            .map_err(SlashingUndoError::UndoFailed)?;
-
-        let points_after = slashing.slash_points_of(&request.validator_id);
-
-        let record = SlashingUndoRecord {
-            validator_id: request.validator_id,
-            proposal_hash: request.proposal_hash,
-            points_before,
-            points_after,
-            slashed_round: request.slashed_round,
-            undo_round: request.undo_round,
-            timestamp: std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .map(|d| d.as_secs())
-                .unwrap_or(0),
-            reason: request.reason,
-        };
-
-        // Update rate-limiting state
-        self.last_undo_round.insert(request.validator_id, current_round);
-
-        // Record in audit log
-        self.audit_log.push(record.clone());
+        // 3. Apply + record atomically (persisted in one transaction).
+        let record = slashing.record_undo(
+            &request.validator_id,
+            current_round,
+            request.slashed_round,
+            request.undo_round,
+            request.proposal_hash,
+            request.reason,
+        )?;
 
         tracing::info!(
-            validator = ?&request.validator_id[..4],
-            points_before,
-            points_after,
-            proposal = ?&request.proposal_hash[..4],
-            "Slashing undo applied"
+            validator = ?&record.validator_id[..4],
+            points_before = record.points_before,
+            points_after = record.points_after,
+            proposal = ?&record.proposal_hash[..4],
+            "Governance-authorized slashing undo applied"
         );
-
         Ok(record)
     }
 
-    /// Get the full audit log of all applied undos.
-    pub fn audit_log(&self) -> &[SlashingUndoRecord] {
-        &self.audit_log
+    /// The full persisted audit log of applied undos.
+    pub fn audit_log(&self, slashing: &SlashingEngine) -> Vec<SlashingUndoRecord> {
+        slashing.undo_audit_log()
     }
 
-    /// Get all undo records for a specific validator.
-    ///
-    /// This is the history method required by the spec, returning all
-    /// undo records for a given validator ID.
-    pub fn history(&self, validator_id: &NodeId) -> Vec<&SlashingUndoRecord> {
-        self.audit_log
-            .iter()
+    /// All undo records for a specific validator.
+    pub fn history(&self, slashing: &SlashingEngine, validator_id: &NodeId) -> Vec<SlashingUndoRecord> {
+        slashing
+            .undo_audit_log()
+            .into_iter()
             .filter(|r| &r.validator_id == validator_id)
             .collect()
     }
 
-    /// Check whether an undo is currently allowed for the given validator at the
-    /// given round (i.e., the rate limit has not been exceeded).
-    pub fn can_undo(&self, validator_id: &NodeId, current_round: u64) -> bool {
-        if let Some(&last_round) = self.last_undo_round.get(validator_id) {
-            current_round.saturating_sub(last_round) >= self.min_undo_interval
-        } else {
-            true
+    /// Whether an undo is currently allowed for `validator_id` at
+    /// `current_round` (rate limit not exceeded), per persisted state.
+    pub fn can_undo(&self, slashing: &SlashingEngine, validator_id: &NodeId, current_round: u64) -> bool {
+        match slashing.last_undo_round(validator_id) {
+            Some(last_round) => current_round.saturating_sub(last_round) >= self.min_undo_interval,
+            None => true,
         }
     }
 
-    /// Get the total number of undos that have been applied.
-    pub fn total_undos(&self) -> usize {
-        self.audit_log.len()
+    /// Total number of undos that have been applied (persisted).
+    pub fn total_undos(&self, slashing: &SlashingEngine) -> usize {
+        slashing.undo_audit_log().len()
     }
 }
 
@@ -298,6 +358,7 @@ impl Default for SlashingUndoManager {
 mod tests {
     use super::*;
     use crate::slashing::{SlashOffense, DEFAULT_EJECTION_THRESHOLD, DEFAULT_SLASH_THRESHOLD};
+    use ed25519_dalek::{Signer, SigningKey};
 
     fn node(id: u8) -> NodeId {
         let mut n = [0u8; 32];
@@ -305,150 +366,278 @@ mod tests {
         n
     }
 
-    fn make_request(validator: NodeId, slashed_round: u64, undo_round: u64) -> SlashingUndoRequest {
-        SlashingUndoRequest {
+    /// A deterministic governance signing key for tests.
+    fn gov_key(seed: u8) -> SigningKey {
+        SigningKey::from_bytes(&[seed; 32])
+    }
+
+    /// A 1-of-1 governance authority for the given key.
+    fn authority_of(key: &SigningKey) -> GovernanceAuthority {
+        GovernanceAuthority::new(vec![key.verifying_key().to_bytes()], 1).unwrap()
+    }
+
+    /// A manager authorized by a single governance key with a given interval.
+    fn governed(key: &SigningKey, interval: u64) -> SlashingUndoManager {
+        SlashingUndoManager::with_governance_and_interval(authority_of(key), interval)
+    }
+
+    /// Build an undo request signed by `signers` (each at its key index).
+    fn signed_request(
+        validator: NodeId,
+        slashed_round: u64,
+        undo_round: u64,
+        signers: &[(u32, &SigningKey)],
+    ) -> SlashingUndoRequest {
+        let mut request = SlashingUndoRequest {
             validator_id: validator,
             slashed_round,
             undo_round,
             proposal_hash: [1u8; 32],
             reason: "Test undo".to_string(),
-        }
+            governance_signatures: vec![],
+        };
+        let commitment = request.authorization_commitment();
+        request.governance_signatures = signers
+            .iter()
+            .map(|(idx, sk)| GovernanceSignature {
+                key_index: *idx,
+                signature: sk.sign(&commitment).to_bytes().to_vec(),
+            })
+            .collect();
+        request
     }
 
     #[test]
     fn test_undo_liveness_violation() {
+        let gov = gov_key(7);
         let mut slashing = SlashingEngine::new_in_memory(DEFAULT_SLASH_THRESHOLD, DEFAULT_EJECTION_THRESHOLD);
-        let mut undo_mgr = SlashingUndoManager::new();
+        let mut undo_mgr = SlashingUndoManager::with_governance(authority_of(&gov));
 
         let n = node(1);
         slashing.register_validator(n, 10_000);
         slashing.record_offense(n, SlashOffense::LivenessViolation);
         assert_eq!(slashing.slash_points_of(&n), 100);
 
-        let request = make_request(n, 50, 100);
+        let request = signed_request(n, 50, 100, &[(0, &gov)]);
         let record = undo_mgr.apply_undo(&mut slashing, request, 100).unwrap();
         assert_eq!(record.points_before, 100);
         assert_eq!(record.points_after, 0);
-        assert_eq!(record.slashed_round, 50);
-        assert_eq!(record.undo_round, 100);
         assert_eq!(slashing.slash_points_of(&n), 0);
-        assert_eq!(undo_mgr.total_undos(), 1);
+        assert_eq!(undo_mgr.total_undos(&slashing), 1);
+    }
+
+    // ── AUDIT-2026-07 C6 (#344) regression tests ──────────────────────────
+
+    #[test]
+    fn undo_without_governance_authority_is_rejected() {
+        // A manager with no authority must refuse every undo (fail closed).
+        let mut slashing = SlashingEngine::new_in_memory(DEFAULT_SLASH_THRESHOLD, DEFAULT_EJECTION_THRESHOLD);
+        let mut undo_mgr = SlashingUndoManager::new();
+        let n = node(1);
+        slashing.register_validator(n, 10_000);
+        slashing.record_offense(n, SlashOffense::Equivocation);
+
+        let gov = gov_key(7);
+        let request = signed_request(n, 50, 100, &[(0, &gov)]);
+        let err = undo_mgr.apply_undo(&mut slashing, request, 100).unwrap_err();
+        assert!(matches!(err, SlashingUndoError::Unauthorized(_)));
+        // The slash must be untouched.
+        assert_eq!(slashing.slash_points_of(&n), 500);
     }
 
     #[test]
-    fn test_undo_equivocation() {
+    fn undo_signed_by_wrong_key_is_rejected() {
+        // THE C6 regression: the old code applied any undo. Now a signature
+        // by a key that is NOT in the governance set is rejected.
+        let gov = gov_key(7);
+        let attacker = gov_key(66);
         let mut slashing = SlashingEngine::new_in_memory(DEFAULT_SLASH_THRESHOLD, DEFAULT_EJECTION_THRESHOLD);
-        let mut undo_mgr = SlashingUndoManager::new();
-
-        let n = node(2);
+        let mut undo_mgr = SlashingUndoManager::with_governance(authority_of(&gov));
+        let n = node(1);
         slashing.register_validator(n, 10_000);
-        // Equivocation = 500 points
         slashing.record_offense(n, SlashOffense::Equivocation);
-        assert_eq!(slashing.slash_points_of(&n), 500);
 
-        // Undo now correctly removes the full equivocation amount (500 pts)
-        let request = make_request(n, 50, 100);
-        undo_mgr.apply_undo(&mut slashing, request, 100).unwrap();
-        assert_eq!(slashing.slash_points_of(&n), 0);
+        // Attacker signs with their own key, claiming key index 0.
+        let request = signed_request(n, 50, 100, &[(0, &attacker)]);
+        let err = undo_mgr.apply_undo(&mut slashing, request, 100).unwrap_err();
+        assert!(matches!(err, SlashingUndoError::Unauthorized(_)));
+        assert_eq!(slashing.slash_points_of(&n), 500);
+    }
+
+    #[test]
+    fn unsigned_undo_is_rejected() {
+        let gov = gov_key(7);
+        let mut slashing = SlashingEngine::new_in_memory(DEFAULT_SLASH_THRESHOLD, DEFAULT_EJECTION_THRESHOLD);
+        let mut undo_mgr = SlashingUndoManager::with_governance(authority_of(&gov));
+        let n = node(1);
+        slashing.register_validator(n, 10_000);
+        slashing.record_offense(n, SlashOffense::Equivocation);
+
+        let request = signed_request(n, 50, 100, &[]); // no signatures
+        assert!(matches!(
+            undo_mgr.apply_undo(&mut slashing, request, 100),
+            Err(SlashingUndoError::Unauthorized(_))
+        ));
+    }
+
+    #[test]
+    fn threshold_requires_multiple_signers() {
+        // 2-of-3 governance: one signature is not enough.
+        let k0 = gov_key(1);
+        let k1 = gov_key(2);
+        let k2 = gov_key(3);
+        let authority = GovernanceAuthority::new(
+            vec![
+                k0.verifying_key().to_bytes(),
+                k1.verifying_key().to_bytes(),
+                k2.verifying_key().to_bytes(),
+            ],
+            2,
+        )
+        .unwrap();
+        let mut slashing = SlashingEngine::new_in_memory(DEFAULT_SLASH_THRESHOLD, DEFAULT_EJECTION_THRESHOLD);
+        let mut undo_mgr = SlashingUndoManager::with_governance(authority);
+        let n = node(1);
+        slashing.register_validator(n, 10_000);
+        slashing.record_offense(n, SlashOffense::Equivocation);
+        slashing.record_offense(n, SlashOffense::LivenessViolation);
+
+        // One signer → rejected.
+        let one = signed_request(n, 50, 100, &[(0, &k0)]);
+        assert!(matches!(
+            undo_mgr.apply_undo(&mut slashing, one, 100),
+            Err(SlashingUndoError::Unauthorized(_))
+        ));
+        // Two distinct signers → accepted.
+        let two = signed_request(n, 50, 100, &[(0, &k0), (2, &k2)]);
+        assert!(undo_mgr.apply_undo(&mut slashing, two, 100).is_ok());
+    }
+
+    #[test]
+    fn rate_limit_survives_a_restart() {
+        // THE persistence regression: the rate-limit state must live in the
+        // slashing store so reopening the engine does NOT reset it and let a
+        // second undo through within the interval.
+        use crate::slashing::{RedbSlashingStore, SlashingStore};
+        use std::sync::Arc;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("slashing.redb");
+        let gov = gov_key(7);
+        let n = node(9);
+
+        {
+            let store: Arc<dyn SlashingStore> = Arc::new(RedbSlashingStore::open(&path).unwrap());
+            let mut slashing = SlashingEngine::with_store(store).unwrap();
+            slashing.register_validator(n, 10_000);
+            slashing.record_offense(n, SlashOffense::Equivocation);
+            slashing.record_offense(n, SlashOffense::LivenessViolation);
+            let mut mgr = governed(&gov, 100);
+            mgr.apply_undo(&mut slashing, signed_request(n, 50, 100, &[(0, &gov)]), 100)
+                .unwrap();
+        }
+
+        // Reopen from the same file — the last-undo round must persist.
+        let store: Arc<dyn SlashingStore> = Arc::new(RedbSlashingStore::open(&path).unwrap());
+        let mut slashing = SlashingEngine::with_store(store).unwrap();
+        assert_eq!(slashing.last_undo_round(&n), Some(100), "rate-limit round must persist");
+        assert_eq!(slashing.undo_audit_log().len(), 1, "audit log must persist");
+
+        let mut mgr = governed(&gov, 100);
+        // A second undo at round 150 (interval 100) must still be rate-limited
+        // AFTER the restart — the old in-memory state would have reset to allow it.
+        let err = mgr
+            .apply_undo(&mut slashing, signed_request(n, 50, 150, &[(0, &gov)]), 150)
+            .unwrap_err();
+        assert!(matches!(err, SlashingUndoError::RateLimitExceeded { .. }));
     }
 
     #[test]
     fn test_undo_rate_limit() {
+        let gov = gov_key(7);
         let mut slashing = SlashingEngine::new_in_memory(DEFAULT_SLASH_THRESHOLD, DEFAULT_EJECTION_THRESHOLD);
-        let mut undo_mgr = SlashingUndoManager::with_interval(100);
+        let mut undo_mgr = governed(&gov, 100);
 
         let n = node(3);
         slashing.register_validator(n, 10_000);
-        // Record two offenses so we have enough history for two undos
         slashing.record_offense(n, SlashOffense::Equivocation);
         slashing.record_offense(n, SlashOffense::LivenessViolation);
 
-        // First undo at round 100
-        let request1 = make_request(n, 50, 100);
-        undo_mgr.apply_undo(&mut slashing, request1, 100).unwrap();
-
-        // Second undo at round 150 — should fail (interval = 100)
-        let request2 = make_request(n, 50, 150);
-        let result = undo_mgr.apply_undo(&mut slashing, request2, 150);
-        assert!(result.is_err());
-
-        // Third undo at round 200 — should succeed (still has one offense in history)
-        let request3 = make_request(n, 50, 200);
-        undo_mgr.apply_undo(&mut slashing, request3, 200).unwrap();
-        assert_eq!(undo_mgr.total_undos(), 2);
+        undo_mgr
+            .apply_undo(&mut slashing, signed_request(n, 50, 100, &[(0, &gov)]), 100)
+            .unwrap();
+        // Second undo at round 150 — within the interval, rejected.
+        assert!(undo_mgr
+            .apply_undo(&mut slashing, signed_request(n, 50, 150, &[(0, &gov)]), 150)
+            .is_err());
+        // Third at round 200 — interval elapsed, succeeds.
+        undo_mgr
+            .apply_undo(&mut slashing, signed_request(n, 50, 200, &[(0, &gov)]), 200)
+            .unwrap();
+        assert_eq!(undo_mgr.total_undos(&slashing), 2);
     }
 
     #[test]
     fn test_can_undo_rate_limit() {
-        let mut undo_mgr = SlashingUndoManager::with_interval(100);
+        let gov = gov_key(7);
+        let mut slashing = SlashingEngine::new_in_memory(DEFAULT_SLASH_THRESHOLD, DEFAULT_EJECTION_THRESHOLD);
+        let mut undo_mgr = governed(&gov, 100);
         let n = node(4);
+        slashing.register_validator(n, 10_000);
+        slashing.record_offense(n, SlashOffense::Equivocation);
 
-        assert!(undo_mgr.can_undo(&n, 0));
-        undo_mgr.last_undo_round.insert(n, 50);
-        assert!(!undo_mgr.can_undo(&n, 100)); // 100 - 50 = 50 < 100
-        assert!(undo_mgr.can_undo(&n, 150)); // 150 - 50 = 100 >= 100
+        assert!(undo_mgr.can_undo(&slashing, &n, 0));
+        undo_mgr
+            .apply_undo(&mut slashing, signed_request(n, 50, 50, &[(0, &gov)]), 50)
+            .unwrap();
+        assert!(!undo_mgr.can_undo(&slashing, &n, 100)); // 100 - 50 = 50 < 100
+        assert!(undo_mgr.can_undo(&slashing, &n, 150)); // 150 - 50 = 100 >= 100
     }
 
     #[test]
     fn test_undo_no_slash_points() {
+        let gov = gov_key(7);
         let mut slashing = SlashingEngine::new_in_memory(DEFAULT_SLASH_THRESHOLD, DEFAULT_EJECTION_THRESHOLD);
-        let mut undo_mgr = SlashingUndoManager::new();
+        let mut undo_mgr = SlashingUndoManager::with_governance(authority_of(&gov));
 
         let n = node(5);
         slashing.register_validator(n, 10_000);
-        // No offense recorded — slash points = 0
-
-        let request = make_request(n, 50, 100);
-        let result = undo_mgr.apply_undo(&mut slashing, request, 100);
-        assert!(result.is_err());
+        // No offense recorded — nothing to undo.
+        let request = signed_request(n, 50, 100, &[(0, &gov)]);
+        assert!(undo_mgr.apply_undo(&mut slashing, request, 100).is_err());
     }
 
     #[test]
     fn test_audit_log() {
+        let gov = gov_key(7);
         let mut slashing = SlashingEngine::new_in_memory(DEFAULT_SLASH_THRESHOLD, DEFAULT_EJECTION_THRESHOLD);
-        let mut undo_mgr = SlashingUndoManager::new();
+        let mut undo_mgr = SlashingUndoManager::with_governance(authority_of(&gov));
 
         let n1 = node(10);
         let n2 = node(20);
-
         slashing.register_validator(n1, 10_000);
         slashing.register_validator(n2, 10_000);
         slashing.record_offense(n1, SlashOffense::LivenessViolation);
         slashing.record_offense(n2, SlashOffense::LivenessViolation);
 
         undo_mgr
-            .apply_undo(&mut slashing, make_request(n1, 50, 100), 100)
+            .apply_undo(&mut slashing, signed_request(n1, 50, 100, &[(0, &gov)]), 100)
             .unwrap();
         undo_mgr
-            .apply_undo(&mut slashing, make_request(n2, 50, 100), 100)
+            .apply_undo(&mut slashing, signed_request(n2, 50, 100, &[(0, &gov)]), 100)
             .unwrap();
 
-        assert_eq!(undo_mgr.audit_log().len(), 2);
-        assert_eq!(undo_mgr.history(&n1).len(), 1);
-        assert_eq!(undo_mgr.history(&n2).len(), 1);
+        assert_eq!(undo_mgr.audit_log(&slashing).len(), 2);
+        assert_eq!(undo_mgr.history(&slashing, &n1).len(), 1);
+        assert_eq!(undo_mgr.history(&slashing, &n2).len(), 1);
     }
 
     #[test]
-    fn test_default_undo_manager() {
-        let mgr = SlashingUndoManager::default();
-        assert!(mgr.audit_log().is_empty());
-        assert_eq!(mgr.total_undos(), 0);
-    }
-
-    #[test]
-    fn test_slashing_undo_request_fields() {
-        let request = SlashingUndoRequest {
-            validator_id: node(42),
-            slashed_round: 50,
-            undo_round: 100,
-            proposal_hash: [2u8; 32],
-            reason: "Bug fix".to_string(),
-        };
-        assert_eq!(request.validator_id[0], 42);
-        assert_eq!(request.slashed_round, 50);
-        assert_eq!(request.undo_round, 100);
-        assert_eq!(request.proposal_hash, [2u8; 32]);
-        assert_eq!(request.reason, "Bug fix");
+    fn governance_authority_rejects_bad_config() {
+        assert!(GovernanceAuthority::new(vec![], 1).is_err());
+        assert!(GovernanceAuthority::new(vec![[1u8; 32]], 0).is_err());
+        assert!(GovernanceAuthority::new(vec![[1u8; 32]], 2).is_err());
+        assert!(GovernanceAuthority::new(vec![[1u8; 32]], 1).is_ok());
     }
 
     #[test]
@@ -477,8 +666,6 @@ mod tests {
             min_interval: 100,
         };
         assert!(e.to_string().contains("rate limit"));
-        assert!(e.to_string().contains("50"));
-        assert!(e.to_string().contains("75"));
 
         let e = SlashingUndoError::NoOffenseHistory([1, 2, 3, 4]);
         assert!(e.to_string().contains("no offense history"));


### PR DESCRIPTION
## Summary

**AUDIT-2026-07 C6** (#344, mainnet blocker) — two flaws collapsed the penalty model:

1. **Unauthenticated undo.** `apply_undo` carried a `proposal_hash` but never verified any governance decision — **anyone with API access could reverse any slash**.
2. **Non-persistent rate limit.** The one-undo-per-interval limit and the audit log lived only in the undo manager's memory, so a **restart reset `last_undo_round`** and let the cap be bypassed.

## Fixes

**Governance authorization**
- `SlashingUndoRequest` now carries `governance_signatures`. `GovernanceAuthority` holds the registered governance key set + threshold — a node-operator/genesis config, **not settable from a consensus payload** (the same fail-closed registry discipline as C4/C9).
- `apply_undo` verifies at least `threshold` **distinct** valid Ed25519 signatures over a domain-separated authorization commitment (validator, slashed/undo rounds, proposal hash, reason) before doing anything. A manager built without an authority **refuses every undo** (fail closed).

**Persistent rate limit + audit**
- `last_undo_round` and `undo_audit_log` moved into `SlashingState`, so they persist in the same redb store — and, via the new `SlashingEngine::record_undo`, in the **same transaction** as the slash-point decrement (rate-limit stamp + audit entry + point change are one atomic persisted write, with snapshot/rollback on persist failure).
- The undo manager reads the rate limit and audit log from persisted state instead of its own memory. `SlashingUndoRecord` moved to `slashing` (re-exported from `slashing_undo` for the existing path). New `SlashingState` fields are `#[serde(default)]` — old persisted state loads unchanged.

## Testing (14 tests, all green)

- **`undo_signed_by_wrong_key_is_rejected`** — THE regression: an attacker's own signature is rejected (the old code applied *any* undo).
- **`undo_without_governance_authority_is_rejected`** / **`unsigned_undo_is_rejected`** — fail closed.
- **`threshold_requires_multiple_signers`** — 2-of-3 needs two distinct keys.
- **`rate_limit_survives_a_restart`** — persist an undo, reopen the redb store, confirm `last_undo_round` + audit log survived and a second undo within the interval is still rate-limited (the memory-only version reset here).

Full `omnia-consensus` suite green (327 lib + doctests); node/substrate build; both CI clippy gates + `cargo doc -D warnings` + `fmt` clean.

## Scope

This fully closes both audited flaws. In production the governance keys are the council's public keys (or the threshold-BLS group from C2); wiring the authority to a live on-chain governance module (rather than static config) is a natural follow-up but not required to close the vulnerability.