### PR TITLE
Harden API integration test environment setup

### DIFF
--- a/node/tests/api_integration.rs
+++ b/node/tests/api_integration.rs
@@ -218,6 +218,33 @@ fn build_test_app_state(port: u16) -> AppState {
     }
 }
 
+/// Configure auth and rate-limit environment for a test server.
+///
+/// Callers must hold [`ENV_LOCK`] before invoking this so the process-global
+/// environment remains stable while router state reads it.
+fn configure_test_server_env(authorized_callers: Option<&str>, rate_limit_rps: Option<u64>) {
+    std::env::set_var("OMNIA_JWT_SECRET", JWT_SECRET);
+    std::env::set_var("OMNIA_JWT_ALLOW_LEGACY_HS256", "true");
+
+    if let Some(callers) = authorized_callers {
+        std::env::set_var("OMNIA_AUTHORIZED_CALLERS", callers);
+    } else {
+        std::env::remove_var("OMNIA_AUTHORIZED_CALLERS");
+    }
+
+    if let Some(rps) = rate_limit_rps {
+        std::env::set_var("OMNIA_RATE_LIMIT_RPS", rps.to_string());
+    } else {
+        std::env::remove_var("OMNIA_RATE_LIMIT_RPS");
+    }
+
+    // Reset the JWT config cache and re-initialize from the env vars we just set.
+    // Without this, validate_token() reads a stale cache from a prior test run
+    // and rejects HS256 tokens.
+    omnia_node::api::auth::reset_jwt_secret_for_test();
+    omnia_node::api::auth::init_jwt_secret();
+}
+
 /// Like `setup_server` but allows pre-registering DIDs in the economics
 /// state before the server starts. Uses the same ENV_LOCK + EnvGuard pattern
 /// as `setup_server` to avoid env var races with parallel tests.
@@ -227,15 +254,7 @@ where
 {
     let lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
 
-    std::env::set_var("OMNIA_JWT_SECRET", JWT_SECRET);
-    std::env::set_var("OMNIA_AUTHORIZED_CALLERS", ADMIN_CALLER);
-    std::env::set_var("OMNIA_JWT_ALLOW_LEGACY_HS256", "true");
-    std::env::remove_var("OMNIA_RATE_LIMIT_RPS");
-    // Reset the JWT config cache and re-initialize from the env vars we just set.
-    // Without this, validate_token() reads a stale cache from a prior test run
-    // and rejects HS256 tokens.
-    omnia_node::api::auth::reset_jwt_secret_for_test();
-    omnia_node::api::auth::init_jwt_secret();
+    configure_test_server_env(Some(ADMIN_CALLER), None);
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
         .await
@@ -288,15 +307,7 @@ where
 {
     let lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
 
-    std::env::set_var("OMNIA_JWT_SECRET", JWT_SECRET);
-    std::env::set_var("OMNIA_AUTHORIZED_CALLERS", ADMIN_CALLER);
-    std::env::set_var("OMNIA_JWT_ALLOW_LEGACY_HS256", "true");
-    std::env::remove_var("OMNIA_RATE_LIMIT_RPS");
-    // Reset the JWT config cache and re-initialize from the env vars we just set.
-    // Without this, validate_token() reads a stale cache from a prior test run
-    // and rejects HS256 tokens.
-    omnia_node::api::auth::reset_jwt_secret_for_test();
-    omnia_node::api::auth::init_jwt_secret();
+    configure_test_server_env(Some(ADMIN_CALLER), None);
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
         .await
@@ -339,10 +350,16 @@ where
 
 /// Start a test HTTP server on a random port.
 ///
-/// Reads `OMNIA_JWT_SECRET`, `OMNIA_AUTHORIZED_CALLERS`, and
-/// `OMNIA_RATE_LIMIT_RPS` from the environment at construction time.
-/// The caller must set these **before** calling this function.
-async fn start_test_server() -> (String, tokio::task::JoinHandle<()>) {
+/// The caller must hold [`ENV_LOCK`] for the lifetime of the returned server.
+/// This helper configures the environment and refreshes the JWT cache before
+/// constructing state or building the router.
+async fn start_test_server(
+    _lock: &std::sync::MutexGuard<'static, ()>,
+    authorized_callers: Option<&str>,
+    rate_limit_rps: Option<u64>,
+) -> (String, tokio::task::JoinHandle<()>) {
+    configure_test_server_env(authorized_callers, rate_limit_rps);
+
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
         .await
         .expect("Failed to bind to random port");
@@ -382,24 +399,7 @@ struct TestServer {
 async fn setup_server(rate_limit_rps: Option<u64>) -> TestServer {
     let lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
 
-    // Set auth env vars
-    std::env::set_var("OMNIA_JWT_SECRET", JWT_SECRET);
-    std::env::set_var("OMNIA_AUTHORIZED_CALLERS", ADMIN_CALLER);
-    std::env::set_var("OMNIA_JWT_ALLOW_LEGACY_HS256", "true");
-    // Reset the JWT config cache and re-initialize from the env vars we just set.
-    // Without this, validate_token() reads a stale cache from a prior test run
-    // and rejects HS256 tokens.
-    omnia_node::api::auth::reset_jwt_secret_for_test();
-    omnia_node::api::auth::init_jwt_secret();
-
-    // Set or clear rate limit override
-    if let Some(rps) = rate_limit_rps {
-        std::env::set_var("OMNIA_RATE_LIMIT_RPS", rps.to_string());
-    } else {
-        std::env::remove_var("OMNIA_RATE_LIMIT_RPS");
-    }
-
-    let (base_url, handle) = start_test_server().await;
+    let (base_url, handle) = start_test_server(&lock, Some(ADMIN_CALLER), rate_limit_rps).await;
 
     let env_guard = EnvGuard {
         keys: vec![

--- a/node/tests/docker_compose_e2e.rs
+++ b/node/tests/docker_compose_e2e.rs
@@ -106,6 +106,7 @@ impl ComposeGuard {
                 "30",
             ])
             .env("OMNIA_JWT_SECRET", TEST_COMPOSE_JWT_SECRET)
+            .env("OMNIA_JWT_ALLOW_LEGACY_HS256", "true")
             .current_dir(&self.project_root)
             .status()
             .expect("failed to run docker compose down");
@@ -141,6 +142,7 @@ fn compose_up(project_root: &PathBuf) {
     let output = Command::new("docker")
         .args(["compose", "-f", COMPOSE_FILE, "up", "-d", "--build", "--wait"])
         .env("OMNIA_JWT_SECRET", TEST_COMPOSE_JWT_SECRET)
+        .env("OMNIA_JWT_ALLOW_LEGACY_HS256", "true")
         .current_dir(project_root)
         .output()
         .expect("failed to run docker compose up");

--- a/node/tests/integration.rs
+++ b/node/tests/integration.rs
@@ -70,13 +70,14 @@ async fn start_test_server() -> (String, tokio::task::JoinHandle<()>, ServerGuar
     let lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
     // Set JWT secret before building the router so auth middleware can read it
     std::env::set_var("OMNIA_JWT_SECRET", TEST_JWT_SECRET);
+    std::env::set_var("OMNIA_JWT_ALLOW_LEGACY_HS256", "true");
     // Reset the JWT secret cache and re-initialize from the env var we just set.
     // Without this, create_token() reads a stale cache from a prior test run
     // and returns SecretNotConfigured.
     omnia_node::api::auth::reset_jwt_secret_for_test();
     omnia_node::api::auth::init_jwt_secret();
     let env_guard = EnvGuard {
-        keys: vec!["OMNIA_JWT_SECRET"],
+        keys: vec!["OMNIA_JWT_SECRET", "OMNIA_JWT_ALLOW_LEGACY_HS256"],
     };
 
     // Pick a random available port

--- a/omnia-adapters/src/settlement/bitcoin.rs
+++ b/omnia-adapters/src/settlement/bitcoin.rs
@@ -16,7 +16,7 @@ use async_trait::async_trait;
 /// Bitcoin settlement adapter.
 ///
 /// Roadmap-only stub: every legacy [`SettlementLayer`] operation returns
-/// [`SettlementError::NotImplemented`](super::SettlementError::NotImplemented).
+/// [`SettlementError::NotImplemented`].
 /// Do not wire this adapter into production settlement selection.
 ///
 /// This is a stub implementation that returns `NotImplemented` for all

--- a/omnia-adapters/src/settlement/cosmos.rs
+++ b/omnia-adapters/src/settlement/cosmos.rs
@@ -13,7 +13,7 @@ use async_trait::async_trait;
 /// Cosmos settlement adapter.
 ///
 /// Roadmap-only stub: every legacy [`SettlementLayer`] operation returns
-/// [`SettlementError::NotImplemented`](super::SettlementError::NotImplemented).
+/// [`SettlementError::NotImplemented`].
 /// Do not wire this adapter into production settlement selection.
 ///
 /// This is a stub implementation. Cosmos SDK chains with CosmWasm

--- a/omnia-adapters/src/settlement/solana.rs
+++ b/omnia-adapters/src/settlement/solana.rs
@@ -12,7 +12,7 @@ use async_trait::async_trait;
 /// Solana settlement adapter.
 ///
 /// Roadmap-only stub: every legacy [`SettlementLayer`] operation returns
-/// [`SettlementError::NotImplemented`](super::SettlementError::NotImplemented).
+/// [`SettlementError::NotImplemented`].
 /// Do not wire this adapter into production settlement selection.
 ///
 /// This is a stub implementation. Solana's native Rust programs and


### PR DESCRIPTION
### Motivation

- Prevent race conditions and stale JWT configuration by ensuring tests hold `ENV_LOCK` and configure JWT/auth/rate-limit env vars before building router or `AppState`.
- Ensure HS256 legacy JWTs are explicitly allowed and the JWT secret is reset/initialized so tokens generated in tests are accepted.

### Description

- Add `configure_test_server_env(authorized_callers: Option<&str>, rate_limit_rps: Option<u64>)` to centralize setting `OMNIA_JWT_SECRET`, `OMNIA_JWT_ALLOW_LEGACY_HS256`, `OMNIA_AUTHORIZED_CALLERS`, `OMNIA_RATE_LIMIT_RPS`, and to call `omnia_node::api::auth::reset_jwt_secret_for_test()` and `omnia_node::api::auth::init_jwt_secret()`.
- Update `setup_server_with_economics()` and `setup_server_with_financial()` to hold `ENV_LOCK` and call `configure_test_server_env()` before constructing `AppState` or building the HTTP router.
- Change `start_test_server()` signature to require the `ENV_LOCK` guard and accept `authorized_callers` and `rate_limit_rps` parameters, and call `configure_test_server_env()` before binding the listener and building the router.
- Update `setup_server()` to call the new `start_test_server(&lock, ...)` variant so env configuration and JWT cache initialization occur while `ENV_LOCK` is held.

### Testing

- Ran `cargo fmt --check` and formatting was applied to satisfy the check (now passes). 
- Built the API integration test binary with `cargo test -p omnia-node --test api_integration --no-run`, which compiled the tests successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a71f98f57a88326ae38b32bd239090e)