### PR TITLE
fix(node): reject known-weak JWT secret at startup + require it in compose (C11, #349)

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -1,3 +1,23 @@
+# Copy this file to `docker/.env` and fill in real values before running
+# any of the docker-compose stacks. `docker/.env` is gitignored.
+
+# ---------------------------------------------------------------------------
+# OMNIA_JWT_SECRET (REQUIRED)
+# ---------------------------------------------------------------------------
+# HMAC-SHA256 secret used to sign and verify node API JWTs. The compose files
+# reference it with the required-variable syntax (${OMNIA_JWT_SECRET:?...}),
+# so `docker compose up` fails fast if it is unset — there is deliberately no
+# insecure default. The node itself also refuses to start if the secret is a
+# known-weak / placeholder value or shorter than 32 bytes.
+#
+# Generate a strong, unique secret (do NOT reuse the example below):
+#   openssl rand -hex 32
+#
+# Every node in a single testnet must share the SAME secret.
+OMNIA_JWT_SECRET=REPLACE_ME_WITH_openssl_rand_hex_32
+
+# ---------------------------------------------------------------------------
 # Grafana admin password for the monitoring stack.
 # Change this before deploying to any shared or production environment.
+# ---------------------------------------------------------------------------
 GRAFANA_ADMIN_PASSWORD=change-me

--- a/docker/docker-compose.testnet.yml
+++ b/docker/docker-compose.testnet.yml
@@ -32,7 +32,7 @@ services:
       - OMNIA_HTTP_PORT=8080
       - OMNIA_DATA_DIR=/app/data
       - OMNIA_TOTAL_NODES=3
-      - OMNIA_JWT_SECRET=${OMNIA_JWT_SECRET:-omnia-testnet-jwt-secret-CHANGE-ME}
+      - OMNIA_JWT_SECRET=${OMNIA_JWT_SECRET:?set OMNIA_JWT_SECRET (see docker/.env.example)}
       - OMNIA_AUTHORIZED_CALLERS=admin-caller
       - OMNIA_RATE_LIMIT_RPS=${OMNIA_RATE_LIMIT_RPS:-10}
       - OMNIA_LANE0_VALIDATORS=${OMNIA_LANE0_VALIDATORS:-}
@@ -69,7 +69,7 @@ services:
       - OMNIA_HTTP_PORT=8080
       - OMNIA_DATA_DIR=/app/data
       - OMNIA_TOTAL_NODES=3
-      - OMNIA_JWT_SECRET=${OMNIA_JWT_SECRET:-omnia-testnet-jwt-secret-CHANGE-ME}
+      - OMNIA_JWT_SECRET=${OMNIA_JWT_SECRET:?set OMNIA_JWT_SECRET (see docker/.env.example)}
       - OMNIA_AUTHORIZED_CALLERS=admin-caller
       - OMNIA_RATE_LIMIT_RPS=${OMNIA_RATE_LIMIT_RPS:-10}
       - OMNIA_LANE0_VALIDATORS=${OMNIA_LANE0_VALIDATORS:-}
@@ -99,7 +99,7 @@ services:
       - OMNIA_HTTP_PORT=8080
       - OMNIA_DATA_DIR=/app/data
       - OMNIA_TOTAL_NODES=3
-      - OMNIA_JWT_SECRET=${OMNIA_JWT_SECRET:-omnia-testnet-jwt-secret-CHANGE-ME}
+      - OMNIA_JWT_SECRET=${OMNIA_JWT_SECRET:?set OMNIA_JWT_SECRET (see docker/.env.example)}
       - OMNIA_AUTHORIZED_CALLERS=admin-caller
       - OMNIA_RATE_LIMIT_RPS=${OMNIA_RATE_LIMIT_RPS:-10}
       - OMNIA_LANE0_VALIDATORS=${OMNIA_LANE0_VALIDATORS:-}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - OMNIA_DATA_DIR=/app/data
       - OMNIA_TOTAL_NODES=5
       - OMNIA_CORS_ORIGINS=*
-      - OMNIA_JWT_SECRET=${OMNIA_JWT_SECRET:-omnia-testnet-jwt-secret-CHANGE-ME}
+      - OMNIA_JWT_SECRET=${OMNIA_JWT_SECRET:?set OMNIA_JWT_SECRET (see docker/.env.example)}
       - OMNIA_AUTHORIZED_CALLERS=admin-caller
       - OMNIA_RATE_LIMIT_RPS=${OMNIA_RATE_LIMIT_RPS:-10}
       - OMNIA_LANE0_VALIDATORS=${OMNIA_LANE0_VALIDATORS:-}
@@ -51,7 +51,7 @@ services:
       - OMNIA_DATA_DIR=/app/data
       - OMNIA_TOTAL_NODES=5
       - OMNIA_CORS_ORIGINS=*
-      - OMNIA_JWT_SECRET=${OMNIA_JWT_SECRET:-omnia-testnet-jwt-secret-CHANGE-ME}
+      - OMNIA_JWT_SECRET=${OMNIA_JWT_SECRET:?set OMNIA_JWT_SECRET (see docker/.env.example)}
       - OMNIA_AUTHORIZED_CALLERS=admin-caller
       - OMNIA_RATE_LIMIT_RPS=${OMNIA_RATE_LIMIT_RPS:-10}
       - OMNIA_LANE0_VALIDATORS=${OMNIA_LANE0_VALIDATORS:-}
@@ -79,7 +79,7 @@ services:
       - OMNIA_DATA_DIR=/app/data
       - OMNIA_TOTAL_NODES=5
       - OMNIA_CORS_ORIGINS=*
-      - OMNIA_JWT_SECRET=${OMNIA_JWT_SECRET:-omnia-testnet-jwt-secret-CHANGE-ME}
+      - OMNIA_JWT_SECRET=${OMNIA_JWT_SECRET:?set OMNIA_JWT_SECRET (see docker/.env.example)}
       - OMNIA_AUTHORIZED_CALLERS=admin-caller
       - OMNIA_RATE_LIMIT_RPS=${OMNIA_RATE_LIMIT_RPS:-10}
       - OMNIA_LANE0_VALIDATORS=${OMNIA_LANE0_VALIDATORS:-}
@@ -109,7 +109,7 @@ services:
       - OMNIA_DATA_DIR=/app/data
       - OMNIA_TOTAL_NODES=5
       - OMNIA_CORS_ORIGINS=*
-      - OMNIA_JWT_SECRET=${OMNIA_JWT_SECRET:-omnia-testnet-jwt-secret-CHANGE-ME}
+      - OMNIA_JWT_SECRET=${OMNIA_JWT_SECRET:?set OMNIA_JWT_SECRET (see docker/.env.example)}
       - OMNIA_AUTHORIZED_CALLERS=admin-caller
       - OMNIA_RATE_LIMIT_RPS=${OMNIA_RATE_LIMIT_RPS:-10}
       - OMNIA_LANE0_VALIDATORS=${OMNIA_LANE0_VALIDATORS:-}
@@ -141,7 +141,7 @@ services:
       - OMNIA_DATA_DIR=/app/data
       - OMNIA_TOTAL_NODES=5
       - OMNIA_CORS_ORIGINS=*
-      - OMNIA_JWT_SECRET=${OMNIA_JWT_SECRET:-omnia-testnet-jwt-secret-CHANGE-ME}
+      - OMNIA_JWT_SECRET=${OMNIA_JWT_SECRET:?set OMNIA_JWT_SECRET (see docker/.env.example)}
       - OMNIA_AUTHORIZED_CALLERS=admin-caller
       - OMNIA_RATE_LIMIT_RPS=${OMNIA_RATE_LIMIT_RPS:-10}
       - OMNIA_LANE0_VALIDATORS=${OMNIA_LANE0_VALIDATORS:-}

--- a/node/src/api/auth.rs
+++ b/node/src/api/auth.rs
@@ -181,6 +181,89 @@ pub struct CallerIdentity {
 /// lifetime but can be reset in tests via \[`reset_jwt_secret_for_test`\].
 static JWT_SECRET: StdMutex<Option<Option<String>>> = StdMutex::new(None);
 
+/// Minimum acceptable length (in bytes) for `OMNIA_JWT_SECRET`.
+///
+/// HMAC-SHA256 keys shorter than this offer too little entropy to resist
+/// offline brute force. 32 bytes matches the digest width and is the
+/// value `openssl rand -hex 32` / `-base64 32` produce.
+pub const MIN_JWT_SECRET_LEN: usize = 32;
+
+/// Publicly-known or trivially-guessable JWT secrets the node refuses to
+/// boot with (compared case-insensitively, after trimming). The compose
+/// files historically defaulted to `omnia-testnet-jwt-secret-CHANGE-ME`,
+/// so any operator who didn't override it shipped a forgeable secret
+/// (AUDIT-2026-07 C11, #349). Substrings `change-me` / `changeme` are also
+/// rejected separately, so variants of the placeholder are caught too.
+const WEAK_JWT_SECRETS: &[&str] = &[
+    "omnia-testnet-jwt-secret-change-me",
+    "secret",
+    "jwt-secret",
+    "jwtsecret",
+    "password",
+    "changeme",
+    "change-me",
+    "test",
+    "test-secret",
+    "testsecret",
+    "insecure",
+    "default",
+    "admin",
+];
+
+/// The configured `OMNIA_JWT_SECRET` is unsafe to run with.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum WeakJwtSecretError {
+    /// The secret is set but empty (or all whitespace).
+    #[error("OMNIA_JWT_SECRET is empty — set a strong secret, e.g. `openssl rand -hex 32`")]
+    Empty,
+    /// The secret is a publicly-known placeholder or a trivially weak value.
+    #[error(
+        "OMNIA_JWT_SECRET is a publicly-known or trivially weak value — refusing to start. \
+         Generate a strong, unique secret, e.g. `openssl rand -hex 32`"
+    )]
+    KnownWeak,
+    /// The secret is shorter than [`MIN_JWT_SECRET_LEN`] bytes.
+    #[error(
+        "OMNIA_JWT_SECRET is too short ({0} bytes); require at least 32 bytes of entropy. \
+         Generate one with `openssl rand -hex 32`"
+    )]
+    TooShort(usize),
+}
+
+/// Validate the strength of the configured `OMNIA_JWT_SECRET` at startup
+/// (AUDIT-2026-07 C11, #349).
+///
+/// Returns `Ok(())` when the variable is **unset** — that is a distinct,
+/// separately-handled condition (the auth middleware then rejects every
+/// authenticated request; it is never an auth *bypass*). When the variable
+/// is set, the value must not be empty, must not be a known-weak/placeholder
+/// secret, and must be at least [`MIN_JWT_SECRET_LEN`] bytes. Callers should
+/// treat an `Err` as fatal and refuse to start.
+pub fn validate_jwt_secret_strength() -> Result<(), WeakJwtSecretError> {
+    match std::env::var("OMNIA_JWT_SECRET") {
+        Err(_) => Ok(()),
+        Ok(secret) => check_jwt_secret_strength(&secret),
+    }
+}
+
+/// Pure strength check for a candidate secret — factored out of
+/// [`validate_jwt_secret_strength`] so it is unit-testable without touching
+/// process environment variables.
+fn check_jwt_secret_strength(secret: &str) -> Result<(), WeakJwtSecretError> {
+    let trimmed = secret.trim();
+    if trimmed.is_empty() {
+        return Err(WeakJwtSecretError::Empty);
+    }
+    let lower = trimmed.to_ascii_lowercase();
+    if lower.contains("change-me") || lower.contains("changeme") || WEAK_JWT_SECRETS.contains(&lower.as_str()) {
+        return Err(WeakJwtSecretError::KnownWeak);
+    }
+    if trimmed.len() < MIN_JWT_SECRET_LEN {
+        return Err(WeakJwtSecretError::TooShort(trimmed.len()));
+    }
+    Ok(())
+}
+
 /// Initialise the JWT secret cache. Called once at application startup.
 ///
 /// This must be invoked before any request hits the auth middleware so
@@ -788,5 +871,74 @@ mod tests {
     fn test_default_cors_layer() {
         let _layer = default_cors_layer();
         // If this compiles and doesn't panic, the CORS layer is valid.
+    }
+
+    // ---- AUDIT-2026-07 C11 (#349): weak JWT secret denylist ----
+
+    #[test]
+    fn test_check_jwt_secret_rejects_compose_default() {
+        // The exact publicly-known compose default must be rejected.
+        assert_eq!(
+            check_jwt_secret_strength("omnia-testnet-jwt-secret-CHANGE-ME"),
+            Err(WeakJwtSecretError::KnownWeak)
+        );
+    }
+
+    #[test]
+    fn test_check_jwt_secret_rejects_changeme_variants_case_insensitive() {
+        for weak in [
+            "CHANGE-ME",
+            "changeme",
+            "please-CHANGEME-now-xxxxxxxxxxxxxxxxxxxx",
+            "my-change-me-secret-value-still-weak-yy",
+            "  Secret  ",
+            "PASSWORD",
+            "admin",
+        ] {
+            assert_eq!(
+                check_jwt_secret_strength(weak),
+                Err(WeakJwtSecretError::KnownWeak),
+                "expected {weak:?} to be rejected as known-weak"
+            );
+        }
+    }
+
+    #[test]
+    fn test_check_jwt_secret_rejects_empty() {
+        assert_eq!(check_jwt_secret_strength(""), Err(WeakJwtSecretError::Empty));
+        assert_eq!(check_jwt_secret_strength("   "), Err(WeakJwtSecretError::Empty));
+    }
+
+    #[test]
+    fn test_check_jwt_secret_rejects_short() {
+        // 31 bytes: one under the floor, and not otherwise weak.
+        let short = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d"; // 31 chars
+        assert_eq!(short.len(), 31);
+        assert_eq!(check_jwt_secret_strength(short), Err(WeakJwtSecretError::TooShort(31)));
+    }
+
+    #[test]
+    fn test_check_jwt_secret_accepts_strong() {
+        // A long random hex secret as `openssl rand -hex 32` would produce.
+        let strong = "9f8c1e2d3a4b5c6d7e8f90a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8091a2b3";
+        assert!(strong.len() >= MIN_JWT_SECRET_LEN);
+        assert_eq!(check_jwt_secret_strength(strong), Ok(()));
+    }
+
+    #[test]
+    fn test_validate_jwt_secret_strength_ok_when_unset() {
+        // Unset is not a weak-secret error (handled separately by the
+        // middleware, which rejects authenticated requests).
+        let _lock = JWT_SECRET_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::remove_var("OMNIA_JWT_SECRET");
+        assert_eq!(validate_jwt_secret_strength(), Ok(()));
+    }
+
+    #[test]
+    fn test_validate_jwt_secret_strength_rejects_env_default() {
+        let _lock = JWT_SECRET_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::set_var("OMNIA_JWT_SECRET", "omnia-testnet-jwt-secret-CHANGE-ME");
+        assert_eq!(validate_jwt_secret_strength(), Err(WeakJwtSecretError::KnownWeak));
+        std::env::remove_var("OMNIA_JWT_SECRET");
     }
 }

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -130,7 +130,16 @@ async fn main() -> Result<()> {
     // 2. Initialize tracing with the configured log level
     init_tracing(&config.log_level);
 
-    // 2b. Initialize the JWT secret cache from the environment.
+    // 2b. Reject known-weak / placeholder JWT secrets before anything else
+    // touches auth (AUDIT-2026-07 C11, #349). An operator who shipped the
+    // old compose default would otherwise run with a forgeable, publicly
+    // known secret. An unset secret is allowed here (the auth middleware
+    // rejects authenticated requests in that case — it is never a bypass).
+    if let Err(e) = omnia_node::api::auth::validate_jwt_secret_strength() {
+        anyhow::bail!("Refusing to start: {e}");
+    }
+
+    // 2c. Initialize the JWT secret cache from the environment.
     // This must happen before any request hits the auth middleware.
     omnia_node::api::auth::init_jwt_secret();
 

--- a/node/tests/docker_compose_e2e.rs
+++ b/node/tests/docker_compose_e2e.rs
@@ -44,6 +44,15 @@ const PROJECT_ROOT: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/..");
 /// Relative path to the 5-node Docker Compose file from the project root.
 const COMPOSE_FILE: &str = "docker/docker-compose.yml";
 
+/// Strong JWT secret injected into the compose environment for the e2e run.
+///
+/// The compose files now require `OMNIA_JWT_SECRET` (`${...:?}`) and the node
+/// rejects known-weak / too-short secrets at startup (AUDIT-2026-07 C11,
+/// #349), so the test must deploy like a real operator would — with a
+/// strong, explicitly-set secret. This is a throwaway 64-hex value used only
+/// by the ephemeral test stack.
+const TEST_COMPOSE_JWT_SECRET: &str = "e2e0f1a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d5e6f708192a3b4c5d6e7";
+
 /// Host ports mapped to each of the 5 nodes.
 /// Bootstrap = 9090, node-1 = 9091, …, node-4 = 9094.
 const NODE_PORTS: &[u16] = &[9090, 9091, 9092, 9093, 9094];
@@ -96,6 +105,7 @@ impl ComposeGuard {
                 "--timeout",
                 "30",
             ])
+            .env("OMNIA_JWT_SECRET", TEST_COMPOSE_JWT_SECRET)
             .current_dir(&self.project_root)
             .status()
             .expect("failed to run docker compose down");
@@ -130,6 +140,7 @@ fn compose_up(project_root: &PathBuf) {
     eprintln!("[docker-e2e] Starting Docker Compose stack (this may take a while on first run)…");
     let output = Command::new("docker")
         .args(["compose", "-f", COMPOSE_FILE, "up", "-d", "--build", "--wait"])
+        .env("OMNIA_JWT_SECRET", TEST_COMPOSE_JWT_SECRET)
         .current_dir(project_root)
         .output()
         .expect("failed to run docker compose up");
@@ -446,11 +457,10 @@ async fn test_docker_compose_5node_e2e() {
         "Register operation should be processed"
     );
 
-    // Mint UBC to the DID (requires OMNIA_AUTHORIZED_CALLERS to include
-    // the anonymous caller; in the Docker setup without OMNIA_JWT_SECRET,
-    // auth is skipped so the caller is "__anonymous__". Since OMNIA_AUTHORIZED_CALLERS
-    // is not set, mint may fail with 403. We test that the shard operation
-    // endpoint is reachable and functioning — a 403 means auth is working.
+    // Mint UBC to the DID (a privileged shard op). OMNIA_AUTHORIZED_CALLERS
+    // is not configured in this stack, so the caller is not privileged and
+    // mint may fail with 403. We test that the shard operation endpoint is
+    // reachable and functioning — a 403 means authorization is being enforced.
     let mut mint_params = serde_json::Map::new();
     mint_params.insert("did".to_string(), json!(test_did));
     mint_params.insert("amount".to_string(), json!(1000));


### PR DESCRIPTION
## 🚀 Description

Closes the publicly-known-JWT-secret operational flaw with two layers of defense:

- **Node startup denylist** — `validate_jwt_secret_strength()` (in `node/src/api/auth.rs`) rejects an empty, known-weak, or too-short (`< 32` byte) `OMNIA_JWT_SECRET` and the node refuses to boot with a clear remediation hint (`openssl rand -hex 32`). An **unset** secret is still permitted — that is a distinct, already-handled condition (the auth middleware rejects authenticated requests; it is never a bypass). The denylist catches the exact compose placeholder, any `change-me` / `changeme` variant (case-insensitively), and a handful of trivially weak values.
- **Compose hardening** — `docker-compose.yml` and `docker-compose.testnet.yml` now use Docker's required-variable syntax `${OMNIA_JWT_SECRET:?...}` (matching `docker-compose.wan.yml`), so `docker compose up` fails fast when the secret is unset instead of silently substituting the insecure default. `docker/.env.example` documents generating a strong secret.

## 💡 Motivation and Context

Fixes #349 (AUDIT-2026-07 critical C11). The compose files defaulted `OMNIA_JWT_SECRET` to `omnia-testnet-jwt-secret-CHANGE-ME`, so any operator who didn't read the compose file shipped a forgeable, publicly-known JWT secret — an authentication bypass on misconfigured deployments.

## ✅ How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing

New unit tests in `node/src/api/auth.rs` cover the denylist: the exact compose default, case-insensitive `change-me` variants and weak words, empty, too-short (31 bytes), a strong secret that passes, and the env-driven `validate_jwt_secret_strength()` (unset → OK, default → rejected). The `docker-tests`-gated e2e harness now injects a strong throwaway secret so it deploys like a real operator.

Gates run locally: `cargo fmt`, `cargo test -p omnia-node --lib auth` (28 pass), workspace `--lib` and `--all-targets` clippy (`-D warnings -D unwrap_used`), and `RUSTDOCFLAGS="-D warnings" cargo doc -p omnia-node` — all clean.

## 📝 Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## ➕ Additional Context

Backward compatible for correctly-configured deployments (a strong, explicitly-set secret keeps working). Operators relying on the insecure default will now get a fast, actionable failure — which is the point. One of the two remaining AUDIT-2026-07 criticals; C10 (#348) follows.