### PR TITLE
Add working monitoring for the WAN testnet (Prometheus -> Grafana Cloud)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ ops/testnet-keys/
 
 # Local benchmark reports
 bench-results/
+
+# Grafana Cloud API token for Prometheus remote_write (never commit)
+docker/monitoring/grafana-cloud-token

--- a/docker/docker-compose.monitoring.yml
+++ b/docker/docker-compose.monitoring.yml
@@ -1,0 +1,45 @@
+# Monitoring for the geo-distributed WAN testnet — run on host A only.
+#
+# Host A is the only host permitted through B's and C's firewalls on port
+# 9090, so it is the natural place to scrape from.
+#
+# Deliberately Prometheus-only: metrics are shipped to Grafana Cloud via
+# remote_write (configure it in monitoring/prometheus-wan.yml). A Grafana
+# running on host A could not alert you that host A is down — which is the
+# single most important thing to be alerted about. Dashboards and alert
+# rules live in Grafana Cloud instead.
+#
+# Bring up:
+#   docker compose -f docker/docker-compose.monitoring.yml up -d
+#
+# Check that all three nodes are being scraped ("up" must be 1 for each):
+#   curl -s localhost:9095/api/v1/query?query=up | python3 -m json.tool
+
+services:
+  prometheus:
+    image: prom/prometheus:v2.52.0
+    container_name: omnia-prometheus
+    restart: unless-stopped
+    # Bridge networking, NOT host: the Omnia node already owns host port
+    # 9090, so Prometheus is published on 9095 to avoid the clash.
+    ports:
+      - "127.0.0.1:9095:9090"
+    extra_hosts:
+      # Lets the container reach host A's own node at host.docker.internal:9090.
+      - "host.docker.internal:host-gateway"
+    volumes:
+      - ./monitoring/prometheus-wan.yml:/etc/prometheus/prometheus.yml:ro
+      # Grafana Cloud API token, referenced by password_file in the config.
+      # Gitignored. Create it before enabling remote_write; comment this
+      # line out until then, or the container fails to start.
+      - ./monitoring/grafana-cloud-token:/etc/prometheus/grafana-cloud-token:ro
+      - prometheus-wan-data:/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      # Local retention only needs to cover a Grafana Cloud outage; the
+      # cloud holds the long-term series.
+      - '--storage.tsdb.retention.time=15d'
+
+volumes:
+  prometheus-wan-data:

--- a/docker/monitoring/prometheus-wan.yml
+++ b/docker/monitoring/prometheus-wan.yml
@@ -1,0 +1,71 @@
+# Prometheus scrape config for the geo-distributed WAN testnet.
+#
+# The other configs in this directory target Docker bridge hostnames on
+# port 8080 (`omnia-node-1:8080`), which only exist in the single-host
+# multi-node stacks. WAN members run `docker-compose.wan.yml` with host
+# networking, one container named `omnia-node` per host, HTTP + metrics on
+# port 9090 — so those configs silently scrape nothing here.
+#
+# Run this from host A (the bench/ingress host), which is the only host
+# permitted through B's and C's firewalls on port 9090.
+#
+# Fill in the remote_write block to ship metrics to Grafana Cloud. That
+# matters for more than convenience: alerts evaluated in the cloud still
+# fire when host A itself goes down, whereas a Grafana running on A cannot
+# tell you that A is unreachable.
+
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+  external_labels:
+    network: omnia-wan-testnet
+
+scrape_configs:
+  - job_name: 'omnia-wan'
+    metrics_path: /metrics
+    static_configs:
+      # Host A — reached via the Docker host gateway (see extra_hosts in
+      # docker-compose.monitoring.yml). Not `localhost`: that would resolve
+      # inside the Prometheus container.
+      - targets: ['host.docker.internal:9090']
+        labels:
+          node: 'A'
+          region: 'nbg1-eu-central'
+          role: 'bootstrap-validator-ingress'
+      - targets: ['178.156.163.211:9090']
+        labels:
+          node: 'B'
+          region: 'ash-us-east'
+          role: 'validator'
+      - targets: ['5.223.85.30:9090']
+        labels:
+          node: 'C'
+          region: 'sin-ap-southeast'
+          role: 'validator'
+
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']
+
+# ---------------------------------------------------------------------------
+# Grafana Cloud remote_write
+# ---------------------------------------------------------------------------
+# Get these from grafana.com -> your stack -> Prometheus -> "Send Metrics":
+#   url      -> the "Remote Write Endpoint"
+#   username -> the numeric "Username / Instance ID"
+#   token    -> an API token with the MetricsPublisher role
+#
+# The token is read from a file so it never lands in git. Create it on host A:
+#
+#   printf '%s' '<your-token>' > docker/monitoring/grafana-cloud-token
+#   chmod 600 docker/monitoring/grafana-cloud-token
+#
+# (docker/monitoring/grafana-cloud-token is gitignored.)
+#
+# Uncomment and fill in the two values below once the token file exists.
+#
+# remote_write:
+#   - url: https://prometheus-prod-XX-prod-YY-ZZZZ.grafana.net/api/prom/push
+#     basic_auth:
+#       username: '000000'
+#       password_file: /etc/prometheus/grafana-cloud-token


### PR DESCRIPTION

The existing Prometheus configs target Docker bridge hostnames on port
8080 (omnia-node-1:8080), which only exist in the single-host multi-node
stacks. WAN members run docker-compose.wan.yml with host networking, one
container named omnia-node per host, metrics on port 9090 — so the running
Prometheus has been scraping nothing at all.

That is why the alert rule in monitoring/grafana/alerts/omnia-alerts.yml
(PeerCountDrop: omnia_node_peers_connected < 2) never fired when the mesh
partitioned for four days. The rule was correct; it was never evaluated
against real data.

Adds:
- monitoring/prometheus-wan.yml — scrapes all three WAN nodes on 9090 with
  node/region/role labels, plus a remote_write template for Grafana Cloud
  (token read via password_file so it stays out of git).
- docker-compose.monitoring.yml — Prometheus only, published on 9095 since
  the node owns 9090, with host-gateway so it can scrape host A itself.

Deliberately no local Grafana: a Grafana on host A cannot alert that host A
is down, which is the failure that matters most. Dashboards and alert
evaluation belong in Grafana Cloud, fed by remote_write.

Refs #412