### PR TITLE
fix(ci): use plain-string extra-files for release-please



### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -14,13 +14,7 @@
       "tag-format": "v${version}",
       "separate-pull-requests": false,
       "skip-github-release": false,
-      "extra-files": [
-        {
-          "type": "toml",
-          "path": "Cargo.toml"
-        },
-        "Cargo.lock"
-      ]
+      "extra-files": ["Cargo.toml", "Cargo.lock"]
     }
   },
   "changelog-type": "default",


### PR DESCRIPTION
type:toml crashes because [workspace.package].version is nested.
Plain strings use regex PlainText updater instead of JSONPath.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release configuration for more streamlined version management.
  * Continued tracking updates across both package manifest and lock files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->