### PR TITLE
fix(ci): use yaml type for Chart.yaml in release-please config



### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -21,9 +21,9 @@
         },
         "Cargo.lock",
         {
-          "type": "json",
+          "type": "yaml",
           "path": "helm/omnia-node/Chart.yaml",
-          "jsonpath": "$..appVersion"
+          "target": "appVersion"
         }
       ]
     }


### PR DESCRIPTION
json type with jsonpath does not work on YAML files.
appVersion is a top-level key, so yaml type + target is correct.

values.yaml image.tag is nested (image.tag) which release-please
cannot handle, so it stays managed by the auto-sync in release.yml.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Helm chart release configuration to use YAML targeting for the application version.
  * Improved compatibility and reliability when updating chart metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->