### PR TITLE
fix(consensus): enforce leader eligibility on the propose path (H3, #353)

### DIFF
--- a/omnia-consensus/src/consensus.rs
+++ b/omnia-consensus/src/consensus.rs
@@ -981,6 +981,53 @@ impl<S: SlashingBackend> ConsensusEngine<S> {
         candidates.iter().map(|(id, (_, stake))| (*id, *stake)).collect()
     }
 
+    /// Whether `node` is the **primary** VRF-elected leader for `round`
+    /// (AUDIT-2026-07 H3, #353). Ignores slashing/failover — use
+    /// [`is_active_leader_for_round`](Self::is_active_leader_for_round) to
+    /// gate proposing.
+    pub fn is_leader_for_round(
+        &self,
+        node: &NodeId,
+        candidates: &HashMap<NodeId, (omnia_crypto::NodeKeypair, u64)>,
+        round: u64,
+    ) -> bool {
+        self.compute_leader(candidates, round)
+            .map(|leader| &leader == node)
+            .unwrap_or(false)
+    }
+
+    /// The **active** leader for `round`: the highest-ranked member of the
+    /// leader schedule (primary + `backup_depth` backups) that is not
+    /// slashed (AUDIT-2026-07 H3, #353). This provides zero-timeout failover
+    /// — if the primary is slashed, the first healthy backup is entitled to
+    /// propose. Every honest node computes the identical schedule, so exactly
+    /// one node is the active leader. Returns `None` only if the schedule is
+    /// empty (no candidates) or every scheduled member is slashed.
+    pub fn active_leader_for_round(
+        &self,
+        candidates: &HashMap<NodeId, (omnia_crypto::NodeKeypair, u64)>,
+        round: u64,
+        backup_depth: usize,
+    ) -> Option<NodeId> {
+        self.compute_leader_schedule(candidates, round, backup_depth)
+            .into_iter()
+            .find(|node| !self.is_slashed(node))
+    }
+
+    /// Whether `node` is the active leader for `round` and therefore entitled
+    /// to propose (AUDIT-2026-07 H3, #353). The propose path **must** gate on
+    /// this so that "leader-based consensus" is enforced rather than
+    /// decorative — a non-leader that proposes out of turn is refused.
+    pub fn is_active_leader_for_round(
+        &self,
+        node: &NodeId,
+        candidates: &HashMap<NodeId, (omnia_crypto::NodeKeypair, u64)>,
+        round: u64,
+        backup_depth: usize,
+    ) -> bool {
+        self.active_leader_for_round(candidates, round, backup_depth).as_ref() == Some(node)
+    }
+
     /// Evolve the leader-election beacon by folding the committed DAG
     /// frontier into it (AUDIT-2026-07 C1, #339).
     ///
@@ -1594,6 +1641,85 @@ mod tests {
         assert_eq!(supermajority(7), 5);
         assert_eq!(supermajority(10), 7);
         assert_eq!(supermajority(100), 67);
+    }
+
+    // ── AUDIT-2026-07 H3 (#353): leader enforcement on the propose path ──
+
+    fn leader_test_candidates(n: u8) -> HashMap<NodeId, (omnia_crypto::NodeKeypair, u64)> {
+        let mut candidates = HashMap::new();
+        for i in 1..=n {
+            candidates.insert(node(i), (omnia_crypto::generate_keypair(), 100u64));
+        }
+        candidates
+    }
+
+    #[test]
+    fn test_exactly_one_primary_leader_per_round() {
+        let mut config = test_config();
+        config.total_nodes = 5;
+        config.round_seed = [7u8; 32];
+        let engine = ConsensusEngine::new(config, SlashingEngine::new_in_memory(1, 1000));
+        let candidates = leader_test_candidates(5);
+        let round = 1;
+
+        let leader = engine.compute_leader(&candidates, round).unwrap();
+        let flagged: Vec<&NodeId> = candidates
+            .keys()
+            .filter(|n| engine.is_leader_for_round(n, &candidates, round))
+            .collect();
+        assert_eq!(flagged.len(), 1, "exactly one node is the primary leader");
+        assert_eq!(*flagged[0], leader);
+    }
+
+    #[test]
+    fn test_only_active_leader_may_propose() {
+        let mut config = test_config();
+        config.total_nodes = 5;
+        config.round_seed = [9u8; 32];
+        let engine = ConsensusEngine::new(config, SlashingEngine::new_in_memory(1, 1000));
+        let candidates = leader_test_candidates(5);
+        let round = 2;
+
+        let leader = engine.compute_leader(&candidates, round).unwrap();
+        // With no one slashed, the active leader is the primary.
+        assert_eq!(engine.active_leader_for_round(&candidates, round, 4), Some(leader));
+        assert!(engine.is_active_leader_for_round(&leader, &candidates, round, 4));
+        // Every non-leader is refused proposing rights.
+        for n in candidates.keys().filter(|n| **n != leader) {
+            assert!(
+                !engine.is_active_leader_for_round(n, &candidates, round, 4),
+                "a non-leader must not be entitled to propose"
+            );
+        }
+    }
+
+    #[test]
+    fn test_active_leader_fails_over_when_primary_slashed() {
+        let mut config = test_config();
+        config.total_nodes = 5;
+        config.round_seed = [11u8; 32];
+        let round = 3;
+        let candidates = leader_test_candidates(5);
+
+        // Probe the schedule with an unslashed engine.
+        let probe = ConsensusEngine::new(config.clone(), SlashingEngine::new_in_memory(1, 1000));
+        let schedule = probe.compute_leader_schedule(&candidates, round, 4);
+        let primary = schedule[0];
+        let expected_backup = schedule[1];
+
+        // Slash the primary, then build the real engine with that backend.
+        let mut slashing = SlashingEngine::new_in_memory(1, 1000);
+        slashing.record_offense(primary, SlashOffense::Equivocation);
+        let engine = ConsensusEngine::new(config, slashing);
+        assert!(engine.is_slashed(&primary));
+
+        // Proposing rights fail over to the first healthy backup.
+        assert_eq!(
+            engine.active_leader_for_round(&candidates, round, 4),
+            Some(expected_backup)
+        );
+        assert!(!engine.is_active_leader_for_round(&primary, &candidates, round, 4));
+        assert!(engine.is_active_leader_for_round(&expected_backup, &candidates, round, 4));
     }
 
     #[test]

--- a/substrate/src/lib.rs
+++ b/substrate/src/lib.rs
@@ -175,6 +175,12 @@ pub const TARGET_TPS: u32 = 10_000;
 /// Target latency for finality (milliseconds)
 pub const TARGET_FINALITY_MS: u64 = 5_000;
 
+/// Depth of the VRF leader schedule (primary + backups) consulted when
+/// deciding who may propose a round (AUDIT-2026-07 H3, #353). If the primary
+/// and the first few backups are all slashed/silent, the round falls through
+/// to the normal timeout path.
+const LEADER_SCHEDULE_DEPTH: usize = 4;
+
 /// Parse the consensus seed from the `OMNIA_CONSENSUS_SEED` environment variable.
 ///
 /// Accepts a hex-encoded 64-character (32-byte) seed for cryptographic strength.
@@ -983,16 +989,17 @@ impl Substrate {
         // this stays single-leader.
         let current_round = self.consensus.current_round();
         if !self.validator_candidates.is_empty() {
-            const LEADER_SCHEDULE_DEPTH: usize = 4;
-            let schedule = self.consensus.compute_leader_schedule(
+            // AUDIT-2026-07 H3 (#353): only the round's active leader may
+            // propose. `is_active_leader_for_round` computes the VRF-keyed
+            // schedule and skips slashed members (zero-timeout backup
+            // failover), so leader-based consensus is enforced rather than
+            // decorative. `propose_block` re-checks this as a defensive guard.
+            if self.consensus.is_active_leader_for_round(
+                &self.config.node_id,
                 &self.validator_candidates,
                 current_round,
                 LEADER_SCHEDULE_DEPTH,
-            );
-            let active_leader = schedule.iter().find(|node| !self.consensus.is_slashed(node));
-            if active_leader == Some(&self.config.node_id) {
-                // We are the active leader (primary, or the first
-                // non-slashed backup) — produce a block proposal.
+            ) {
                 self.propose_block(current_round).await;
             }
         }
@@ -1462,6 +1469,23 @@ impl Substrate {
     /// FIND-CRIT-001 FIX: This method is now async to avoid `blocking_write()`
     /// inside an async context, which can deadlock the Tokio runtime.
     async fn propose_block(&mut self, round: u64) -> Vec<EventId> {
+        // AUDIT-2026-07 H3 (#353): defensive re-check — refuse to propose
+        // unless this node is the active leader for the round, so a proposal
+        // can never be produced out of turn even if a caller forgets the
+        // gate. No-op when no validator set is configured (leaderless / test
+        // mode), preserving existing behaviour.
+        if !self.validator_candidates.is_empty()
+            && !self.consensus.is_active_leader_for_round(
+                &self.config.node_id,
+                &self.validator_candidates,
+                round,
+                LEADER_SCHEDULE_DEPTH,
+            )
+        {
+            tracing::warn!(round, "propose_block called by a non-leader — refusing to propose");
+            return Vec::new();
+        }
+
         let pending = self.mempool.drain_up_to(self.max_block_events);
         if pending.is_empty() {
             return Vec::new();


### PR DESCRIPTION
## 🚀 Description

Makes leader-based proposing enforced rather than decorative.

- New `ConsensusEngine` methods: `is_leader_for_round` (strict primary), `active_leader_for_round` (highest-ranked **non-slashed** member of the primary+backups schedule — zero-timeout failover), and `is_active_leader_for_round` (the gate the propose path must use).
- Substrate's block-proposal decision now calls `is_active_leader_for_round` instead of an ad-hoc inline schedule scan, and **`propose_block` re-checks it as a defensive guard** so a proposal can never be produced out of turn even if a caller forgets the gate. Both are no-ops when no validator set is configured (leaderless / test mode), preserving existing behaviour.

## 💡 Motivation and Context

Fixes #353 (AUDIT-2026-07 / H3). The engine exposed `compute_leader` / `compute_leader_schedule` but nothing *required* leadership when proposing — the substrate loop scanned the schedule inline and there was no first-class predicate, so any validator could call `propose_block` out of turn.

The leaderless hashgraph witness/round-advancement mechanics are **deliberately left untouched** — bolting leader gating onto witness creation would risk BFT liveness. Enforcement belongs on who may *propose a block*, which is exactly what the audit calls out. (Related: C1/#339 already made the leader function itself unpredictable.)

## ✅ How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing

New regression tests in `omnia-consensus/src/consensus.rs`:
- `test_exactly_one_primary_leader_per_round` — exactly one node is the primary leader.
- `test_only_active_leader_may_propose` — the active leader is entitled to propose; every non-leader is refused.
- `test_active_leader_fails_over_when_primary_slashed` — proposing rights fail over to the first healthy backup when the primary is slashed.

Gates run locally: `cargo fmt`, `cargo test -p omnia-consensus --lib consensus::` (33 pass), workspace `--lib` and `--all-targets` clippy (`-D warnings -D unwrap_used`), and `RUSTDOCFLAGS="-D warnings" cargo doc` for consensus + substrate — all clean.

## 📝 Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## ➕ Additional Context

Third item of the high-severity tier (#351–#376), worked top-down.