### PR TITLE
fix(ci): bump workspace version to 0.1.92, fix release-please toml targeting


### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,30 @@ jobs:
             echo "::error::release-please should update Cargo.toml via extra-files in its release PR."
             exit 1
           else
-            echo "Version confirmed: $EXPECTED"
+            echo "Cargo.toml confirmed: $EXPECTED"
+          fi
+
+      - name: Verify Helm Chart.yaml appVersion
+        run: |
+          EXPECTED="${{ steps.version.outputs.version }}"
+          ACTUAL=$(awk '/^appVersion:/{gsub(/[^0-9.]/, "", $2); print $2; exit}' helm/omnia-node/Chart.yaml)
+          if [ "$EXPECTED" != "$ACTUAL" ]; then
+            echo "::error::Chart.yaml appVersion ($ACTUAL) does not match tag ($EXPECTED)"
+            exit 1
+          else
+            echo "Chart.yaml confirmed: $EXPECTED"
+          fi
+
+      - name: Auto-sync Helm values.yaml image tag
+        run: |
+          EXPECTED="${{ steps.version.outputs.version }}"
+          ACTUAL=$(awk '/^  tag:/{gsub(/[^0-9.]/, "", $2); print $2; exit}' helm/omnia-node/values.yaml)
+          if [ "$EXPECTED" != "$ACTUAL" ]; then
+            echo "::warning::values.yaml image.tag ($ACTUAL) does not match tag ($EXPECTED) — auto-fixing"
+            sed -i "s/^  tag: \".*\"/  tag: \"$EXPECTED\"/" helm/omnia-node/values.yaml
+            echo "Auto-fixed values.yaml to: $EXPECTED"
+          else
+            echo "values.yaml confirmed: $EXPECTED"
           fi
 
   build-binaries:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4871,7 +4871,7 @@ dependencies = [
 
 [[package]]
 name = "omnia-adapters"
-version = "0.1.90"
+version = "0.1.92"
 dependencies = [
  "alloy",
  "ark-bn254",
@@ -4911,7 +4911,7 @@ dependencies = [
 
 [[package]]
 name = "omnia-benches"
-version = "0.1.90"
+version = "0.1.92"
 dependencies = [
  "ark-bn254",
  "ark-ff 0.4.2",
@@ -4935,7 +4935,7 @@ dependencies = [
 
 [[package]]
 name = "omnia-binding"
-version = "0.1.90"
+version = "0.1.92"
 dependencies = [
  "base64 0.22.1",
  "blake3",
@@ -4961,7 +4961,7 @@ dependencies = [
 
 [[package]]
 name = "omnia-chaos-tests"
-version = "0.1.90"
+version = "0.1.92"
 dependencies = [
  "anyhow",
  "blake3",
@@ -4985,7 +4985,7 @@ dependencies = [
 
 [[package]]
 name = "omnia-consensus"
-version = "0.1.90"
+version = "0.1.92"
 dependencies = [
  "blake3",
  "ed25519-dalek",
@@ -5008,7 +5008,7 @@ dependencies = [
 
 [[package]]
 name = "omnia-crypto"
-version = "0.1.90"
+version = "0.1.92"
 dependencies = [
  "aes-gcm",
  "bip39",
@@ -5038,7 +5038,7 @@ dependencies = [
 
 [[package]]
 name = "omnia-economics"
-version = "0.1.90"
+version = "0.1.92"
 dependencies = [
  "ed25519-dalek",
  "hex",
@@ -5054,7 +5054,7 @@ dependencies = [
 
 [[package]]
 name = "omnia-fuzz"
-version = "0.1.90"
+version = "0.1.92"
 dependencies = [
  "libfuzzer-sys",
  "omnia-adapters",
@@ -5071,7 +5071,7 @@ dependencies = [
 
 [[package]]
 name = "omnia-limit-verification"
-version = "0.1.90"
+version = "0.1.92"
 dependencies = [
  "blake3",
  "omnia-binding",
@@ -5083,7 +5083,7 @@ dependencies = [
 
 [[package]]
 name = "omnia-network"
-version = "0.1.90"
+version = "0.1.92"
 dependencies = [
  "blake3",
  "futures",
@@ -5105,7 +5105,7 @@ dependencies = [
 
 [[package]]
 name = "omnia-node"
-version = "0.1.90"
+version = "0.1.92"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -5148,7 +5148,7 @@ dependencies = [
 
 [[package]]
 name = "omnia-primitives"
-version = "0.1.90"
+version = "0.1.92"
 dependencies = [
  "bincode",
  "blake3",
@@ -5166,7 +5166,7 @@ dependencies = [
 
 [[package]]
 name = "omnia-shards"
-version = "0.1.90"
+version = "0.1.92"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -5198,7 +5198,7 @@ dependencies = [
 
 [[package]]
 name = "omnia-substrate"
-version = "0.1.90"
+version = "0.1.92"
 dependencies = [
  "aes-gcm",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,9 @@ members = [
 resolver = "2"
 
 [workspace.package]
-# Keep in sync with .release-please-manifest.json.
-# release-please updates this via extra-files; the release workflow
-# hard-fails if tag and workspace version diverge.
+# Do NOT manually edit this version. It is managed by release-please.
+# On push to main, release-please opens a PR that bumps this field,
+# Cargo.lock, and Helm Chart.yaml. The release workflow validates all match the tag.
 version = "0.1.92"
 edition = "2021"
 authors = ["Omnia Protocol Contributors"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ resolver = "2"
 # Keep in sync with .release-please-manifest.json.
 # release-please updates this via extra-files; the release workflow
 # hard-fails if tag and workspace version diverge.
-version = "0.1.90"
+version = "0.1.92"
 edition = "2021"
 authors = ["Omnia Protocol Contributors"]
 license = "CC0-1.0"

--- a/helm/omnia-node/Chart.yaml
+++ b/helm/omnia-node/Chart.yaml
@@ -3,7 +3,7 @@ name: omnia-node
 description: Omnia Protocol Node
 type: application
 version: 0.1.0
-appVersion: "0.1.90"
+appVersion: "0.1.92"
 maintainers:
   - name: omnia-protocol
 keywords:

--- a/helm/omnia-node/values.yaml
+++ b/helm/omnia-node/values.yaml
@@ -14,7 +14,7 @@ image:
   # L-28 fix (audit v0.1.68): default tag pinned to a specific release
   # version rather than `latest` (or empty), so Helm deployments are
   # reproducible. Override per-environment in your own values file.
-  tag: "0.1.90"
+  tag: "0.1.92"
 
 node:
   id: ""

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -14,7 +14,13 @@
       "tag-format": "v${version}",
       "separate-pull-requests": false,
       "skip-github-release": false,
-      "extra-files": ["Cargo.toml", "Cargo.lock"]
+      "extra-files": [
+        {
+          "type": "toml",
+          "path": "Cargo.toml"
+        },
+        "Cargo.lock"
+      ]
     }
   },
   "changelog-type": "default",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -19,7 +19,12 @@
           "type": "toml",
           "path": "Cargo.toml"
         },
-        "Cargo.lock"
+        "Cargo.lock",
+        {
+          "type": "json",
+          "path": "helm/omnia-node/Chart.yaml",
+          "jsonpath": "$..appVersion"
+        }
       ]
     }
   },


### PR DESCRIPTION

- Cargo.toml: 0.1.90 -> 0.1.92 to match latest release tag
- .release-please-manifest.json: align to 0.1.92
- Helm values.yaml + Chart.yaml: 0.1.90 -> 0.1.92
- Cargo.lock: workspace-only update (14 members, 187 deps unchanged)
- release-please-config.json: use explicit object format for Cargo.toml
  extra-files entry to ensure TOML handler is used (previously
  the plain string fallback may not have targeted workspace.package.version)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the application and deployment package version to 0.1.92.
  * Updated the deployment image to use version 0.1.92.
  * Improved release configuration for consistent version updates across application and deployment artifacts.

* **Bug Fixes**
  * Enhanced release validation to verify matching application and deployment versions.
  * Added automatic correction and warning when the deployment image version differs from the release version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->