### PR TITLE
Fix two silent-failure traps in the WAN monitoring setup

### DIFF
--- a/docker/docker-compose.monitoring.yml
+++ b/docker/docker-compose.monitoring.yml
@@ -32,6 +32,10 @@ services:
       # Grafana Cloud API token, referenced by password_file in the config.
       # Gitignored. Create it before enabling remote_write; comment this
       # line out until then, or the container fails to start.
+      #
+      # MUST be chowned to uid 65534 (`nobody`) — this image does not run as
+      # root, and an unreadable token fails silently at WARN level while
+      # everything else looks healthy. See monitoring/prometheus-wan.yml.
       - ./monitoring/grafana-cloud-token:/etc/prometheus/grafana-cloud-token:ro
       - prometheus-wan-data:/prometheus
     command:

--- a/docker/monitoring/prometheus-wan.yml
+++ b/docker/monitoring/prometheus-wan.yml
@@ -24,10 +24,12 @@ scrape_configs:
   - job_name: 'omnia-wan'
     metrics_path: /metrics
     static_configs:
-      # Host A — reached via the Docker host gateway (see extra_hosts in
-      # docker-compose.monitoring.yml). Not `localhost`: that would resolve
-      # inside the Prometheus container.
-      - targets: ['host.docker.internal:9090']
+      # Host A — its own public IP. `localhost` would resolve inside the
+      # Prometheus container, and `host.docker.internal` (via extra_hosts)
+      # proved unreliable across Docker/Ubuntu versions: it resolved on some
+      # hosts and silently produced no target on others. The explicit IP is
+      # unambiguous. The node listens on 0.0.0.0:9090 so this always works.
+      - targets: ['78.47.43.136:9090']
         labels:
           node: 'A'
           region: 'nbg1-eu-central'
@@ -57,8 +59,19 @@ scrape_configs:
 #
 # The token is read from a file so it never lands in git. Create it on host A:
 #
-#   printf '%s' '<your-token>' > docker/monitoring/grafana-cloud-token
-#   chmod 600 docker/monitoring/grafana-cloud-token
+#   read -s -p "token: " T && printf '%s' "$T" > docker/monitoring/grafana-cloud-token && unset T
+#   chown 65534:65534 docker/monitoring/grafana-cloud-token
+#   chmod 644 docker/monitoring/grafana-cloud-token
+#
+# The chown is REQUIRED and easy to miss. The Prometheus image runs as
+# `nobody` (uid 65534), so a root-owned 0600 file is unreadable inside the
+# container. Prometheus does not fail loudly on this — it logs
+#   "unable to read basic auth password file ...: permission denied"
+# at WARN level and retries forever. Scraping keeps working, /metrics looks
+# healthy, and NOTHING reaches Grafana Cloud. Verify with
+# prometheus_remote_storage_bytes_total > 0 (see the runbook).
+#
+# `read -s` keeps the token out of shell history and scrollback.
 #
 # (docker/monitoring/grafana-cloud-token is gitignored.)
 #

--- a/docs/operations/monitoring-setup.md
+++ b/docs/operations/monitoring-setup.md
@@ -1,0 +1,155 @@
+# Monitoring the WAN Testnet (Prometheus → Grafana Cloud)
+
+> Audience: Operators
+> Context: Standing up metrics + alerting for the geo-distributed testnet.
+> Last Updated: 2026-08-01
+
+## Why this exists
+
+A four-day network partition went completely unnoticed in July 2026. The
+alert that would have caught it (`PeerCountDrop`, in
+[`monitoring/grafana/alerts/omnia-alerts.yml`](../../monitoring/grafana/alerts/omnia-alerts.yml))
+had existed for months and was correct — it was simply never evaluated
+against real data:
+
+- The Prometheus configs targeted Docker bridge hostnames on port 8080
+  (`omnia-node-1:8080`), which only exist in the single-host stacks. WAN
+  members run `docker-compose.wan.yml` with host networking, one container
+  named `omnia-node` per host, metrics on **9090**. Prometheus was scraping
+  nothing.
+- Grafana had been in `Exited (1)` for two weeks, so nobody was looking.
+
+Both halves have to work. Metrics with no alerting means nobody notices;
+alerting on metrics that were never collected means the same.
+
+## Architecture, and why Grafana runs in the cloud
+
+```
+node A (Nuremberg) ─┐
+node B (Ashburn)   ─┼─► Prometheus on host A ──remote_write──► Grafana Cloud
+node C (Singapore) ─┘        (scrape :9090)                  (dashboards + alerts)
+```
+
+Prometheus runs on **host A** because it is the only host permitted through
+B's and C's firewalls on 9090.
+
+**Do not run Grafana on host A.** A Grafana there cannot alert you that host
+A is down, which is the single most important thing to be told. Alert
+evaluation belongs in Grafana Cloud, fed by `remote_write`, so it survives
+the loss of the box being monitored.
+
+## Setup
+
+### 1. Grafana Cloud credentials
+
+In your Grafana Cloud instance: **Connections → Add new connection →
+Prometheus → "From my local Prometheus server" → "Send metrics from a
+single Prometheus instance" → "Directly"**, then generate an access-policy
+token (the `set:alloy-data-write` preset includes the required
+`metrics:write` scope).
+
+Note the **url** and **username**; the generated `password` is the token.
+
+Prefer **no expiry** on the token. If it lapses, metrics stop and alerting
+goes silent — and the thing that would have told you is the alerting. If you
+do set an expiry, put a calendar reminder well before it.
+
+### 2. On host A
+
+```bash
+cd /opt/omnia-protocol
+
+# Token — `read -s` keeps it out of shell history and scrollback
+read -s -p "token: " T && printf '%s' "$T" > docker/monitoring/grafana-cloud-token && unset T
+
+# REQUIRED: the Prometheus image runs as `nobody` (uid 65534)
+chown 65534:65534 docker/monitoring/grafana-cloud-token
+chmod 644 docker/monitoring/grafana-cloud-token
+```
+
+Fill in the `remote_write` url and username in
+`docker/monitoring/prometheus-wan.yml` (keep `password_file` — do not inline
+the token), then:
+
+```bash
+docker compose -f docker/docker-compose.monitoring.yml up -d
+```
+
+### 3. Verify — both halves, separately
+
+Scraping:
+
+```bash
+curl -s localhost:9095/api/v1/targets \
+  | python3 -c "import sys,json; [print(t['labels'].get('node','?'), t['scrapeUrl'], t['health']) for t in json.load(sys.stdin)['data']['activeTargets']]"
+```
+
+Expect one line per node, all `up`.
+
+Shipping (this is the step people skip):
+
+```bash
+curl -s localhost:9095/metrics | grep -v '^#' \
+  | grep -E 'remote_storage_(bytes_total|samples_failed_total|samples_pending)'
+```
+
+- `bytes_total` **> 0 and climbing** — data is actually reaching Grafana Cloud
+- `samples_failed_total` **0**
+- `samples_pending` **small / falling** — a large growing value means the
+  queue is backing up and nothing is being delivered
+
+Then query `omnia_node_peers_connected` in Grafana Cloud → Explore. Three
+series, one per node.
+
+### 4. Alert rules
+
+**Alerting → Alert rules → + New alert rule**, using the `grafanacloud-…-prom`
+data source:
+
+| Alert | Query (Code mode) | Condition | Pending |
+|---|---|---|---|
+| Node lost peers | `omnia_node_peers_connected` | `IS BELOW 2` | 3m |
+| Finality stalled | `rate(omnia_node_events_finalized_total[5m])` | `IS BELOW 0.001` | 10m |
+
+Attach a contact point (**Alerting → Contact points**) — an alert with no
+contact point notifies nobody.
+
+**Test it for real.** Stop `omnia-node` on host B and *wait past the pending
+period* (4+ minutes for a 3m rule) before starting it again. Stopping and
+starting in one go proves nothing. An untested alert is a hope, not a
+control.
+
+## Gotchas that cost real time
+
+**The token permission trap.** If the token file is not readable by uid
+65534, Prometheus logs
+
+```
+unable to read basic auth password file /etc/prometheus/grafana-cloud-token: permission denied
+```
+
+at **WARN** level and retries forever. The container stays up, scraping
+keeps working, `/metrics` looks healthy, and nothing ever reaches Grafana
+Cloud. Nothing surfaces as an error. `bytes_total: 0` is the tell.
+
+**`host.docker.internal` is unreliable.** With `extra_hosts: host-gateway`
+it resolves on some Docker/Ubuntu combinations and silently yields no target
+on others. Use host A's explicit IP instead.
+
+**Prometheus publishes on 9095, not 9090.** The Omnia node already owns
+9090 on the host.
+
+**Stale targets linger for ~5 minutes.** After changing a target and
+restarting, the old series still answers instant queries until the lookback
+window passes. Check `/api/v1/targets` for what is actually configured
+rather than inferring from an `up` query.
+
+**Don't copy Grafana's generated `scrape_configs`.** The snippet it produces
+includes its own `localhost:9090` job, which inside the container scrapes
+Prometheus itself. Take only the `remote_write` block.
+
+## Related
+
+- #411 — peers never re-dial a restarted bootstrap node (the partition this
+  monitoring is meant to catch)
+- #412 — restart ordering and peer-health checks in the runbooks

--- a/docs/operations/monitoring-setup.md
+++ b/docs/operations/monitoring-setup.md
@@ -111,13 +111,48 @@ data source:
 | Node lost peers | `omnia_node_peers_connected` | `IS BELOW 2` | 3m |
 | Finality stalled | `rate(omnia_node_events_finalized_total[5m])` | `IS BELOW 0.001` | 10m |
 
+The pending period must be **>= the evaluation group's interval** — the
+interval belongs to the group, not the rule. A 1m group interval with a 3m
+pending period gives detection in ~3-4 minutes; leaving the group at 3m
+pushes worst-case notification out to ~6 minutes.
+
+Under **Configure no data and error handling**, set **no data → Alerting**.
+The `< 2` condition catches a *degraded* node, but a node whose host dies
+stops producing the series entirely — there is no value left to compare, so
+without this the rule lands in "No Data" rather than firing. Leave the
+execution-error state as **Error**: it still notifies, but keeps a Grafana
+or datasource fault distinguishable from a real node fault. If you conflate
+them you will learn to distrust the alert.
+
 Attach a contact point (**Alerting → Contact points**) — an alert with no
-contact point notifies nobody.
+contact point notifies nobody. Send a test through it before relying on it.
 
 **Test it for real.** Stop `omnia-node` on host B and *wait past the pending
 period* (4+ minutes for a 3m rule) before starting it again. Stopping and
 starting in one go proves nothing. An untested alert is a hope, not a
 control.
+
+**Check your spam folder on the first fire.** Verified 2026-08-01: the alert
+fired correctly and delivered in 30s — straight into Gmail's spam folder. An
+alert nobody sees is not much better than no alert. Whitelist the sender
+(Gmail: open the message -> Filter messages like these -> Create filter ->
+"Never send it to Spam"), and consider a second contact point that does not
+depend on email deliverability at all — Grafana Cloud supports Discord,
+Slack, Telegram, and generic webhooks.
+
+### Verified behaviour (2026-08-01)
+
+Stopping `omnia-node` on host B produced **two** firing instances, one each
+for A and C — the per-node labels split them, which is correct and confirms
+the labelling works. Each notification carried the templated summary
+("Omnia node C (sin-ap-southeast) has 1 peer(s), expected 2"), the
+diagnosis, and the runbook link.
+
+Note that a dead node is reported *by its neighbours*, not by itself: its
+own series disappears and that alert instance goes stale after
+`missing series evaluations` intervals, while the surviving nodes each drop
+below 2 peers and fire. Total loss of scraping (host A or Prometheus down)
+is what the no-data → Alerting setting covers.
 
 ## Gotchas that cost real time
 


### PR DESCRIPTION
Follow-up to the monitoring stack merged in #413, from actually bringing it up against the live 3-node WAN network. Both bugs produced a Prometheus that looked completely healthy while shipping **nothing** to Grafana Cloud.

## 1. Token file unreadable by the container

The `prom/prometheus` image runs as `nobody` (uid 65534), so the root-owned `chmod 600` token file the previous instructions produced was inaccessible inside the container.

Prometheus does not treat this as fatal. It logs

```
unable to read basic auth password file /etc/prometheus/grafana-cloud-token: permission denied
```

at **WARN** level and retries forever. The container stays up, scraping keeps working, `/metrics` looks fine. In production this reached **16,768 retries with 12,063 samples queued and `bytes_total` stuck at 0** before anyone noticed — there is no error state anywhere that surfaces it.

Now chowns to 65534, and documents both the failure mode and the `bytes_total > 0` check that actually detects it. Also switches the token-creation step to `read -s` so it stays out of shell history and scrollback.

## 2. `host.docker.internal` resolves inconsistently

With `extra_hosts: host-gateway` it resolved on some Docker/Ubuntu combinations and silently yielded *no target* on others — host A simply absent from the scrape set, with no error logged anywhere. Replaced with host A's explicit IP, which is unambiguous (the node listens on `0.0.0.0:9090`).

## 3. New runbook: `docs/operations/monitoring-setup.md`

Covers the architecture and why Grafana belongs in the cloud rather than on the host being monitored, the Grafana Cloud credential flow, **separate verification of scraping and shipping** (the second is the step people skip), the alert rules, and the gotchas above — including that Prometheus publishes on 9095, that stale targets linger ~5 minutes, and that Grafana's generated snippet's own `scrape_configs` must not be copied.

## Verified live

```
A http://78.47.43.136:9090/metrics    up
B http://178.156.163.211:9090/metrics up
C http://5.223.85.30:9090/metrics     up

remote_storage_bytes_total          2879   (was 0)
remote_storage_samples_failed_total 0
remote_storage_samples_pending      64     (was 12,063)
```

The alert rule previews correctly in Grafana Cloud: nodes at 1 peer evaluate **Firing**, node at 2 evaluates **Normal**.

## Not yet verified

The alert has been confirmed to *evaluate* correctly but has **not** been observed delivering an end-to-end notification past its 3m pending period. The runbook is explicit that this test requires stopping a node and waiting out the pending period — stopping and starting in one go proves nothing.

Refs #411, #412