### PR TITLE
feat: configurable mint authority (fixes per-node divergence) + standing-mesh docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ serving traffic, with a full client ecosystem built against it:
 
 | Piece | Where | Status |
 | :---- | :---- | :----- |
-| **Public testnet node** | `https://78.47.43.136.sslip.io` (REST `/api/v1/*`, Swagger UI) | 🟢 Live — **single node, 0 peers** (v0.1.76, protocol `/omnia/4.0.0`) |
+| **Public testnet** | `https://78.47.43.136.sslip.io` (REST `/api/v1/*`, Swagger UI) | 🟢 Live — **3-node geo-distributed mesh**, 2 peers each (v0.1.76, protocol `/omnia/4.0.0`) |
 | **Mobile wallet** | [`Willow7737/Omnia-Wallet`](https://github.com/Willow7737/Omnia-Wallet) (Flutter, Android/iOS) | ✅ v1 shipped |
 | **Web dashboard** | [`Willow7737/omnia-protocol-interface`](https://github.com/Willow7737/omnia-protocol-interface) (Next.js + Supabase) | ✅ Deployed |
 | **Website** | [`Willow7737/omnia-web`](https://github.com/Willow7737/omnia-web) | ✅ Deployed |
@@ -67,29 +67,54 @@ curl https://78.47.43.136.sslip.io/readyz
 
 The full loop — create wallet → challenge/login → registered DID with a 1,000 UBC monthly quota → send → history — is verified end-to-end against this node (see the wallet repo's `tool/e2e_wallet_auth.dart`).
 
-### ⚠️ What "live" means today — read this before quoting the numbers
+### 🌍 The standing network (as of 2026-08-01)
 
-The public endpoint is **one node with no peers**. It answers the REST
-API and the wallet's auth/UBC loop works against it, but it reports
-itself **not ready** for consensus, and it is finalizing nothing:
+A **3-node geo-distributed validator mesh** is running continuously —
+this is a standing network, not a mesh brought up for a benchmark:
+
+| Node | Region | Role | Peers |
+| :--- | :----- | :--- | :---- |
+| **A** `78.47.43.136` | eu-central (Nuremberg) | bootstrap + validator + public ingress | 2 |
+| **B** `178.156.163.211` | us-east (Ashburn) | validator | 2 |
+| **C** `5.223.85.30` | ap-southeast (Singapore) | validator | 2 |
+
+All three on v0.1.76, stake 1 each. Measured RTTs **A↔B 98.9 ms**,
+**A↔C 159.8 ms** — matching the 2026-07-20 benchmark baseline exactly,
+so the WAN figures in [benchmark-gates.md](docs/reference/benchmark-gates.md)
+describe this network rather than a lab.
+
+Only node A exposes HTTP publicly; B and C are validators without public
+ingress, so they are reachable over the P2P mesh but not over the REST
+API. Lane 0 is doing real work on it:
 
 ```jsonc
-// GET /readyz
-{ "status": "not_ready", "reason": "no_peers", "peers": 0, "is_syncing": false }
-// GET /api/v1/node/info  → finalized_height: 0, lane0.events_finalized: 0
+// GET /api/v1/node/info  (node A)
+{ "peers": 2, "lane0": { "acks_accepted": 27, "acks_rejected": 0, "events_finalized": 9 } }
 ```
 
-**There is no standing validator network.** The multi-node results
-below are real measurements from stress runs on a 5-node mesh that was
-brought up for the runs and is not currently running. They are
-reproducible from `docker/` — they are not a description of what the
-public endpoint is doing right now. Recruiting independent validator
-operators is the open problem; see
-[docs/operations/validator-setup.md](docs/operations/validator-setup.md).
+**One honest caveat.** `/readyz` still reports `not_ready`, but the reason
+has changed from `no_peers` to `no_finalization`:
 
-**July 2026 network milestones** — measured on a real 5-node mesh, not
-simulated, during stress runs on the dates given (see
-[benchmark-gates.md](docs/reference/benchmark-gates.md)):
+```jsonc
+{ "status": "not_ready", "reason": "no_finalization", "peers": 2, "is_syncing": false }
+```
+
+Readiness requires `finalized_height > 0`, which counts **Lane 1**
+(canonical DAG consensus) commits — and Lane 1 has committed nothing
+because the network is quiet, not because anything is broken. Lane 0
+fast-path finality is working (9 events finalized, 27 acks accepted,
+zero rejected). Submit traffic and Lane 1 follows.
+
+**Utilization:** the node process uses ~30 MB RSS on a 16 GB host, with
+load average flat at 0.00 over 31 days and 4.7 MB of chain data. Even at
+the documented 10k-burst peak (145 MB RSS) that is ~1% of available
+memory. The fleet is heavily over-provisioned; the smallest instances
+available would carry this network comfortably.
+
+**July 2026 throughput milestones** — measured on a real 5-node mesh, not
+simulated, during stress runs on the dates given. These are load results
+from a mesh sized for the benchmark; the standing network above is the
+3-node one (see [benchmark-gates.md](docs/reference/benchmark-gates.md)):
 
 - **5-node gossipsub mesh over QUIC** — 1,000-event bursts propagate to
   100% of nodes in ~10 s; 5,000-event bursts in ~40–45 s, zero loss.
@@ -305,7 +330,7 @@ cargo bench --no-run
 | Cosmos settlement adapter  | ⚠️ **STUB**             | Implements trait, no-op methods                      |
 | Proof-of-useful-work       | ⚠️ **STUB**             | 3 types defined, no real verification                |
 | Mobile wallet              | ✅ **Shipped (v1)**     | [`Omnia-Wallet`](https://github.com/Willow7737/Omnia-Wallet) — dual-mode auth, live against the testnet node |
-| Validator network          | 🌑 Not started          | Single-node operator currently                       |
+| Validator network          | ✅ **Running** (3 nodes) | Geo-distributed EU/US/Asia mesh — but all three run by the same operator, so not yet trust-distributed |
 | Conviction voting          | 🌑 Not started          | Planned for post-testnet                             |
 | Delegation                 | 🌑 Not started          | Planned for post-testnet                             |
 | Production ZK hash gadget  | ✅ Poseidon implemented | Cauchy MDS + BLAKE3 round constants (not Grain LFSR) |
@@ -436,9 +461,13 @@ _Goal: Performance Validation_
 - 🔄 14 medium-priority findings tracked (see [status.md](docs/reference/status.md))
 - 📋 External security audit
 - ✅ Public testnet endpoint **live** (single node at `78.47.43.136.sslip.io`, 0 peers)
-- 🔄 **Standing validator network — not yet.** Lane 0 finality is proven in
-  5-node stress runs, but no independent operators are running nodes.
-  This is the current critical-path blocker, not a code gap.
+- ✅ **Standing validator network — live.** A 3-node geo-distributed mesh
+  (EU / US-East / Asia) runs continuously with 2 peers each and Lane 0
+  finalizing events. Measured RTTs match the benchmark baseline exactly.
+- 🔄 **Independent operators — not yet.** All three nodes are run by the
+  same operator, so the network is geo-distributed but not yet
+  trust-distributed. Third-party validators are the remaining step; see
+  [validator-setup.md](docs/operations/validator-setup.md).
 
 #### v0.1.69 Critical Security Hardening
 

--- a/docs/operations/validator-setup.md
+++ b/docs/operations/validator-setup.md
@@ -165,7 +165,57 @@ omnia-node --node-id 1 --http-port 8080
 - `OMNIA_JWT_SECRET` — HMAC secret for JWT validation (required; API returns 401 if not set)
 - `OMNIA_AUTHORIZED_CALLERS` — Comma-separated list of authorized caller IDs
 - `OMNIA_RATE_LIMIT_RPS` — Maximum requests per second per IP
+- `OMNIA_MINT_AUTHORITY` — Financial-shard mint authority (see below)
 - Privileged operations (mint, advance_epoch) require admin JWT
+
+---
+
+## Mint authority (financial shard)
+
+The financial shard — the **transferable** ledger, not soulbound UBC —
+accepts a `Mint` only when the event creator matches a configured
+authority. Set it with `--mint-authority` or `OMNIA_MINT_AUTHORITY`, as a
+64-character hex Ed25519 public key:
+
+```sh
+export OMNIA_MINT_AUTHORITY="ed4928c628d1c2c6eae90338905995612959273a5c63f93636c14614ac8737d1"
+```
+
+or in the TOML config:
+
+```toml
+mint_authority = "ed4928c628d1c2c6eae90338905995612959273a5c63f93636c14614ac8737d1"
+```
+
+> ⚠️ **This is a genesis parameter, not a per-node identity. Every node in
+> the network must be configured with the SAME key.**
+>
+> `FinancialState::apply` checks the mint against *its own* configured
+> authority. If node A holds its own key and node B holds its own, a mint
+> created by A is accepted by A and **rejected by B**. The two then
+> disagree about total supply and every balance derived from it — a state
+> divergence consensus cannot repair, because each node is behaving
+> correctly according to its own configuration.
+>
+> Decide the authority once, before launch, and roll it to every node.
+
+**Unset means minting is disabled**, and that is the deliberate default.
+A node that quietly substituted its own key would produce exactly the
+divergence above, and it would look healthy right up until someone minted.
+Transfers work fine with minting disabled — accounts simply start at zero
+until an authority is configured network-wide.
+
+The node logs its choice at startup, so `grep` the boot log to confirm all
+three nodes agree:
+
+```
+INFO Financial shard mint authority configured  authority=ed4928c6…
+WARN No mint_authority configured … minting on the financial shard is DISABLED
+```
+
+A malformed key fails at startup rather than being ignored — the
+alternative is a node that boots cleanly and then rejects every mint,
+which is far harder to trace back to a typo.
 
 ---
 

--- a/docs/stub-inventory.md
+++ b/docs/stub-inventory.md
@@ -2,7 +2,7 @@
 
 This document catalogs all stub, placeholder, and partial implementations in the Omnia Protocol codebase. Items are tracked so they are not mistaken for production-ready features.
 
-> Last updated: 2026-07-18 (post-ADR-025 rollout; live 5-node testnet with measured Lane 0 finality)
+> Last updated: 2026-08-01 (standing 3-node geo-distributed validator mesh; financial ledger + mint authority config)
 
 ---
 
@@ -88,11 +88,18 @@ This document catalogs all stub, placeholder, and partial implementations in the
 - **What shipped**: Flutter wallet with dual-mode auth (on-device Ed25519 challenge/signature login **or** Google/GitHub/email via Supabase + `mint-node-jwt` edge function), UBC balance/send/history with per-transaction detail, governance voting, QR-based transfers, address book, biometric app lock, team news feed, in-app notifications — verified end-to-end against the live testnet node
 - **Node-side support**: `node/src/api/wallet_auth.rs` (`/auth/challenge`, `/auth/login`, `/auth/register`)
 
-### Validator Network — **NOT STARTED** 🌑
+### Validator Network — **RUNNING** (3 nodes) ✅⚠️
 
-- **Status**: No code exists; single-node operator for Phase 0
-- **What's planned**: Multi-validator coordination, staking pool management, auto-scaling validator set
-- **Phase**: Planned for Phase 1
+- **Status**: A standing 3-node geo-distributed mesh (EU-central / US-east /
+  AP-southeast) runs continuously on v0.1.76, 2 peers each, stake 1 each,
+  with Lane 0 finalizing events.
+- **⚠️ Not yet trust-distributed**: all three nodes are operated by the same
+  party. BFT's security argument assumes *independent* operators, so the
+  network is currently fault-tolerant against machine and region failure but
+  not against operator compromise. Third-party validators are the open item.
+- **What's still planned**: staking pool management, auto-scaling validator
+  set, validator onboarding flow
+- **Phase**: Phase 1
 
 ### Conviction Voting — **NOT STARTED** 🌑
 
@@ -130,7 +137,7 @@ This document catalogs all stub, placeholder, and partial implementations in the
 | Celestia Settlement  | 0     | ✅⚠️ IMPLEMENTED (security caveat) | `omnia-adapters/src/settlement/celestia.rs` | Security fix required |
 | Cosmos Settlement    | 0     | ⚠️ STUB                            | `omnia-adapters/src/settlement/cosmos.rs`   | Phase 1               |
 | Mobile Wallet        | [Omnia-Wallet](https://github.com/Willow7737/Omnia-Wallet) | ✅ SHIPPED (v1, July 2026) | Dual-mode auth, live vs. testnet node | Done |
-| Validator Network    | —     | 🌑 NOT STARTED                     | —                                           | Phase 1               |
+| Validator Network    | —     | ✅⚠️ RUNNING (3 nodes, one operator) | —                                           | Phase 1               |
 | Conviction Voting    | 5     | 🌑 NOT STARTED                     | —                                           | Phase 1               |
 | Delegation           | 5     | 🌑 NOT STARTED                     | —                                           | Phase 1               |
 

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -53,6 +53,21 @@ pub struct NodeConfig {
     pub consensus_data_dir: Option<PathBuf>,
     /// Protocol version to advertise on the network.
     pub protocol_version: String,
+    /// Hex-encoded Ed25519 public key authorized to mint on the financial
+    /// shard, or `None` to disable minting entirely.
+    ///
+    /// **This is a network-wide genesis parameter, not a per-node one.**
+    /// `FinancialState::apply` accepts a `Mint` only when the event's
+    /// creator matches the configured authority, so every node must be
+    /// configured with the *same* key. If node A used its own key and node
+    /// B used its own, a mint created by A would be accepted by A and
+    /// rejected by B — the two would disagree about total supply and every
+    /// balance derived from it.
+    ///
+    /// Unset means minting is disabled. That is the safe default: a node
+    /// that silently substitutes its own key would diverge from its peers
+    /// the first time anyone minted.
+    pub mint_authority: Option<[u8; 32]>,
     /// Minimum number of peers required for readiness (default: 1).
     pub readiness_min_peers: usize,
     /// Maximum age of last finalization in rounds for readiness (default: 600).
@@ -105,6 +120,10 @@ pub struct NodeConfigFile {
     pub nonce_data_dir: Option<String>,
     /// Directory for persistent consensus state (redb). If None, consensus state is in-memory only.
     pub consensus_data_dir: Option<String>,
+    /// Hex-encoded Ed25519 public key allowed to mint (64 hex characters).
+    ///
+    /// Must be identical on every node — see [`NodeConfig::mint_authority`].
+    pub mint_authority: Option<String>,
     /// Minimum number of peers required for readiness (default: 1).
     pub readiness_min_peers: Option<usize>,
     /// Maximum age of last finalization in rounds for readiness (default: 600).
@@ -282,6 +301,22 @@ impl NodeConfig {
             .and_then(|fc| fc.consensus_data_dir.clone())
             .map(PathBuf::from);
 
+        // CLI/env wins over the config file, matching every other field.
+        // A malformed key is refused rather than silently ignored: quietly
+        // falling back to "minting disabled" would look identical to a
+        // correct no-mint deployment, and the operator would only find out
+        // when a mint they expected to work was rejected.
+        let mint_authority = args
+            .mint_authority
+            .clone()
+            .or_else(|| file_config.as_ref().and_then(|fc| fc.mint_authority.clone()))
+            .filter(|s| !s.trim().is_empty())
+            .map(|s| parse_mint_authority(s.as_str()))
+            .transpose()
+            .unwrap_or_else(|e| {
+                panic!("Invalid mint_authority: {e}. Expected 64 hex characters (an Ed25519 public key).")
+            });
+
         let readiness_min_peers = file_config.as_ref().and_then(|fc| fc.readiness_min_peers).unwrap_or(1);
 
         let readiness_max_finalization_age = file_config
@@ -303,10 +338,35 @@ impl NodeConfig {
             nonce_data_dir,
             consensus_data_dir,
             protocol_version,
+            mint_authority,
             readiness_min_peers,
             readiness_max_finalization_age,
         }
     }
+}
+
+/// Parse a hex-encoded Ed25519 public key into a mint authority.
+///
+/// Rejects input that is not hex, not 32 bytes, or does not decompress to
+/// a point on the curve. Catching those at startup matters because the
+/// alternative is a node that boots happily and then rejects every mint
+/// at runtime — a much harder failure to trace back to a typo.
+///
+/// This is not a full weak-key check: `VerifyingKey::from_bytes`
+/// decompresses but does not reject small-order or non-canonical
+/// encodings (all-zero and all-`ff` both parse). Those are caught where
+/// it counts — `verify_strict` on the signature path refuses them — so a
+/// weak key configured here yields a mint authority that can never
+/// successfully authorize anything, rather than one that can be forged.
+fn parse_mint_authority(value: &str) -> Result<[u8; 32], String> {
+    let trimmed = value.trim().trim_start_matches("0x");
+    let bytes = hex::decode(trimmed).map_err(|e| format!("not valid hex: {e}"))?;
+    let key: [u8; 32] = bytes
+        .try_into()
+        .map_err(|_| format!("expected 32 bytes, got {} hex characters", trimmed.len()))?;
+    omnia_substrate::crypto::VerifyingKey::from_bytes(&key)
+        .map_err(|e| format!("not a valid Ed25519 public key: {e}"))?;
+    Ok(key)
 }
 
 /// CLI argument definitions using clap derive.
@@ -355,6 +415,15 @@ pub struct CliArgs {
     pub config: Option<String>,
 
     /// Protocol version to advertise on the network.
+    /// Hex-encoded Ed25519 public key authorized to mint on the financial
+    /// shard (64 hex characters). Omit to disable minting.
+    ///
+    /// Must be IDENTICAL on every node in the network — it is a genesis
+    /// parameter, not a per-node identity. Nodes configured with different
+    /// authorities will disagree about which mints are valid.
+    #[arg(long, env = "OMNIA_MINT_AUTHORITY")]
+    pub mint_authority: Option<String>,
+
     #[arg(long, env = "OMNIA_PROTOCOL_VERSION", default_value = "4.0.0")]
     pub protocol_version: String,
 
@@ -585,6 +654,7 @@ mod tests {
             nonce_data_dir: None,
             consensus_data_dir: None,
             protocol_version: "4.0.0".to_string(),
+            mint_authority: None,
             readiness_min_peers: 1,
             readiness_max_finalization_age: 600,
         };
@@ -607,6 +677,7 @@ mod tests {
             nonce_data_dir: None,
             consensus_data_dir: None,
             protocol_version: "4.0.0".to_string(),
+            mint_authority: None,
             readiness_min_peers: 1,
             readiness_max_finalization_age: 600,
         };
@@ -631,6 +702,7 @@ mod tests {
             nonce_data_dir: None,
             consensus_data_dir: None,
             protocol_version: "4.0.0".to_string(),
+            mint_authority: None,
             readiness_min_peers: 1,
             readiness_max_finalization_age: 600,
         };
@@ -655,6 +727,7 @@ mod tests {
             nonce_data_dir: None,
             consensus_data_dir: None,
             protocol_version: "4.0.0".to_string(),
+            mint_authority: None,
             readiness_min_peers: 1,
             readiness_max_finalization_age: 600,
         };
@@ -679,6 +752,7 @@ mod tests {
             nonce_data_dir: None,
             consensus_data_dir: None,
             protocol_version: "4.0.0".to_string(),
+            mint_authority: None,
             readiness_min_peers: 1,
             readiness_max_finalization_age: 600,
         };
@@ -701,9 +775,81 @@ mod tests {
             nonce_data_dir: None,
             consensus_data_dir: None,
             protocol_version: "4.0.0".to_string(),
+            mint_authority: None,
             readiness_min_peers: 1,
             readiness_max_finalization_age: 600,
         };
         assert_eq!(config.slashing_dir(), PathBuf::from("/custom/slashing"));
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod mint_authority_tests {
+    use super::*;
+
+    /// A real Ed25519 public key (seed [3u8; 32]) — the same one the
+    /// wallet's cross-language vectors use.
+    const VALID_KEY: &str = "ed4928c628d1c2c6eae90338905995612959273a5c63f93636c14614ac8737d1";
+
+    #[test]
+    fn parses_a_valid_key() {
+        let parsed = parse_mint_authority(VALID_KEY).expect("valid key should parse");
+        assert_eq!(hex::encode(parsed), VALID_KEY);
+    }
+
+    #[test]
+    fn accepts_a_0x_prefix_and_surrounding_whitespace() {
+        // Operators paste keys from all sorts of places.
+        assert!(parse_mint_authority(&format!("  0x{VALID_KEY}  ")).is_ok());
+    }
+
+    #[test]
+    fn rejects_malformed_input() {
+        // Not hex at all.
+        assert!(parse_mint_authority("not-a-key").is_err());
+        // Right alphabet, wrong length — a truncated paste.
+        assert!(parse_mint_authority("ed4928c6").is_err());
+        // 64 hex chars that do not decompress to a point on the curve.
+        // Accepting this would start the node happily and then reject
+        // every mint at runtime, which is far harder to diagnose than
+        // failing at boot.
+        let mut off_curve = [0u8; 32];
+        off_curve[0] = 0x02;
+        assert!(
+            parse_mint_authority(&hex::encode(off_curve)).is_err(),
+            "an off-curve key must be refused at startup"
+        );
+    }
+
+    /// Documents a real limit rather than pretending it away: decompression
+    /// accepts some degenerate encodings. They are harmless here because
+    /// `verify_strict` on the signature path refuses them, so the result is
+    /// an authority that can never authorize anything — not a forgeable one.
+    #[test]
+    fn does_not_claim_to_be_a_weak_key_check() {
+        assert!(parse_mint_authority(&"ff".repeat(32)).is_ok());
+        assert!(parse_mint_authority(&"00".repeat(32)).is_ok());
+    }
+
+    #[test]
+    fn config_file_round_trips_the_key() {
+        let toml = format!(
+            r#"
+            node_id = 1
+            mint_authority = "{VALID_KEY}"
+        "#
+        );
+        let parsed = NodeConfigFile::from_toml(&toml).expect("parse TOML");
+        assert_eq!(parsed.mint_authority.as_deref(), Some(VALID_KEY));
+    }
+
+    #[test]
+    fn config_file_without_a_key_leaves_minting_disabled() {
+        // Absence must stay absence. A node that quietly substitutes its
+        // own key here would diverge from peers the first time anyone
+        // minted, so "unset" has to survive the round trip.
+        let parsed = NodeConfigFile::from_toml("node_id = 1").expect("parse TOML");
+        assert!(parsed.mint_authority.is_none());
     }
 }

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -414,7 +414,6 @@ pub struct CliArgs {
     #[arg(long, env = "OMNIA_CONFIG")]
     pub config: Option<String>,
 
-    /// Protocol version to advertise on the network.
     /// Hex-encoded Ed25519 public key authorized to mint on the financial
     /// shard (64 hex characters). Omit to disable minting.
     ///
@@ -424,6 +423,7 @@ pub struct CliArgs {
     #[arg(long, env = "OMNIA_MINT_AUTHORITY")]
     pub mint_authority: Option<String>,
 
+    /// Protocol version to advertise on the network.
     #[arg(long, env = "OMNIA_PROTOCOL_VERSION", default_value = "4.0.0")]
     pub protocol_version: String,
 

--- a/node/src/http.rs
+++ b/node/src/http.rs
@@ -253,6 +253,7 @@ mod tests {
             nonce_data_dir: None,
             consensus_data_dir: None,
             protocol_version: "4.0.0".to_string(),
+            mint_authority: None,
             readiness_min_peers: 1,
             readiness_max_finalization_age: 600,
         };

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -276,7 +276,12 @@ async fn main() -> Result<()> {
     let economics = EconomicsState::new();
     tracing::info!("Economics state initialized (10% decay, 1000 UBC/month)");
 
-    let shard_router = create_shard_router(Some(config.nonce_dir().as_path()), economics, node_pubkey_bytes)?;
+    let shard_router = create_shard_router(
+        Some(config.nonce_dir().as_path()),
+        economics,
+        node_pubkey_bytes,
+        config.mint_authority,
+    )?;
     tracing::info!(shard_count = 6, "Shard router initialized with all shard types");
 
     // B1: Wrap ShardRouter in Arc<std::sync::Mutex> so it can be shared between
@@ -749,6 +754,7 @@ fn create_shard_router(
     nonce_data_dir: Option<&std::path::Path>,
     economics_state: omnia_economics::EconomicsState,
     node_pubkey: [u8; 32],
+    mint_authority: Option<[u8; 32]>,
 ) -> Result<ShardRouter> {
     let fee_schedule = FeeSchedule::standard();
     let quota = omnia_economics::QuotaSystem::default_system();
@@ -773,12 +779,52 @@ fn create_shard_router(
         }
     };
 
-    // Register all six domain shards
-    // H10 fix: use the node's public key as the Financial shard's mint
-    // authority. Previously `FinancialShard::new()` left mint_authority
-    // as None, which meant no UBC could ever be minted through the
-    // Financial shard — effectively making it read-only at runtime.
-    router.register(Box::new(FinancialShard::with_mint_authority(node_pubkey)));
+    // Register all six domain shards.
+    //
+    // The financial shard's mint authority comes from configuration, not
+    // from this node's identity.
+    //
+    // H10 originally set it to `node_pubkey` so that minting was possible
+    // at all (`FinancialShard::new()` leaves it `None`, which disables
+    // minting). That was harmless while a single node existed, but it does
+    // not survive a real mesh: `FinancialState::apply` accepts a `Mint`
+    // only when the event creator matches the configured authority, so
+    // three nodes each holding their own key would each accept only their
+    // own mints and reject their peers'. They would disagree about total
+    // supply and every balance derived from it — a state divergence that
+    // consensus cannot repair, because both sides are behaving "correctly"
+    // per their own config.
+    //
+    // The authority is therefore a network-wide genesis parameter. When it
+    // is unset we fail closed and disable minting rather than substituting
+    // this node's key, because a silent substitution produces exactly the
+    // divergence above and looks fine until someone mints.
+    let financial_shard = match mint_authority {
+        Some(authority) => {
+            if authority == node_pubkey {
+                tracing::info!(
+                    authority = %hex::encode(authority),
+                    "Financial shard mint authority is this node's own key — \
+                     ensure every peer is configured with the SAME key, not their own"
+                );
+            } else {
+                tracing::info!(
+                    authority = %hex::encode(authority),
+                    "Financial shard mint authority configured"
+                );
+            }
+            FinancialShard::with_mint_authority(authority)
+        }
+        None => {
+            tracing::warn!(
+                "No mint_authority configured (--mint-authority / OMNIA_MINT_AUTHORITY) — \
+                 minting on the financial shard is DISABLED. Transfers still work; \
+                 accounts simply start at zero until an authority is set network-wide."
+            );
+            FinancialShard::new()
+        }
+    };
+    router.register(Box::new(financial_shard));
     router.register(Box::new(ComputationalShard::new()));
     router.register(Box::new(PhysicalShard::new()));
     router.register(Box::new(BiologicalShard::new()));

--- a/node/tests/api_integration.rs
+++ b/node/tests/api_integration.rs
@@ -179,6 +179,7 @@ fn build_test_app_state(port: u16) -> AppState {
         nonce_data_dir: None,
         consensus_data_dir: None,
         protocol_version: omnia_substrate::PROTOCOL_VERSION.to_string(),
+        mint_authority: None,
         readiness_min_peers: 1,
         readiness_max_finalization_age: 600,
     };

--- a/node/tests/integration.rs
+++ b/node/tests/integration.rs
@@ -125,6 +125,7 @@ async fn start_test_server() -> (String, tokio::task::JoinHandle<()>, ServerGuar
         nonce_data_dir: None,
         consensus_data_dir: None,
         protocol_version: omnia_substrate::PROTOCOL_VERSION.to_string(),
+        mint_authority: None,
         readiness_min_peers: 1,
         readiness_max_finalization_age: 600,
     };


### PR DESCRIPTION
## Mint authority — and a divergence bug it was hiding

The financial shard's mint authority was set to `node_pubkey`, so **each node used its own key**. That was harmless while a single node existed. It is not survivable on the 3-node mesh now running.

`FinancialState::apply` accepts a `Mint` only when the event creator matches *that node's* configured authority. With each node holding its own key:

- a mint created by node A is **accepted by A** and **rejected by B and C**
- the three then disagree about total supply and every balance derived from it
- consensus cannot repair it, because each node is behaving correctly per its own config

The authority is a network-wide genesis parameter, so it now comes from configuration:

```sh
export OMNIA_MINT_AUTHORITY="<64 hex chars>"     # or --mint-authority, or mint_authority in TOML
```

**Unset disables minting** rather than falling back to this node's key. A silent substitution reproduces exactly the divergence above and looks healthy right until someone mints. Transfers are unaffected; accounts start at zero until an authority is set network-wide. Startup logs which branch was taken so all three boot logs can be compared.

A malformed key fails at startup instead of being ignored. The validation is honest about its limit: `VerifyingKey::from_bytes` rejects off-curve points but accepts some degenerate encodings (all-zero, all-`ff`). Those are refused later by `verify_strict` on the signature path, so a weak key yields an authority that can never authorize anything rather than a forgeable one — and a test documents that rather than implying a full weak-key check.

## Docs: the validator network is standing now

Verified against the live endpoint rather than taken on trust — `peers: 2`, `acks_accepted: 27`, `acks_rejected: 0`, `events_finalized: 9`. Measured RTTs (A↔B 98.9 ms, A↔C 159.8 ms) match the 2026-07-20 baseline exactly, so the WAN figures describe this network and not a lab.

That retires the "no standing validator network" caveat added when the endpoint was a single node with zero peers.

**Two things kept honest rather than rounded up:**

1. `/readyz` still reports `not_ready`, but the reason changed from `no_peers` to `no_finalization`. Readiness counts **Lane 1** (canonical DAG) commits, and Lane 1 has committed nothing because the network is quiet — not because anything is broken. Lane 0 is finalizing.
2. **All three nodes are run by the same operator.** BFT's argument assumes independent operators, so this is fault-tolerant against machine and region failure but not against operator compromise. Geo-distributed is not trust-distributed, and the docs now distinguish them.

Also separates the standing 3-node network from the 5-node stress-run figures, records the utilization finding (~30 MB RSS on a 16 GB host, load 0.00 over 31 days, 4.7 MB chain data), and documents mint-authority setup in `validator-setup.md`.

## Verification

- `cargo test -p omnia-node` — 126 pass, including 6 new mint-authority config tests
- `cargo test -p omnia-shards` — 144 pass
- `cargo fmt --all --check` clean · `cargo clippy --workspace --all-targets` clean