### PR TITLE
Harden rotate-jwt-secret.sh against two production footguns

### DIFF
--- a/scripts/rotate-jwt-secret.sh
+++ b/scripts/rotate-jwt-secret.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 # Rotate OMNIA_JWT_SECRET for a docker-compose deployment.
 #
+# Usage:
+#   ./scripts/rotate-jwt-secret.sh [compose-file]
+#
+# PASS THE COMPOSE FILE THAT ACTUALLY GOVERNS THIS HOST. The default below
+# is the local multi-node stack; a geo-distributed WAN member runs
+# `docker/docker-compose.wan.yml`. Rotating against the wrong file silently
+# does nothing to the live node (and may try to start a second stack that
+# fights the running one for port 9090).
+#
 # What it does:
 #   1. Generates a fresh 256-bit secret.
 #   2. Writes it to docker/.env (compose substitutes it into every node).
@@ -15,10 +24,39 @@
 # function (Supabase mode) on the next 401. The Supabase secret MUST be
 # updated in the same sitting or Supabase-mode sign-ins will 401 until
 # it is.
+#
+# MULTI-NODE DEPLOYMENTS: recreating the bootstrap node's container drops
+# its peer connections, and peers do NOT re-dial it (see issue #411). The
+# mesh silently degrades to a partition — the bootstrap node keeps serving
+# HTTP 200 while finalizing nothing. After rotating on the bootstrap node
+# you MUST restart the other nodes. The completion output below spells this
+# out with a verification command.
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
 COMPOSE_FILE="${1:-docker/docker-compose.yml}"
+
+if [ ! -f "${COMPOSE_FILE}" ]; then
+    echo "error: compose file not found: ${COMPOSE_FILE}" >&2
+    echo "Pass the file that governs this host, e.g." >&2
+    echo "  $0 docker/docker-compose.wan.yml" >&2
+    exit 1
+fi
+
+# Compose gives shell environment variables priority over docker/.env, so an
+# exported OMNIA_JWT_SECRET would shadow the value we are about to write and
+# the rotation would silently no-op. Refuse rather than pretend to succeed.
+if [ -n "${OMNIA_JWT_SECRET:-}" ]; then
+    echo "error: OMNIA_JWT_SECRET is set in this shell." >&2
+    echo "Compose prefers shell env over docker/.env, so the rotation would" >&2
+    echo "write a new secret that the containers then ignore. Run:" >&2
+    echo >&2
+    echo "  unset OMNIA_JWT_SECRET" >&2
+    echo >&2
+    echo "then re-run this script." >&2
+    exit 1
+fi
+
 NEW_SECRET=$(openssl rand -hex 32)
 
 touch docker/.env
@@ -36,3 +74,26 @@ echo "  ${NEW_SECRET}"
 echo
 echo "Supabase: Dashboard -> Edge Functions -> Secrets -> OMNIA_JWT_SECRET"
 echo "(or: supabase secrets set OMNIA_JWT_SECRET=${NEW_SECRET} --project-ref <ref>)"
+echo
+echo "----------------------------------------------------------------------"
+echo "MULTI-NODE: restart the other nodes now, or the mesh stays partitioned."
+echo "----------------------------------------------------------------------"
+echo
+echo "Recreating this container dropped its peer connections. Peers do NOT"
+echo "re-dial a bootstrap node that restarts (issue #411), so they will keep"
+echo "running without it and this node will finalize nothing — while still"
+echo "answering HTTP 200. On EVERY other node in the mesh, run:"
+echo
+echo "  cd /opt/omnia-protocol && docker restart omnia-node"
+echo
+echo "Then verify every node reports the full peer count (n-1 peers each):"
+echo
+echo '  for ip in localhost <B-ip> <C-ip>; do'
+echo '    printf "%-16s peers=" "$ip"'
+echo '    curl -s "http://$ip:9090/api/v1/node/info" \'
+echo '      | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['"'"'peers'"'"'], '"'"'lane0_finalized='"'"', d['"'"'lane0'"'"']['"'"'events_finalized'"'"'])"'
+echo '  done'
+echo
+echo "A node reporting fewer peers than expected is partitioned: with equal"
+echo "stake, 3 validators need all 3 acks for Lane 0 quorum, so one missing"
+echo "peer halts finality network-wide."


### PR DESCRIPTION
Both of these were hit during a real rotation on the live WAN testnet.

## 1. Shadowing shell variable silently no-ops the rotation

Compose gives shell environment variables priority over `docker/.env`. If `OMNIA_JWT_SECRET` happens to be exported in the operator's shell (easy to do — e.g. reading the current value to check it), the script writes a fresh secret to `docker/.env` that the containers then **ignore**. The rotation appears to succeed and the old secret stays live.

The script now refuses to run in that state and tells the operator to `unset` it.

## 2. Recreating the bootstrap node partitions the mesh

Peers do not re-dial a bootstrap node that restarts (#411). They keep running without it, so the bootstrap node ends up with `peers: 0`, finalizing nothing — while still answering HTTP 200 and serving balances. That is exactly how the live node sat orphaned for ~4.3 days after a routine rotation, with user-visible finality at zero the whole time and nothing alerting.

Completion output now instructs the operator to restart every other node and prints a copy-pasteable peer-count verification with the expected result stated:

```
MULTI-NODE: restart the other nodes now, or the mesh stays partitioned.

  cd /opt/omnia-protocol && docker restart omnia-node

Then verify every node reports the full peer count (n-1 peers each):

  for ip in localhost <B-ip> <C-ip>; do
    printf "%-16s peers=" "$ip"
    curl -s "http://$ip:9090/api/v1/node/info" \
      | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['peers'], 'lane0_finalized=', d['lane0']['events_finalized'])"
  done
```

## 3. Compose-file argument validation

Errors if the given file doesn't exist, and the header now documents that WAN members must pass `docker/docker-compose.wan.yml`. Rotating against the wrong file does nothing to the live node and can start a second stack that contends for port 9090 — also hit during the incident.

## Verification

- `bash -n` clean.
- Guard confirmed to abort with exit 1 when `OMNIA_JWT_SECRET` is set.
- Printed verification snippet rendered and checked to be valid, copy-pasteable bash (nested quoting is fiddly).

This is mitigation, not a fix — #411 tracks making peers actually re-dial, #412 tracks the runbook updates.