### PR TITLE
Fix mesh self-healing and peer accounting; document the 3→5 expansion failures

### DIFF
--- a/docs/operations/geo-testnet.md
+++ b/docs/operations/geo-testnet.md
@@ -155,13 +155,31 @@ re-dial a bootstrap that restarts (#411). Restarting A after the others
 would orphan it — exactly the failure that went unnoticed for four days in
 July 2026.
 
-> **Watch for tracked files you edited in place on host A.** A checkout will
-> refuse to overwrite them, and `git stash -u` will sweep them away —
-> including `docker/monitoring/prometheus-wan.yml`, whose live copy holds the
-> real `remote_write` credentials that the committed version leaves
-> commented out. Restoring the committed version silently stops metrics
-> reaching Grafana Cloud. Back it up outside the repo first, and confirm
-> `grep -c '^remote_write'` returns 1 before restarting Prometheus.
+> **Back up host A's live monitoring files outside the repo before the
+> checkout.** Two of them do not survive it:
+>
+> - `docker/monitoring/prometheus-wan.yml` — the live copy carries the real
+>   `remote_write` url and username; the committed version leaves that block
+>   commented out. Silently stops shipping if overwritten.
+> - `docker/monitoring/grafana-cloud-token` — **`git stash -u` takes this
+>   too.** It is gitignored on current `main`, but `.gitignore` is itself
+>   part of what you are upgrading, so on the old commit the rule does not
+>   exist yet and the file is merely untracked. `-u` stashes untracked files;
+>   only `-a` includes ignored ones. Losing it leaves a bind-mount pointing
+>   at nothing, Docker creates a *directory* in its place, and Prometheus
+>   fails to start with `not a directory`.
+>
+> ```bash
+> mkdir -p /root/monitoring-backup
+> cp -a docker/monitoring/prometheus-wan.yml \
+>       docker/monitoring/grafana-cloud-token /root/monitoring-backup/
+> ```
+>
+> Recover from the stash with `git checkout stash@{0}^3 -- <path>` (untracked
+> files live in the stash's *third* parent, not its tree). Afterwards confirm
+> `grep -c '^remote_write' docker/monitoring/prometheus-wan.yml` returns 1,
+> and re-apply `chown 65534:65534` + `chmod 644` to the token before starting
+> Prometheus.
 
 **5. Verify — every node must report 4 peers.**
 

--- a/docs/operations/geo-testnet.md
+++ b/docs/operations/geo-testnet.md
@@ -3,7 +3,7 @@
 > Audience: Operators
 > Context: Running the Omnia testnet across real internet distance (multiple
 > regions), and benchmarking it honestly.
-> Last Updated: 2026-07-19
+> Last Updated: 2026-08-02
 
 Every benchmark recorded before this runbook ran on a **single host**
 (near-zero RTT between containers). This runbook takes the same stack across
@@ -124,12 +124,29 @@ Append the per-node variables on D and E (`OMNIA_NODE_ID=4` / `5`,
 `OMNIA_KEY_DIR=../ops/testnet-keys/node3` / `node4`, `OMNIA_TOTAL_NODES=5`,
 and `OMNIA_BOOTSTRAP_NODES` listing the other four).
 
-**4. Restart in order — A first, then everyone else.**
+**4. Put every node on the same commit, then restart in order.**
+
+New nodes get a fresh clone of the current default branch. The existing
+nodes are running whatever image they were last built from, which may be
+months behind. **Rebuild them too** — Lane 0 acks are encoded with postcard,
+which is not self-describing, so a field added to `SignedAck` in the interim
+makes the two builds mutually unintelligible.
 
 ```bash
-# On A:
+# On EVERY host, new and old alike:
+cd /opt/omnia-protocol
+git fetch origin && git checkout -B main origin/main
+docker compose -f docker/docker-compose.wan.yml build
+```
+
+Build everywhere *before* restarting anything — a Rust release build takes
+3–7 minutes and you do not want nodes bouncing one at a time across that
+window. Then:
+
+```bash
+# On A first:
 docker compose -f docker/docker-compose.wan.yml up -d
-# Then on B, C, D, E:
+# Then B, C, D, E:
 docker compose -f docker/docker-compose.wan.yml up -d
 ```
 
@@ -137,6 +154,14 @@ A must go first because it is the bootstrap node, and peers do **not**
 re-dial a bootstrap that restarts (#411). Restarting A after the others
 would orphan it — exactly the failure that went unnoticed for four days in
 July 2026.
+
+> **Watch for tracked files you edited in place on host A.** A checkout will
+> refuse to overwrite them, and `git stash -u` will sweep them away —
+> including `docker/monitoring/prometheus-wan.yml`, whose live copy holds the
+> real `remote_write` credentials that the committed version leaves
+> commented out. Restoring the committed version silently stops metrics
+> reaching Grafana Cloud. Back it up outside the repo first, and confirm
+> `grep -c '^remote_write'` returns 1 before restarting Prometheus.
 
 **5. Verify — every node must report 4 peers.**
 
@@ -150,6 +175,30 @@ done
 Anything below `peers=4` is a partial mesh. Do not move on until all five
 agree — a node with a different validator set will reject acks it should
 accept, and the symptom (finality stalls) looks nothing like the cause.
+
+`peers` alone is not sufficient. Also confirm every node converges on the
+same ack and finality counts, because version skew produces a full peer
+count and zero finality:
+
+```bash
+for ip in localhost 178.156.163.211 5.223.85.30 46.62.218.24 46.224.103.217; do
+  printf "%-16s " "$ip"
+  curl -s "http://$ip:9090/api/v1/node/info" | python3 -c "import sys,json; d=json.load(sys.stdin); l=d['lane0']; print('acks_ok=', l['acks_accepted'], 'acks_rej=', l['acks_rejected'], 'final=', l['events_finalized'])"
+done
+```
+
+Certificates are grow-only sets of the same acks, so healthy nodes converge.
+Counts that cluster into groups — 36/36/14 for one build and 24/24 for
+another — mean acks are not crossing between the groups.
+
+**`acks_rejected` staying at 0 does not clear the network.** A batch whose
+wire format the receiver cannot parse fails in `decode_ack_batch`, which is
+upstream of the counter: it logs `Lane 0 ack batch rejected` at WARN and
+drops the message. Check the log, not the counter:
+
+```bash
+docker logs omnia-node 2>&1 | grep -ci "ack batch rejected"   # must be 0
+```
 
 **6. Update monitoring — this is easy to forget and silently degrades it.**
 

--- a/docs/operations/geo-testnet.md
+++ b/docs/operations/geo-testnet.md
@@ -262,8 +262,10 @@ Verify each node, then the mesh:
 curl -s http://localhost:9090/api/v1/node/info | python3 -m json.tool
 # expect: "lane0": {...} present and this_node_is_validator=true in logs
 
-# From A — peers must be 2 on every node before benchmarking:
-for ip in localhost <B> <C>; do printf "%s peers=" "$ip"; \
+# From A — every node must report (node_count - 1) peers before benchmarking.
+# That is 4 on the current 5-node mesh. Fewer means a partial mesh, and Lane 0
+# quorum needs 4 of 5 acks, so one absent peer is enough to halt finality.
+for ip in localhost <B> <C> <D> <E>; do printf "%s peers=" "$ip"; \
   curl -s "http://$ip:9090/metrics" | awk '/^omnia_node_peers_connected /{print $2}'; done
 ```
 

--- a/docs/operations/monitoring-setup.md
+++ b/docs/operations/monitoring-setup.md
@@ -25,13 +25,15 @@ alerting on metrics that were never collected means the same.
 ## Architecture, and why Grafana runs in the cloud
 
 ```
-node A (Nuremberg) ─┐
-node B (Ashburn)   ─┼─► Prometheus on host A ──remote_write──► Grafana Cloud
-node C (Singapore) ─┘        (scrape :9090)                  (dashboards + alerts)
+node A (Nuremberg)  ─┐
+node B (Ashburn)    ─┤
+node C (Singapore)  ─┼─► Prometheus on host A ──remote_write──► Grafana Cloud
+node D (Helsinki)   ─┤        (scrape :9090)                  (dashboards + alerts)
+node E (Falkenstein)─┘
 ```
 
-Prometheus runs on **host A** because it is the only host permitted through
-B's and C's firewalls on 9090.
+Prometheus runs on **host A** because it is the only host the other members
+allow through their firewalls on 9090.
 
 **Do not run Grafana on host A.** A Grafana there cannot alert you that host
 A is down, which is the single most important thing to be told. Alert
@@ -98,8 +100,8 @@ curl -s localhost:9095/metrics | grep -v '^#' \
 - `samples_pending` **small / falling** — a large growing value means the
   queue is backing up and nothing is being delivered
 
-Then query `omnia_node_peers_connected` in Grafana Cloud → Explore. Three
-series, one per node.
+Then query `omnia_node_peers_connected` in Grafana Cloud → Explore. One series
+per node — five on the current mesh.
 
 ### 4. Alert rules
 

--- a/docs/operations/monitoring-setup.md
+++ b/docs/operations/monitoring-setup.md
@@ -2,7 +2,7 @@
 
 > Audience: Operators
 > Context: Standing up metrics + alerting for the geo-distributed testnet.
-> Last Updated: 2026-08-01
+> Last Updated: 2026-08-02
 
 ## Why this exists
 
@@ -110,7 +110,7 @@ data source:
 
 | Alert | Query (Code mode) | Condition | Pending |
 |---|---|---|---|
-| Node lost peers | `omnia_node_peers_connected` | `IS BELOW <n-1>` | 3m |
+| Node lost peers | `max_over_time(omnia_node_peers_connected[10m])` | `IS BELOW <n-1>` | 5m |
 | Finality stalled | `rate(omnia_node_events_finalized_total[5m])` | `IS BELOW 0.001` | 10m |
 
 **The peer threshold is `node_count - 1`** — in a healthy mesh every node
@@ -118,6 +118,20 @@ sees every other. It is `2` for the 3-node topology and `4` for 5 nodes.
 **Update it whenever the validator set changes.** A stale `< 2` on a 5-node
 mesh does not error or look broken; it simply keeps reporting healthy until
 three of five nodes are gone.
+
+**Use `max_over_time`, not the raw gauge.** `omnia_node_peers_connected`
+flaps: peer-level connectivity is derived from connection-level libp2p events
+without consulting `num_established`, so closing one of several connections
+to a peer drops it from the count until the next connection is established
+(#422). Measured on the live 5-node mesh, a node read 3 for ~64 seconds and
+recovered untouched. A raw `< 4` pages on every one of those. `max_over_time`
+asks whether the node reached full connectivity *anywhere* in the window — a
+transient dip does, a genuinely dead link never does. Detection costs one
+window; false positives go to zero.
+
+Note the gauge can also over-report. A half-open connection is counted by the
+side that did not observe the close, so a broken link may show as `4` on one
+end and `3` on the other. The alert catches it from the dropping side only.
 
 The pending period must be **>= the evaluation group's interval** — the
 interval belongs to the group, not the rule. A 1m group interval with a 3m

--- a/monitoring/grafana/alerts/omnia-alerts.yml
+++ b/monitoring/grafana/alerts/omnia-alerts.yml
@@ -16,15 +16,23 @@ groups:
           summary: "No events being finalized"
           description: "The rate of finalized events has been zero for 5 minutes."
 
+      # The threshold is `node_count - 1`: in a healthy mesh every node sees
+      # every other one. It is 4 for the current 5-node WAN testnet.
+      #
+      # RAISE IT WHENEVER THE VALIDATOR SET GROWS. A stale threshold does not
+      # error and does not look broken — it just keeps reporting healthy
+      # through the degradation it exists to catch. A `< 2` left over from the
+      # 3-node topology would stay silent on a 5-node mesh until three of five
+      # nodes were gone, long after Lane 0 finality had already halted.
       - alert: PeerCountDrop
-        expr: omnia_node_peers_connected < 2
+        expr: omnia_node_peers_connected < 4
         for: 3m
         labels:
           severity: warning
           component: network
         annotations:
           summary: "Low peer count"
-          description: "Connected peers dropped below 2."
+          description: "Connected peers dropped below 4 (expected node_count - 1)."
 
       - alert: HighSlashingRate
         expr: rate(omnia_slashing_events_total[10m]) > 0.1

--- a/omnia-network/src/gossip.rs
+++ b/omnia-network/src/gossip.rs
@@ -34,6 +34,16 @@ const DEFAULT_PARTITION_THRESHOLD_MS: u64 = 30_000; // 30 seconds (was 3s)
 /// before the peer is considered silent.
 const DEFAULT_HEARTBEAT_INTERVAL_MS: u64 = DEFAULT_PARTITION_THRESHOLD_MS / 3;
 
+/// Base delay before the first re-dial attempt after the mesh is detected
+/// incomplete (issue #411). Doubles per consecutive failed sweep up to
+/// [`MAX_REDIAL_INTERVAL_MS`].
+const DEFAULT_REDIAL_INTERVAL_MS: u64 = 15_000;
+
+/// Ceiling for the re-dial backoff. A permanently dead peer is retried at
+/// this cadence forever rather than being abandoned — an operator who fixes
+/// a firewall rule should not also have to restart nodes to recover the mesh.
+const MAX_REDIAL_INTERVAL_MS: u64 = 300_000;
+
 /// Constant topic name for Omnia events gossip. Avoids per-call allocation.
 const OMNIA_EVENTS_TOPIC: &str = "omnia_events";
 
@@ -152,6 +162,13 @@ pub struct GossipConfig {
     /// anti-entropy. Default: 10000 ms.
     #[serde(default = "default_sync_interval")]
     pub sync_interval_ms: u64,
+    /// Base interval in milliseconds between re-dial sweeps when fewer peers
+    /// are connected than [`GossipConfig::bootstrap_peers`] lists (issue
+    /// #411). Doubles per consecutive unsuccessful sweep up to
+    /// [`MAX_REDIAL_INTERVAL_MS`]. `0` disables re-dialling, restoring the
+    /// dial-once-at-startup behaviour. Default: 15000 ms.
+    #[serde(default = "default_redial_interval")]
+    pub redial_interval_ms: u64,
 }
 
 fn default_partition_threshold() -> u64 {
@@ -174,6 +191,10 @@ fn default_sync_interval() -> u64 {
     10_000
 }
 
+fn default_redial_interval() -> u64 {
+    DEFAULT_REDIAL_INTERVAL_MS
+}
+
 impl Default for GossipConfig {
     fn default() -> Self {
         Self {
@@ -190,6 +211,7 @@ impl Default for GossipConfig {
             max_events_per_second: 100,
             burst_capacity: 200,
             sync_interval_ms: default_sync_interval(),
+            redial_interval_ms: DEFAULT_REDIAL_INTERVAL_MS,
         }
     }
 }
@@ -314,6 +336,11 @@ pub struct GossipProtocol {
     connected_peers: HashSet<PeerId>,
     /// When this node last published a keepalive heartbeat.
     last_heartbeat: Instant,
+    /// When the last re-dial sweep ran (issue #411).
+    last_redial: Instant,
+    /// Consecutive re-dial sweeps that have not restored a full mesh. Drives
+    /// the exponential backoff; reset to 0 as soon as the mesh is complete.
+    redial_attempts: u32,
     /// Whether a partition is currently detected (to avoid duplicate events).
     partition_active: bool,
     /// Per-peer rate limiter (token bucket).
@@ -420,6 +447,8 @@ impl GossipProtocol {
             last_seen: HashMap::new(),
             connected_peers: HashSet::new(),
             last_heartbeat: Instant::now(),
+            last_redial: Instant::now(),
+            redial_attempts: 0,
             partition_active: false,
             rate_limiter,
             rate_deferred: VecDeque::new(),
@@ -1161,6 +1190,99 @@ impl GossipProtocol {
         if let Err(e) = self.publish_raw(HEARTBEAT_TOPIC, payload).await {
             tracing::debug!("Heartbeat publish failed: {e}");
         }
+    }
+
+    /// Backoff before the next re-dial sweep, given how many consecutive
+    /// sweeps have failed to restore a full mesh.
+    ///
+    /// Exponential from `base`, capped at [`MAX_REDIAL_INTERVAL_MS`], then
+    /// spread by up to ±20%. The jitter is derived from the node id rather
+    /// than an RNG: it must differ *between* nodes (so a shared upstream blip
+    /// does not make every node redial in lockstep) but does not need to be
+    /// unpredictable, and a deterministic value keeps this testable.
+    fn redial_backoff_ms(&self, attempts: u32) -> u64 {
+        let base = self.config.redial_interval_ms;
+        let stepped = base
+            .saturating_mul(1u64 << attempts.min(16))
+            .min(MAX_REDIAL_INTERVAL_MS);
+
+        // ±20%, keyed on (node_id, attempt) so successive sweeps on one node
+        // also differ rather than landing on a fixed offset.
+        let seed = blake3_hash_domain(
+            b"omnia-redial-jitter",
+            &[&self.node_id[..], &attempts.to_le_bytes()].concat(),
+        );
+        let spread = stepped / 5;
+        if spread == 0 {
+            return stepped;
+        }
+        let offset = u64::from_le_bytes(seed[..8].try_into().unwrap_or([0u8; 8])) % (spread * 2 + 1);
+        stepped.saturating_sub(spread).saturating_add(offset)
+    }
+
+    /// Re-dial configured peers when the mesh is short of members (#411).
+    ///
+    /// [`dial_bootstrap_peers`](Self::dial_bootstrap_peers) previously ran
+    /// exactly once, at startup. Nothing re-dialled afterwards, so **any**
+    /// lost link was permanent until one of the two nodes restarted — the
+    /// mesh could only degrade between restarts. On the 5-node WAN testnet
+    /// two nodes lost their link 15 seconds after forming it and stayed
+    /// disconnected until one was restarted by hand.
+    ///
+    /// That matters beyond connectivity: Lane 0 quorum on five equal-stake
+    /// validators is four, so two accumulated link losses halt finality
+    /// network-wide while every node keeps answering HTTP 200.
+    ///
+    /// A sweep is a no-op unless the mesh is actually short, so a healthy
+    /// network never dials. When it is short, every configured address is
+    /// re-dialled; libp2p suppresses redundant dials to peers it is already
+    /// connected to or currently dialling, so the cost is bounded and there
+    /// is no need to track which specific link is missing.
+    ///
+    /// **This only repairs links that *this* node can initiate.** A node with
+    /// an empty `bootstrap_peers` (the classic bootstrap node) never sweeps
+    /// and relies on its peers dialling it. A link is restored if *either*
+    /// end dials, so listing all other members on every non-bootstrap node is
+    /// enough — but a topology where only one node has peers configured
+    /// leaves that node's losses unrepairable.
+    pub async fn maybe_redial_peers(&mut self) {
+        if self.config.redial_interval_ms == 0
+            || self.network_cmd_tx.is_none()
+            || self.config.bootstrap_peers.is_empty()
+        {
+            return;
+        }
+
+        // A full mesh needs nothing. Reset the backoff so the next genuine
+        // loss is retried promptly rather than at whatever interval the last
+        // outage escalated to.
+        if self.connected_peer_count() >= self.config.bootstrap_peers.len() {
+            if self.redial_attempts > 0 {
+                info!(
+                    peers = self.connected_peer_count(),
+                    "Mesh complete — re-dial backoff reset"
+                );
+                self.redial_attempts = 0;
+            }
+            return;
+        }
+
+        let wait = std::time::Duration::from_millis(self.redial_backoff_ms(self.redial_attempts));
+        if self.last_redial.elapsed() < wait {
+            return;
+        }
+
+        self.last_redial = Instant::now();
+        self.redial_attempts = self.redial_attempts.saturating_add(1);
+
+        warn!(
+            connected = self.connected_peer_count(),
+            expected = self.config.bootstrap_peers.len(),
+            attempt = self.redial_attempts,
+            "Mesh incomplete — re-dialling configured peers"
+        );
+
+        self.dial_bootstrap_peers().await;
     }
 
     /// Publish an anti-entropy digest on [`SYNC_TOPIC`] if one is due
@@ -2515,6 +2637,128 @@ mod tests {
             gossip.take_aux_messages().is_empty(),
             "heartbeats must not be buffered as aux messages"
         );
+    }
+
+    // ── #411: mesh repair via periodic re-dial ────────────────────────
+
+    /// Builds a protocol with `n` configured peers and a wired command
+    /// channel, returning the receiver so dials can be observed.
+    fn redial_harness(peers: usize) -> (GossipProtocol, mpsc::Receiver<NetworkCommand>) {
+        let graph = Arc::new(RwLock::new(CausalGraph::new()));
+        let config = GossipConfig {
+            bootstrap_peers: (0..peers)
+                .map(|i| format!("/ip4/10.0.0.{}/udp/4001/quic-v1", i + 1))
+                .collect(),
+            ..GossipConfig::default()
+        };
+        let mut gossip = GossipProtocol::new(node(1), config, graph);
+        let (tx, rx) = mpsc::channel(64);
+        gossip.network_cmd_tx = Some(tx);
+        (gossip, rx)
+    }
+
+    /// A complete mesh must never dial. This is what keeps the sweep free on
+    /// a healthy network.
+    #[tokio::test]
+    async fn redial_is_a_noop_while_the_mesh_is_complete() {
+        let (mut gossip, mut rx) = redial_harness(2);
+        gossip.connected_peers.insert(PeerId::random());
+        gossip.connected_peers.insert(PeerId::random());
+        for p in gossip.connected_peers.clone() {
+            gossip.last_seen.insert(p, Instant::now());
+        }
+
+        gossip.last_redial = Instant::now() - std::time::Duration::from_secs(3600);
+        gossip.maybe_redial_peers().await;
+
+        assert!(rx.try_recv().is_err(), "a complete mesh must not dial");
+        assert_eq!(gossip.redial_attempts, 0);
+    }
+
+    /// The regression: a link is lost and nothing restarts. Before #411 this
+    /// produced no dial ever, and the mesh stayed degraded indefinitely.
+    #[tokio::test]
+    async fn redial_dials_every_configured_peer_when_short() {
+        let (mut gossip, mut rx) = redial_harness(2);
+        let live = PeerId::random();
+        gossip.connected_peers.insert(live);
+        gossip.last_seen.insert(live, Instant::now());
+
+        gossip.last_redial = Instant::now() - std::time::Duration::from_secs(3600);
+        gossip.maybe_redial_peers().await;
+
+        let mut dialled = 0;
+        while rx.try_recv().is_ok() {
+            dialled += 1;
+        }
+        assert_eq!(dialled, 2, "every configured address should be re-dialled");
+        assert_eq!(gossip.redial_attempts, 1);
+    }
+
+    /// Sweeps are rate limited: a second call before the backoff elapses is
+    /// silent, so a persistently unreachable peer is not hammered.
+    #[tokio::test]
+    async fn redial_respects_backoff_between_sweeps() {
+        let (mut gossip, mut rx) = redial_harness(2);
+        gossip.last_redial = Instant::now() - std::time::Duration::from_secs(3600);
+
+        gossip.maybe_redial_peers().await;
+        while rx.try_recv().is_ok() {}
+        let after_first = gossip.redial_attempts;
+
+        // Immediately again — the backoff has not elapsed.
+        gossip.maybe_redial_peers().await;
+
+        assert!(rx.try_recv().is_err(), "second sweep must wait for the backoff");
+        assert_eq!(gossip.redial_attempts, after_first);
+    }
+
+    /// Backoff grows per failed sweep and is capped, so a dead peer settles
+    /// into a slow retry instead of being abandoned or hammered.
+    #[test]
+    fn redial_backoff_grows_and_is_capped() {
+        let (gossip, _rx) = redial_harness(1);
+
+        let first = gossip.redial_backoff_ms(0);
+        let later = gossip.redial_backoff_ms(4);
+        assert!(later > first, "backoff must grow with consecutive failures");
+
+        // ±20% jitter, so allow the cap plus that margin.
+        let ceiling = MAX_REDIAL_INTERVAL_MS + MAX_REDIAL_INTERVAL_MS / 5;
+        for attempts in 0..40 {
+            assert!(
+                gossip.redial_backoff_ms(attempts) <= ceiling,
+                "attempt {attempts} exceeded the capped backoff"
+            );
+        }
+    }
+
+    /// Jitter must differ between nodes, or a shared upstream blip makes the
+    /// whole mesh redial in lockstep.
+    #[test]
+    fn redial_jitter_differs_between_nodes() {
+        let graph = Arc::new(RwLock::new(CausalGraph::new()));
+        let config = GossipConfig {
+            bootstrap_peers: vec!["/ip4/10.0.0.1/udp/4001/quic-v1".to_string()],
+            ..GossipConfig::default()
+        };
+        let a = GossipProtocol::new(node(1), config.clone(), graph.clone());
+        let b = GossipProtocol::new(node(2), config, graph);
+
+        let differs = (0..8).any(|n| a.redial_backoff_ms(n) != b.redial_backoff_ms(n));
+        assert!(differs, "two nodes must not share an identical backoff schedule");
+    }
+
+    /// Setting the interval to 0 restores the old dial-once behaviour.
+    #[tokio::test]
+    async fn redial_can_be_disabled() {
+        let (mut gossip, mut rx) = redial_harness(2);
+        gossip.config.redial_interval_ms = 0;
+        gossip.last_redial = Instant::now() - std::time::Duration::from_secs(3600);
+
+        gossip.maybe_redial_peers().await;
+
+        assert!(rx.try_recv().is_err(), "redial_interval_ms = 0 must disable sweeps");
     }
 
     /// A due heartbeat publishes `node_id ‖ unix_millis` on the

--- a/omnia-network/src/gossip.rs
+++ b/omnia-network/src/gossip.rs
@@ -164,8 +164,8 @@ pub struct GossipConfig {
     pub sync_interval_ms: u64,
     /// Base interval in milliseconds between re-dial sweeps when fewer peers
     /// are connected than [`GossipConfig::bootstrap_peers`] lists (issue
-    /// #411). Doubles per consecutive unsuccessful sweep up to
-    /// [`MAX_REDIAL_INTERVAL_MS`]. `0` disables re-dialling, restoring the
+    /// #411). Doubles per consecutive unsuccessful sweep up to a ceiling of
+    /// 300000 ms. `0` disables re-dialling, restoring the
     /// dial-once-at-startup behaviour. Default: 15000 ms.
     #[serde(default = "default_redial_interval")]
     pub redial_interval_ms: u64,

--- a/omnia-network/src/network.rs
+++ b/omnia-network/src/network.rs
@@ -434,6 +434,47 @@ pub enum NetworkEvent {
     },
 }
 
+/// Whether a connection-level swarm event opened or closed a connection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ConnectionChange {
+    /// A new connection to the peer was established.
+    Opened,
+    /// An existing connection to the peer was closed.
+    Closed,
+}
+
+/// Map a connection-level swarm event onto a peer-level [`NetworkEvent`],
+/// or `None` when the peer's overall reachability did not change.
+///
+/// libp2p reports **connections**, not peers, and routinely holds more than
+/// one connection to the same peer — a dial that crosses an inbound dial, a
+/// relayed path coexisting with a direct one during a DCUtR upgrade, and so
+/// on. Emitting `PeerConnected` for every `ConnectionEstablished` and
+/// `PeerDisconnected` for every `ConnectionClosed` therefore makes every
+/// downstream peer set flap: closing one of three connections marks a fully
+/// connected peer as gone until the next connection happens to open.
+///
+/// That is not cosmetic. `GossipProtocol::connected_peer_count()` feeds
+/// `omnia_node_peers_connected`, which is the primary partition signal and
+/// the input to the `PeerCountDrop` alert. Issue #422 recorded a node on the
+/// live 5-node mesh reporting 3 of 4 peers for ~64 seconds, then recovering
+/// untouched, while every link was healthy throughout.
+///
+/// `num_established` is the number of connections to that peer remaining
+/// *after* the event, so the peer-level transitions are exactly `Opened`
+/// with 1 (the first connection) and `Closed` with 0 (the last).
+pub(crate) fn peer_level_event(
+    peer_id: PeerId,
+    num_established: u32,
+    change: ConnectionChange,
+) -> Option<NetworkEvent> {
+    match change {
+        ConnectionChange::Opened if num_established == 1 => Some(NetworkEvent::PeerConnected(peer_id)),
+        ConnectionChange::Closed if num_established == 0 => Some(NetworkEvent::PeerDisconnected(peer_id)),
+        _ => None,
+    }
+}
+
 /// Combined libp2p behaviour for Omnia.
 ///
 /// Includes GossipSub for event propagation, mDNS for LAN discovery,
@@ -850,18 +891,51 @@ impl OmniaNetwork {
             SwarmEvent::NewListenAddr { address, .. } => {
                 tracing::info!("Listening on {}", address);
             }
-            SwarmEvent::ConnectionEstablished { peer_id, .. } => {
-                if let Err(e) = self.event_tx.send(NetworkEvent::PeerConnected(peer_id)).await {
-                    tracing::warn!("Dropped peer connected event - channel full: {}", e);
+            SwarmEvent::ConnectionEstablished {
+                peer_id,
+                num_established,
+                ..
+            } => {
+                // #422: only the peer's FIRST connection is a peer-level
+                // connect. Additional connections to an already-connected
+                // peer are normal and must not re-announce it.
+                match peer_level_event(peer_id, num_established.get(), ConnectionChange::Opened) {
+                    Some(event) => {
+                        if let Err(e) = self.event_tx.send(event).await {
+                            tracing::warn!("Dropped peer connected event - channel full: {}", e);
+                        }
+                    }
+                    None => tracing::debug!(
+                        peer = %peer_id,
+                        connections = num_established.get(),
+                        "Additional connection to an already-connected peer"
+                    ),
                 }
             }
-            SwarmEvent::ConnectionClosed { peer_id, .. } => {
-                // H-9 fix (audit v0.1.68): clean up the peer's application
-                // score on disconnect so the score map doesn't grow
-                // unboundedly as peers churn.
-                self.peer_score_tracker.remove_peer(&peer_id);
-                if let Err(e) = self.event_tx.send(NetworkEvent::PeerDisconnected(peer_id)).await {
-                    tracing::warn!("Dropped peer disconnected event - channel full: {}", e);
+            SwarmEvent::ConnectionClosed {
+                peer_id,
+                num_established,
+                ..
+            } => {
+                // #422: only the peer's LAST connection closing is a
+                // peer-level disconnect. Tearing down one of several
+                // connections leaves the peer reachable, so neither the
+                // score entry nor the peer set may be dropped here.
+                match peer_level_event(peer_id, num_established, ConnectionChange::Closed) {
+                    Some(event) => {
+                        // H-9 fix (audit v0.1.68): clean up the peer's
+                        // application score on disconnect so the score map
+                        // doesn't grow unboundedly as peers churn.
+                        self.peer_score_tracker.remove_peer(&peer_id);
+                        if let Err(e) = self.event_tx.send(event).await {
+                            tracing::warn!("Dropped peer disconnected event - channel full: {}", e);
+                        }
+                    }
+                    None => tracing::debug!(
+                        peer = %peer_id,
+                        remaining = num_established,
+                        "Connection closed but peer is still connected"
+                    ),
                 }
             }
             _ => {}
@@ -886,6 +960,78 @@ pub(crate) fn extract_peer_id_from_multiaddr(addr: &Multiaddr) -> Option<PeerId>
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
+
+    // -----------------------------------------------------------------
+    // #422: peer-level events must track peers, not connections
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn first_connection_announces_the_peer() {
+        let peer = PeerId::random();
+        let event = peer_level_event(peer, 1, ConnectionChange::Opened);
+        assert!(matches!(event, Some(NetworkEvent::PeerConnected(p)) if p == peer));
+    }
+
+    #[test]
+    fn additional_connections_do_not_re_announce_the_peer() {
+        let peer = PeerId::random();
+        for n in 2..=5 {
+            assert!(
+                peer_level_event(peer, n, ConnectionChange::Opened).is_none(),
+                "connection {n} to an already-connected peer must not emit PeerConnected"
+            );
+        }
+    }
+
+    #[test]
+    fn last_connection_closing_disconnects_the_peer() {
+        let peer = PeerId::random();
+        let event = peer_level_event(peer, 0, ConnectionChange::Closed);
+        assert!(matches!(event, Some(NetworkEvent::PeerDisconnected(p)) if p == peer));
+    }
+
+    #[test]
+    fn closing_one_of_several_connections_keeps_the_peer() {
+        let peer = PeerId::random();
+        for remaining in 1..=4 {
+            assert!(
+                peer_level_event(peer, remaining, ConnectionChange::Closed).is_none(),
+                "peer still has {remaining} connection(s) and must not be reported as disconnected"
+            );
+        }
+    }
+
+    /// The exact sequence behind #422: two connections open, one closes, and
+    /// the peer is still fully connected. Before the fix this produced two
+    /// `PeerConnected` followed by a `PeerDisconnected`, which dropped a live
+    /// peer out of `connected_peers` and made `omnia_node_peers_connected`
+    /// read one short until another connection happened to open.
+    #[test]
+    fn second_connection_closing_does_not_evict_a_live_peer() {
+        let peer = PeerId::random();
+
+        // Two connections established: exactly one peer-level connect.
+        let announced = [
+            peer_level_event(peer, 1, ConnectionChange::Opened),
+            peer_level_event(peer, 2, ConnectionChange::Opened),
+        ]
+        .into_iter()
+        .flatten()
+        .count();
+        assert_eq!(announced, 1, "two connections must announce the peer exactly once");
+
+        // One of them closes, one remains: no peer-level disconnect.
+        assert!(
+            peer_level_event(peer, 1, ConnectionChange::Closed).is_none(),
+            "peer must stay connected while one connection remains"
+        );
+
+        // The survivor closes: now the peer is genuinely gone.
+        assert!(matches!(
+            peer_level_event(peer, 0, ConnectionChange::Closed),
+            Some(NetworkEvent::PeerDisconnected(_))
+        ));
+    }
 
     #[test]
     fn test_version_compatibility_same_version() {

--- a/substrate/src/lib.rs
+++ b/substrate/src/lib.rs
@@ -1033,6 +1033,10 @@ impl Substrate {
                 // frontier so peers that lost events to bounded-queue drops
                 // can request and recover them.
                 gossip.maybe_send_sync_digest().await;
+                // Mesh repair (issue #411): peers were dialled once at
+                // startup and never again, so a dropped link stayed dropped
+                // until a node restarted. No-op while the mesh is complete.
+                gossip.maybe_redial_peers().await;
             }
             self.unprocessed_events.extend(newly_inserted.iter().copied());
 


### PR DESCRIPTION
## 🚀 Description

Two protocol fixes and the runbook corrections that came out of expanding the
WAN testnet from 3 to 5 validators on 2026-08-02.

**Code**

- `omnia-network/src/network.rs` — emit `PeerConnected`/`PeerDisconnected` on
  peer-level transitions rather than per connection, by honouring libp2p's
  `num_established`. Closes #422.
- `omnia-network/src/gossip.rs`, `substrate/src/lib.rs` — add
  `maybe_redial_peers()`, a backoff-and-jitter sweep that repairs a mesh short
  of members. Closes #411.

**Docs / config**

- `monitoring/grafana/alerts/omnia-alerts.yml` — `PeerCountDrop` was still
  `< 2` from the 3-node topology.
- `docs/operations/geo-testnet.md` — expansion now rebuilds every node, not
  just the new ones; verification checks ack convergence and the
  `ack batch rejected` log rather than peer count alone; warns which live
  monitoring files a checkout destroys.
- `docs/operations/monitoring-setup.md` — 5-node topology, and the peer alert
  now uses `max_over_time`.

## 💡 Motivation and Context

Fixes #422. Fixes #411.

The expansion halted Lane 0 finality network-wide for roughly four hours while
every operator-visible signal stayed green — `peers=4`, HTTP 200,
`acks_rejected=0`. Two causes:

1. Quorum rose from 3 to 4 (`acked*3 > total*2`), but A/B/C could only produce
   3 acks between them.
2. A/B/C were 101 commits behind, predating `f550d48` which added `state_root`
   to `SignedAck`. Lane 0 acks are postcard-encoded and postcard is not
   self-describing, so the old and new builds could not read each other's ack
   batches. `decode_ack_batch` fails upstream of `add_ack`, so the drops were
   logged at WARN and never counted — `acks_rejected` stayed 0 throughout.

Diagnosing that surfaced the two defects fixed here.

**#422** — `ConnectionEstablished`/`ConnectionClosed` carry `num_established`
and both discarded it, so closing one of several connections to a peer evicted
a fully connected peer from `connected_peers`. `connected_peer_count()` feeds
`omnia_node_peers_connected`, the primary partition signal. A live node read
3 of 4 peers for ~64 seconds and recovered untouched; degree sums across the
mesh came out odd (19, then 17), which is impossible when every link is counted
by both ends. The same code path also wiped a live peer's application score on
every connection close.

**#411** — `dial_bootstrap_peers()` had one call site, at startup. Nothing
re-dialled afterwards, so any lost link was permanent until a node restarted:
the mesh could only degrade. D and E lost their link 15 seconds after forming
it and stayed disconnected until D was restarted by hand. With quorum at 4 of
5, two accumulated link losses halt finality while every node keeps serving
HTTP 200.

## ✅ How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [x] Manual testing

Eleven new tests.

`peer_level_event` is factored out so the policy is testable without
constructing swarm events — including the exact #422 sequence (two connections
open, one closes, peer must remain connected).

`maybe_redial_peers` is covered for: no-op on a complete mesh, dialling every
configured address when short, backoff between sweeps, growth and capping of
the backoff, per-node jitter divergence, and `redial_interval_ms = 0` restoring
dial-once.

```
cargo test -p omnia-network                        157 + 5 + 1 + 1 passed, 0 failed
cargo test -p omnia-substrate --features network   94 + 9 + 5 + 3 + 13 + 8 passed, 0 failed
cargo clippy -p omnia-network -p omnia-substrate --features network --all-targets   clean
cargo fmt                                          clean
```

Note: `cargo test -p omnia-substrate` *without* `--features network` fails to
compile `gossip_libp2p` and `gossip_simulation` on unresolved imports. Verified
identical on the unmodified tree — pre-existing, untouched here.

Manual verification on the live 5-node WAN testnet (A Nuremberg, B Ashburn,
C Singapore, D Helsinki, E Falkenstein) after bringing all nodes onto one
commit: all five at `peers=4`, an event submitted through A reached `final=1`
on all five with `acks_ok=4` (the fifth ack correctly recorded as a duplicate
after quorum), and `ack batch rejected` at 0 network-wide.

The two code fixes in this PR are **not yet deployed** to the testnet.

## 📝 Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## ➕ Additional Context

**Ordering matters.** #422 should be considered a prerequisite for #411, and
both are in this PR for that reason: reconciling against a flapping
`connected_peers` would produce spurious dials. With the flap fixed, "fewer
peers than configured" is a trustworthy trigger.

**A known limit of the #411 fix.** A node only repairs links it can initiate. A
node with empty `bootstrap_peers` — the classic bootstrap node — never sweeps
and depends on peers dialling it. Since either end restores a link, listing all
members on every non-bootstrap node is sufficient, but a topology where only
one node has peers configured leaves that node's losses unrepairable. Called
out in the doc comment.

**Alerting.** `omnia_node_peers_connected` should be alerted via
`max_over_time(...[10m]) < node_count-1` rather than the raw gauge. Once #422
is deployed the flapping stops, but `max_over_time` remains the safer form and
costs only one window of detection latency.
