### PR TITLE
Fix Windows test failures and deploy nodes from main, not dev


### DIFF
--- a/docs/operations/geo-testnet.md
+++ b/docs/operations/geo-testnet.md
@@ -132,16 +132,16 @@ Lane 0 acks are encoded with postcard, which is not self-describing, so a
 field added to `SignedAck` in the interim makes the two builds mutually
 unintelligible.
 
-**This testnet tracks `dev`**, per §1. Confirm the branch you deploy actually
-contains the change you mean to ship — a merge into `dev` is not in `main`,
-and checking out the wrong one rebuilds the binary already running. That
-failure is silent: the build succeeds, the containers restart, and nothing
-changes.
+**Nodes run `main`** (§1). Before deploying, confirm the change you mean to
+ship has actually reached `main` — a PR merged into `dev` has not, and
+rebuilding then produces the binary already running. That failure is silent:
+the build succeeds, containers restart, and nothing changes. Check with
+`git log origin/main --oneline -1` before touching any host.
 
 ```bash
 # On EVERY host, new and old alike:
 cd /opt/omnia-protocol
-git fetch origin && git checkout -B dev origin/dev
+git fetch origin && git checkout -B main origin/main
 git log -1 --format='%h %s'   # same hash on all five before building
 docker compose -f docker/docker-compose.wan.yml build
 ```
@@ -243,8 +243,13 @@ Ubuntu 24.04, Docker installed:
 ```bash
 apt-get update && apt-get install -y docker.io docker-compose-v2 git curl
 git clone https://github.com/Willow7737/omnia-protocol /opt/omnia-protocol
-cd /opt/omnia-protocol && git checkout dev
+cd /opt/omnia-protocol && git checkout main
 ```
+
+**Nodes run `main`, never `dev`.** `dev` is the integration branch: changes
+land there to be exercised by CI and can be red at any moment. Deploying from
+it puts unvalidated code on validators. The series is
+`feature branch → dev → CI green → merge to main → deploy`.
 
 ## 2. Firewall (all three hosts)
 

--- a/docs/operations/geo-testnet.md
+++ b/docs/operations/geo-testnet.md
@@ -126,16 +126,23 @@ and `OMNIA_BOOTSTRAP_NODES` listing the other four).
 
 **4. Put every node on the same commit, then restart in order.**
 
-New nodes get a fresh clone of the current default branch. The existing
-nodes are running whatever image they were last built from, which may be
-months behind. **Rebuild them too** — Lane 0 acks are encoded with postcard,
-which is not self-describing, so a field added to `SignedAck` in the interim
-makes the two builds mutually unintelligible.
+New nodes get a fresh clone. The existing nodes are running whatever image
+they were last built from, which may be months behind. **Rebuild them too** —
+Lane 0 acks are encoded with postcard, which is not self-describing, so a
+field added to `SignedAck` in the interim makes the two builds mutually
+unintelligible.
+
+**This testnet tracks `dev`**, per §1. Confirm the branch you deploy actually
+contains the change you mean to ship — a merge into `dev` is not in `main`,
+and checking out the wrong one rebuilds the binary already running. That
+failure is silent: the build succeeds, the containers restart, and nothing
+changes.
 
 ```bash
 # On EVERY host, new and old alike:
 cd /opt/omnia-protocol
-git fetch origin && git checkout -B main origin/main
+git fetch origin && git checkout -B dev origin/dev
+git log -1 --format='%h %s'   # same hash on all five before building
 docker compose -f docker/docker-compose.wan.yml build
 ```
 

--- a/omnia-network/src/gossip.rs
+++ b/omnia-network/src/gossip.rs
@@ -2643,18 +2643,36 @@ mod tests {
 
     /// Builds a protocol with `n` configured peers and a wired command
     /// channel, returning the receiver so dials can be observed.
+    ///
+    /// The base interval is milliseconds rather than the production 15s so a
+    /// sweep can be made due by sleeping. Backdating `last_redial` would be
+    /// the obvious alternative, but `Instant - Duration` panics on Windows,
+    /// whose monotonic clock starts near process start rather than at an
+    /// arbitrary epoch — a subtraction that merely looks large on Linux
+    /// underflows there.
     fn redial_harness(peers: usize) -> (GossipProtocol, mpsc::Receiver<NetworkCommand>) {
         let graph = Arc::new(RwLock::new(CausalGraph::new()));
         let config = GossipConfig {
             bootstrap_peers: (0..peers)
                 .map(|i| format!("/ip4/10.0.0.{}/udp/4001/quic-v1", i + 1))
                 .collect(),
+            redial_interval_ms: REDIAL_TEST_INTERVAL_MS,
             ..GossipConfig::default()
         };
         let mut gossip = GossipProtocol::new(node(1), config, graph);
         let (tx, rx) = mpsc::channel(64);
         gossip.network_cmd_tx = Some(tx);
         (gossip, rx)
+    }
+
+    /// Base re-dial interval used by the tests. With ±20% jitter the first
+    /// sweep comes due between 16ms and 24ms, so [`redial_wait_past_backoff`]
+    /// clears it with room to spare while the second sweep (32-48ms) does not.
+    const REDIAL_TEST_INTERVAL_MS: u64 = 20;
+
+    /// Sleep long enough that a first sweep is definitely due.
+    async fn redial_wait_past_backoff() {
+        tokio::time::sleep(std::time::Duration::from_millis(REDIAL_TEST_INTERVAL_MS * 5)).await;
     }
 
     /// A complete mesh must never dial. This is what keeps the sweep free on
@@ -2668,7 +2686,7 @@ mod tests {
             gossip.last_seen.insert(p, Instant::now());
         }
 
-        gossip.last_redial = Instant::now() - std::time::Duration::from_secs(3600);
+        redial_wait_past_backoff().await;
         gossip.maybe_redial_peers().await;
 
         assert!(rx.try_recv().is_err(), "a complete mesh must not dial");
@@ -2684,7 +2702,7 @@ mod tests {
         gossip.connected_peers.insert(live);
         gossip.last_seen.insert(live, Instant::now());
 
-        gossip.last_redial = Instant::now() - std::time::Duration::from_secs(3600);
+        redial_wait_past_backoff().await;
         gossip.maybe_redial_peers().await;
 
         let mut dialled = 0;
@@ -2700,7 +2718,7 @@ mod tests {
     #[tokio::test]
     async fn redial_respects_backoff_between_sweeps() {
         let (mut gossip, mut rx) = redial_harness(2);
-        gossip.last_redial = Instant::now() - std::time::Duration::from_secs(3600);
+        redial_wait_past_backoff().await;
 
         gossip.maybe_redial_peers().await;
         while rx.try_recv().is_ok() {}
@@ -2754,7 +2772,7 @@ mod tests {
     async fn redial_can_be_disabled() {
         let (mut gossip, mut rx) = redial_harness(2);
         gossip.config.redial_interval_ms = 0;
-        gossip.last_redial = Instant::now() - std::time::Duration::from_secs(3600);
+        redial_wait_past_backoff().await;
 
         gossip.maybe_redial_peers().await;
 


### PR DESCRIPTION

The four re-dial tests backdated last_redial with Instant::now() - 1h to
force a sweep due. That panics on Windows, whose monotonic clock starts near
process start rather than an arbitrary epoch, so the subtraction underflows —
'overflow when subtracting duration from instant'. Linux and macOS happen to
tolerate it, so CI caught it only on the windows-latest job.

The tests now use a 20ms base interval and sleep past it, which exercises the
real due-time path instead of manipulating the clock.

Separately, step 4 told operators to deploy from dev while section 1 cloned
dev as well. Both are wrong: dev is the integration branch and may be red at
any moment, so deploying from it puts unvalidated code on validators. Nodes
run main, and the series is feature branch -> dev -> CI green -> merge to
main -> deploy. Both places now say main and the rule is stated once,
explicitly.