### PR TITLE
fix(ci): remove Chart.yaml from release-please, auto-sync both Helm files in release.yml


### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,25 +68,22 @@ jobs:
             echo "Cargo.toml confirmed: $EXPECTED"
           fi
 
-      - name: Verify Helm Chart.yaml appVersion
+      - name: Auto-sync Helm files to release version
         run: |
           EXPECTED="${{ steps.version.outputs.version }}"
-          ACTUAL=$(awk '/^appVersion:/{gsub(/[^0-9.]/, "", $2); print $2; exit}' helm/omnia-node/Chart.yaml)
-          if [ "$EXPECTED" != "$ACTUAL" ]; then
-            echo "::error::Chart.yaml appVersion ($ACTUAL) does not match tag ($EXPECTED)"
-            exit 1
+          CHART_ACTUAL=$(awk '/^appVersion:/{gsub(/[^0-9.]/, "", $2); print $2; exit}' helm/omnia-node/Chart.yaml)
+          VALUES_ACTUAL=$(awk '/^  tag:/{gsub(/[^0-9.]/, "", $2); print $2; exit}' helm/omnia-node/values.yaml)
+
+          if [ "$CHART_ACTUAL" != "$EXPECTED" ]; then
+            echo "::warning::Chart.yaml appVersion ($CHART_ACTUAL) → $EXPECTED — auto-fixing"
+            sed -i "s/^appVersion: \".*\"/appVersion: \"$EXPECTED\"/" helm/omnia-node/Chart.yaml
           else
             echo "Chart.yaml confirmed: $EXPECTED"
           fi
 
-      - name: Auto-sync Helm values.yaml image tag
-        run: |
-          EXPECTED="${{ steps.version.outputs.version }}"
-          ACTUAL=$(awk '/^  tag:/{gsub(/[^0-9.]/, "", $2); print $2; exit}' helm/omnia-node/values.yaml)
-          if [ "$EXPECTED" != "$ACTUAL" ]; then
-            echo "::warning::values.yaml image.tag ($ACTUAL) does not match tag ($EXPECTED) — auto-fixing"
+          if [ "$VALUES_ACTUAL" != "$EXPECTED" ]; then
+            echo "::warning::values.yaml image.tag ($VALUES_ACTUAL) → $EXPECTED — auto-fixing"
             sed -i "s/^  tag: \".*\"/  tag: \"$EXPECTED\"/" helm/omnia-node/values.yaml
-            echo "Auto-fixed values.yaml to: $EXPECTED"
           else
             echo "values.yaml confirmed: $EXPECTED"
           fi

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -19,12 +19,7 @@
           "type": "toml",
           "path": "Cargo.toml"
         },
-        "Cargo.lock",
-        {
-          "type": "yaml",
-          "path": "helm/omnia-node/Chart.yaml",
-          "target": "appVersion"
-        }
+        "Cargo.lock"
       ]
     }
   },


### PR DESCRIPTION

release-please v17.6.0 does not support yaml type for extra-files —
it poisons the entire extra-files pipeline with a JSONPath error.

Fix:
- release-please-config.json: revert to only Cargo.toml + Cargo.lock
  (the two file types release-please handles natively)
- release.yml: merge the two Helm checks into one step that auto-syncs
  BOTH Chart.yaml (appVersion) and values.yaml (image.tag)

The divide of labor is now:
- release-please bumps: Cargo.toml, Cargo.lock, CHANGELOG.md, manifest
- release.yml auto-syncs: Helm Chart.yaml + values.yaml (sed, never blocks)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Management**
  * Release validation now automatically corrects mismatched Helm application and image versions instead of failing.
  * Matching versions are confirmed during validation.
  * `Cargo.lock` is now included in automated release updates.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->