### PR TITLE
Document 3→5 validator expansion, including the peer-alert threshold trap

### DIFF
--- a/docker/monitoring/prometheus-wan.yml
+++ b/docker/monitoring/prometheus-wan.yml
@@ -44,6 +44,14 @@ scrape_configs:
           node: 'C'
           region: 'sin-ap-southeast'
           role: 'validator'
+      # Expanding the validator set? Add each new node here AND raise the
+      # Grafana alert threshold to (node_count - 1). A `< 2` rule on a
+      # 5-node mesh only fires once a node is down to 1 peer — three of five
+      # already gone. See docs/operations/geo-testnet.md.
+      # - targets: ['<D-ip>:9090']
+      #   labels: {node: 'D', region: '<region>', role: 'validator'}
+      # - targets: ['<E-ip>:9090']
+      #   labels: {node: 'E', region: '<region>', role: 'validator'}
 
   - job_name: 'prometheus'
     static_configs:

--- a/docker/monitoring/prometheus-wan.yml
+++ b/docker/monitoring/prometheus-wan.yml
@@ -44,14 +44,20 @@ scrape_configs:
           node: 'C'
           region: 'sin-ap-southeast'
           role: 'validator'
-      # Expanding the validator set? Add each new node here AND raise the
-      # Grafana alert threshold to (node_count - 1). A `< 2` rule on a
-      # 5-node mesh only fires once a node is down to 1 peer — three of five
-      # already gone. See docs/operations/geo-testnet.md.
-      # - targets: ['<D-ip>:9090']
-      #   labels: {node: 'D', region: '<region>', role: 'validator'}
-      # - targets: ['<E-ip>:9090']
-      #   labels: {node: 'E', region: '<region>', role: 'validator'}
+      - targets: ['46.62.218.24:9090']
+        labels:
+          node: 'D'
+          region: 'hel1-eu-central'
+          role: 'validator'
+      - targets: ['46.224.103.217:9090']
+        labels:
+          node: 'E'
+          region: 'fsn1-eu-central'
+          role: 'validator'
+      # Adding another node? Add it here AND raise the Grafana alert
+      # threshold to (node_count - 1) — currently 4 for this 5-node mesh.
+      # A stale threshold does not error; it just keeps reporting healthy
+      # through the degradation it exists to catch. See geo-testnet.md.
 
   - job_name: 'prometheus'
     static_configs:

--- a/docs/operations/geo-testnet.md
+++ b/docs/operations/geo-testnet.md
@@ -31,7 +31,105 @@ internet path — that is the point).
 > validators (2 EU / 2 US / 1 Asia) for real 1-fault tolerance.
 
 Sizing basis: a node peaked at ~160 MB RSS during a 10,000-event burst on
-the 5-node single-host run — CPX21 is generous headroom.
+the 5-node single-host run — CPX21 is generous headroom. Measured in
+production on 2026-08-01, a live node idled at **30 MB RSS with 0.02% CPU**,
+so the constraint is fault tolerance, not resources.
+
+## Expanding the validator set (3 → 5)
+
+Read this whole section before starting. Expansion is not additive: every
+node's `OMNIA_LANE0_VALIDATORS` must change, so **all** nodes restart, not
+just the new ones.
+
+### Why 5
+
+| Validators | Quorum (>2/3 stake) | Faults tolerated |
+|---|---|---|
+| 3 | all 3 | **0** — any node down halts finality |
+| 5 | 4 of 5 | **1** |
+
+Three is a benchmark topology. Five is the smallest set that survives losing
+a node, which is the point of running more than one.
+
+### Procedure
+
+**1. Generate keys for the new nodes — on host A only.**
+
+The validator set must be byte-identical everywhere, so all keys come from
+one place. `setup-validators.sh` reuses existing keys and only creates what
+is missing, so nodes 0–2 keep their identities:
+
+```bash
+cd /opt/omnia-protocol
+NODES=5 ./scripts/setup-validators.sh
+```
+
+This rewrites `OMNIA_LANE0_VALIDATORS` in `docker/.env` with all five
+pubkeys. It preserves an existing `OMNIA_JWT_SECRET` rather than clobbering
+it — confirm that, because a changed secret invalidates every live wallet
+session.
+
+**2. Provision D and E** as in §1–2 above (Docker, clone, firewall). Open
+UDP 4001 between *every* pair of node IPs, and TCP 9090 from host A only.
+Every existing host also needs UDP 4001 opened to D and E — a rule set for
+three nodes does not cover five.
+
+**3. Distribute keys and the shared config.**
+
+```bash
+# On A — copy each node's own key dir, plus the shared validator set
+scp -r ops/testnet-keys/node3 root@<D>:/opt/omnia-protocol/ops/testnet-keys/
+scp -r ops/testnet-keys/node4 root@<E>:/opt/omnia-protocol/ops/testnet-keys/
+for h in <B> <C> <D> <E>; do scp docker/.env root@$h:/opt/omnia-protocol/docker/.env; done
+```
+
+Then on **every** host: `chown -R 1000:1000 ops/testnet-keys`. The container
+runs as uid 1000; an unreadable key does not fail loudly — the node
+silently falls back to an ephemeral identity, logs
+`this_node_is_validator=false`, has every ack rejected as "unknown
+validator", and finality never happens.
+
+Append the per-node variables on D and E (`OMNIA_NODE_ID=4` / `5`,
+`OMNIA_KEY_DIR=../ops/testnet-keys/node3` / `node4`, `OMNIA_TOTAL_NODES=5`,
+and `OMNIA_BOOTSTRAP_NODES` listing the other four).
+
+**4. Restart in order — A first, then everyone else.**
+
+```bash
+# On A:
+docker compose -f docker/docker-compose.wan.yml up -d
+# Then on B, C, D, E:
+docker compose -f docker/docker-compose.wan.yml up -d
+```
+
+A must go first because it is the bootstrap node, and peers do **not**
+re-dial a bootstrap that restarts (#411). Restarting A after the others
+would orphan it — exactly the failure that went unnoticed for four days in
+July 2026.
+
+**5. Verify — every node must report 4 peers.**
+
+```bash
+for ip in localhost <B> <C> <D> <E>; do
+  printf "%-16s " "$ip"
+  curl -s "http://$ip:9090/api/v1/node/info"     | python3 -c "import sys,json; d=json.load(sys.stdin); print('peers=', d['peers'], 'lane0_finalized=', d['lane0']['events_finalized'])"
+done
+```
+
+Anything below `peers=4` is a partial mesh. Do not move on until all five
+agree — a node with a different validator set will reject acks it should
+accept, and the symptom (finality stalls) looks nothing like the cause.
+
+**6. Update monitoring — this is easy to forget and silently degrades it.**
+
+Add D and E to `docker/monitoring/prometheus-wan.yml` and restart
+`omnia-prometheus`, then **change the alert threshold from `< 2` to `< 4`**
+in Grafana Cloud.
+
+Leaving it at `< 2` on a 5-node mesh means the alert only fires once a node
+is down to 1 peer — i.e. after **three of five** nodes are already gone. The
+rule keeps evaluating and reporting healthy through the exact degradation it
+exists to catch. See [monitoring-setup.md](./monitoring-setup.md).
 
 ## 1. Provision B and C
 

--- a/docs/operations/geo-testnet.md
+++ b/docs/operations/geo-testnet.md
@@ -15,11 +15,15 @@ real WAN latency, which is the credibility jump that matters: it converts
 Three nodes, three regions, one provider (Hetzner shown; any VPS provider
 works). All three are Lane 0 validators.
 
-| Node | Region | Role | Suggested size |
-|------|--------|------|----------------|
-| **A** | Nuremberg, EU (`nbg1`) | bootstrap + validator + ingress + bench host | existing box |
-| **B** | Ashburn, US-East (`ash`) | validator | CPX21 (3 vCPU / 4 GB) |
-| **C** | Singapore (`sin`) | validator | CPX21 (3 vCPU / 4 GB) |
+| Node | IP | Region | Role |
+|------|----|--------|------|
+| **A** | 78.47.43.136 | Nuremberg, DE (`nbg1`) | bootstrap + validator + ingress + bench host |
+| **B** | 178.156.163.211 | Ashburn, US-East (`ash`) | validator |
+| **C** | 5.223.85.30 | Singapore (`sin`) | validator |
+| **D** | 46.62.218.24 | Helsinki, FI (`hel1`) | validator |
+| **E** | 46.224.103.217 | Falkenstein, DE (`fsn1`) | validator |
+
+Sizing: CPX21 (3 vCPU / 4 GB) is ample — see the footprint note below.
 
 Expected RTTs: A↔B ~90 ms, A↔C ~170 ms, B↔C ~230 ms (the worst common
 internet path — that is the point).
@@ -47,9 +51,20 @@ just the new ones.
 |---|---|---|
 | 3 | all 3 | **0** — any node down halts finality |
 | 5 | 4 of 5 | **1** |
+| 7 | 5 of 7 | **2** |
 
 Three is a benchmark topology. Five is the smallest set that survives losing
 a node, which is the point of running more than one.
+
+**Correlated failure is the limit, not node count.** Five validators tolerate
+one failure, so *any two simultaneous* losses halt finality. Placement
+therefore matters as much as the number: the current set is 3 EU / 1 US / 1
+Asia, with A (`nbg1`) and E (`fsn1`) both in Germany on the same provider.
+A single German or Hetzner-EU incident is one event that can take two nodes
+and stop finality network-wide. That is an accepted trade for now — it is
+still strictly better than the previous zero-fault-tolerance topology — but
+it means the next expansion should add capacity *outside* the EU (and ideally
+outside Hetzner) rather than more of the same region.
 
 ### Procedure
 
@@ -69,18 +84,34 @@ pubkeys. It preserves an existing `OMNIA_JWT_SECRET` rather than clobbering
 it — confirm that, because a changed secret invalidates every live wallet
 session.
 
-**2. Provision D and E** as in §1–2 above (Docker, clone, firewall). Open
-UDP 4001 between *every* pair of node IPs, and TCP 9090 from host A only.
-Every existing host also needs UDP 4001 opened to D and E — a rule set for
-three nodes does not cover five.
+**2. Provision D and E** as in §1–2 above (Docker, clone, firewall).
+
+Firewall is the step most likely to be done incompletely: five nodes means
+**ten pairs**, and the existing hosts each need rules for the two new IPs.
+On every host, allow UDP 4001 from the other four, and TCP 9090 from host A
+only:
+
+```bash
+# Run on EACH host, omitting its own IP:
+for ip in 78.47.43.136 178.156.163.211 5.223.85.30 46.62.218.24 46.224.103.217; do
+  ufw allow from "$ip" to any port 4001 proto udp
+done
+ufw allow from 78.47.43.136 to any port 9090 proto tcp   # skip on A itself
+```
+
+A missing rule does not announce itself — the mesh simply forms with fewer
+peers than it should, and `peers` sits at 3 instead of 4 on the affected
+nodes. Step 5 is what catches it.
 
 **3. Distribute keys and the shared config.**
 
 ```bash
 # On A — copy each node's own key dir, plus the shared validator set
-scp -r ops/testnet-keys/node3 root@<D>:/opt/omnia-protocol/ops/testnet-keys/
-scp -r ops/testnet-keys/node4 root@<E>:/opt/omnia-protocol/ops/testnet-keys/
-for h in <B> <C> <D> <E>; do scp docker/.env root@$h:/opt/omnia-protocol/docker/.env; done
+scp -r ops/testnet-keys/node3 root@46.62.218.24:/opt/omnia-protocol/ops/testnet-keys/
+scp -r ops/testnet-keys/node4 root@46.224.103.217:/opt/omnia-protocol/ops/testnet-keys/
+for h in 178.156.163.211 5.223.85.30 46.62.218.24 46.224.103.217; do
+  scp docker/.env root@$h:/opt/omnia-protocol/docker/.env
+done
 ```
 
 Then on **every** host: `chown -R 1000:1000 ops/testnet-keys`. The container
@@ -110,7 +141,7 @@ July 2026.
 **5. Verify — every node must report 4 peers.**
 
 ```bash
-for ip in localhost <B> <C> <D> <E>; do
+for ip in localhost 178.156.163.211 5.223.85.30 46.62.218.24 46.224.103.217; do
   printf "%-16s " "$ip"
   curl -s "http://$ip:9090/api/v1/node/info"     | python3 -c "import sys,json; d=json.load(sys.stdin); print('peers=', d['peers'], 'lane0_finalized=', d['lane0']['events_finalized'])"
 done

--- a/docs/operations/monitoring-setup.md
+++ b/docs/operations/monitoring-setup.md
@@ -108,8 +108,14 @@ data source:
 
 | Alert | Query (Code mode) | Condition | Pending |
 |---|---|---|---|
-| Node lost peers | `omnia_node_peers_connected` | `IS BELOW 2` | 3m |
+| Node lost peers | `omnia_node_peers_connected` | `IS BELOW <n-1>` | 3m |
 | Finality stalled | `rate(omnia_node_events_finalized_total[5m])` | `IS BELOW 0.001` | 10m |
+
+**The peer threshold is `node_count - 1`** — in a healthy mesh every node
+sees every other. It is `2` for the 3-node topology and `4` for 5 nodes.
+**Update it whenever the validator set changes.** A stale `< 2` on a 5-node
+mesh does not error or look broken; it simply keeps reporting healthy until
+three of five nodes are gone.
 
 The pending period must be **>= the evaluation group's interval** — the
 interval belongs to the group, not the rule. A 1m group interval with a 3m


### PR DESCRIPTION
Prep for adding validators D and E. Documentation only — no code or config changes to running nodes.

## Why 5

| Validators | Quorum (>2/3 stake) | Faults tolerated |
|---|---|---|
| 3 | all 3 | **0** — any node down halts finality |
| 5 | 4 of 5 | **1** |

Three is a benchmark topology. Five is the smallest set that survives losing a node.

## Expansion is not additive

`OMNIA_LANE0_VALIDATORS` changes on **every** node, so all of them restart — not just the new ones. And **host A must restart first**, because peers do not re-dial a bootstrap node that restarts (#411). Restarting A last would orphan it, which is precisely the failure that ran unnoticed for 4.3 days in July.

The procedure covers:

- Key generation on a single host (`NODES=5 ./scripts/setup-validators.sh` reuses existing keys, so nodes 0–2 keep their identities, and it preserves an existing `OMNIA_JWT_SECRET` rather than clobbering it)
- The `chown -R 1000:1000` the containers need — an unreadable key doesn't fail loudly, the node silently falls back to an ephemeral identity, logs `this_node_is_validator=false`, has every ack rejected as "unknown validator", and finality never happens
- Firewall rules between *every* new pair (a 3-node ruleset doesn't cover 5)
- Restart ordering
- Verification requiring `peers=4` on all five before proceeding

## The trap this PR mainly exists to prevent

**The peer alert threshold is `node_count - 1`.** Going to 5 nodes means it must change from `< 2` to `< 4`.

Left at `< 2` on a five-node mesh, the alert doesn't error, doesn't look broken, and keeps reporting healthy until a node is down to **1 peer — three of five already gone**. It would sail straight through the degradation it exists to catch. Given that a silent partition is exactly what this monitoring was built for after the July incident, that seemed worth flagging in three places: the expansion runbook, the alert table in `monitoring-setup.md`, and inline in `prometheus-wan.yml` right where the new scrape targets get added.

## Also

Records the measured production footprint — **30 MB RSS, 0.02% CPU idle** on a 16 GB box — to make explicit that the constraint here is fault tolerance, not resources.

Refs #411, #412