### PR TITLE
Serve protocol-wide monitoring reads without a JWT

### DIFF
--- a/node/src/api/mod.rs
+++ b/node/src/api/mod.rs
@@ -153,6 +153,28 @@ pub fn build_api_router_with(authorized: Arc<AuthorizedCallers>) -> Router<AppSt
         .route("/errors", get(errors::error_codes))
         .route("/ceremony/state", get(ceremony::ceremony_state))
         .route("/ceremony/transcript", get(ceremony::ceremony_transcript))
+        // Protocol-wide monitoring reads (§4.4, §5, §6, §7, §8, §15).
+        //
+        // These are aggregates over the whole protocol — supply totals, treasury
+        // buckets, fee policy, provider health — with no per-account data and no
+        // caller-derived response. They are what the public dashboard and status
+        // pages render, so requiring a JWT would leave those surfaces blank for
+        // anyone not signed in. Every handler here takes only `State`; none reads
+        // `CallerIdentity`, which is what makes serving them outside the auth
+        // layer well-defined rather than merely convenient.
+        //
+        // Per-account reads (`/economics/balance/:did`, `/financial/balance/:pubkey`),
+        // fee *calculation*, and every mutation stay authenticated below.
+        .route("/supply", get(supply::get_supply))
+        .route("/supply/invariants", get(supply::verify_supply_invariants))
+        .route("/treasury/status", get(treasury::get_treasury_status))
+        .route("/treasury/inventory", get(treasury::get_pilot_inventory))
+        .route("/treasury/accounting", get(treasury::get_treasury_accounting))
+        .route("/fees/burn-policy", get(fees::get_burn_policy))
+        .route("/fees/stats", get(fees::get_fee_stats))
+        .route("/economics/fee-burn", get(economics::get_fee_burn_stats))
+        .route("/bridge/providers", get(bridge::list_providers))
+        .route("/bridge/health", get(bridge::bridge_health))
         // Wallet challenge/signature login — issues JWTs, so must be public.
         .route("/auth/challenge", post(wallet_auth::request_challenge))
         .route("/auth/login", post(wallet_auth::login))
@@ -189,23 +211,10 @@ pub fn build_api_router_with(authorized: Arc<AuthorizedCallers>) -> Router<AppSt
         // Ceremony write operations
         .route("/ceremony/contribute", post(ceremony::ceremony_contribute))
         .route("/ceremony/finalize", post(ceremony::ceremony_finalize))
-        // Sprint 3: Fee-burn statistics (public for dashboards/monitoring)
-        .route("/economics/fee-burn", get(economics::get_fee_burn_stats))
-        // Sprint 3–5: Financial pallet endpoints (Spec §4–§7, §8, §15)
-        // Treasury (§5, §6) — public for monitoring
-        .route("/treasury/status", get(treasury::get_treasury_status))
-        .route("/treasury/inventory", get(treasury::get_pilot_inventory))
-        .route("/treasury/accounting", get(treasury::get_treasury_accounting))
-        // Supply (§4.4, §5.1) — public for monitoring
-        .route("/supply", get(supply::get_supply))
-        .route("/supply/invariants", get(supply::verify_supply_invariants))
-        // Fees and burn (§7)
-        .route("/fees/burn-policy", get(fees::get_burn_policy))
+        // Fee calculation is a POST that prices a hypothetical operation, not a
+        // monitoring read, so it stays behind the JWT with the other non-reads.
+        // The monitoring aggregates it sits beside are served publicly above.
         .route("/fees/calculate", post(fees::calculate_fee))
-        .route("/fees/stats", get(fees::get_fee_stats))
-        // Bridge (§8, §15)
-        .route("/bridge/providers", get(bridge::list_providers))
-        .route("/bridge/health", get(bridge::bridge_health))
         // Payment orders (§8): economic terms come only from signed quotes.
         .route("/payment-orders/quote", post(payment_orders::request_quote))
         .route("/payment-orders/initiate", post(payment_orders::initiate_payment))

--- a/node/tests/integration.rs
+++ b/node/tests/integration.rs
@@ -357,3 +357,72 @@ async fn test_openapi_json_disabled() -> Result<()> {
     assert_eq!(resp.status(), 404, "OpenAPI JSON should be 404 when feature disabled");
     Ok(())
 }
+
+/// Protocol-wide monitoring reads must be reachable without a JWT.
+///
+/// These routes previously sat inside the authenticated router while their own
+/// comments described them as "public for dashboards/monitoring". The code won,
+/// silently: the public dashboard would have started returning 401 on its
+/// treasury, supply and fee panels the moment the financial layer shipped.
+/// Pinning both directions here means that drift fails a test instead of a
+/// status page.
+#[tokio::test]
+async fn test_monitoring_reads_are_public() -> Result<()> {
+    let (base_url, _handle, _guards) = start_test_server().await;
+    let client = reqwest::Client::new();
+
+    for path in [
+        "/api/v1/supply",
+        "/api/v1/supply/invariants",
+        "/api/v1/treasury/status",
+        "/api/v1/treasury/inventory",
+        "/api/v1/treasury/accounting",
+        "/api/v1/fees/burn-policy",
+        "/api/v1/fees/stats",
+        "/api/v1/economics/fee-burn",
+        "/api/v1/bridge/providers",
+        "/api/v1/bridge/health",
+    ] {
+        let resp = client.get(format!("{base_url}{path}")).send().await?;
+        assert_ne!(
+            resp.status(),
+            401,
+            "{path} must be reachable without a token — it is a protocol-wide aggregate rendered by public dashboards"
+        );
+        assert_ne!(resp.status(), 404, "{path} should be routed");
+    }
+
+    Ok(())
+}
+
+/// The other half of the boundary: widening the monitoring reads must not have
+/// widened anything that exposes a single account or changes state.
+#[tokio::test]
+async fn test_account_and_mutation_routes_still_require_auth() -> Result<()> {
+    let (base_url, _handle, _guards) = start_test_server().await;
+    let client = reqwest::Client::new();
+
+    let unauthenticated_gets = [
+        "/api/v1/economics/balance/did:omnia:abc",
+        "/api/v1/financial/balance/deadbeef",
+    ];
+    for path in unauthenticated_gets {
+        let resp = client.get(format!("{base_url}{path}")).send().await?;
+        assert_eq!(
+            resp.status(),
+            401,
+            "{path} exposes one account and must stay authenticated"
+        );
+    }
+
+    // Fee calculation prices a hypothetical operation; it is a POST, not a
+    // monitoring read, and stays behind the JWT with the other non-reads.
+    let resp = client
+        .post(format!("{base_url}/api/v1/fees/calculate"))
+        .json(&json!({ "operation": "transfer" }))
+        .send()
+        .await?;
+    assert_eq!(resp.status(), 401, "/fees/calculate must stay authenticated");
+
+    Ok(())
+}


### PR DESCRIPTION
## 🚀 Description

Moves ten protocol-wide monitoring reads out of the authenticated router and into the public one:

```
/supply, /supply/invariants
/treasury/status, /treasury/inventory, /treasury/accounting
/fees/burn-policy, /fees/stats
/economics/fee-burn
/bridge/providers, /bridge/health
```

No handler changed — only where the routes are registered.

**Deliberately not widened:** `/economics/balance/:did` and `/financial/balance/:pubkey` (each exposes a single account), `/fees/calculate` (a POST that prices a hypothetical operation — it sits among the fee reads and is easy to sweep along with them, but it is not a monitoring read), and every mutation.

## 💡 Motivation and Context

These ten routes sat inside `authenticated_routes` while the comments directly above three of the groups described them as *"public for dashboards/monitoring"*. The code won that disagreement silently.

Nothing surfaced it because **these routes do not exist on `main` yet**. The deployed node (v0.1.95, built from `main`) returns 404 for all of them. The moment the financial layer ships, `omnia-protocol-interface` — an unauthenticated public dashboard — would have started returning 401 on its treasury, supply and fee panels. That is a regression introduced *by* the release rather than by any commit in it, which is the kind that gets diagnosed slowly and on the most visible surface.

The comments described the intent correctly, so the routing is what changed.

Each of the ten is a `GET` returning an aggregate over the whole protocol — supply totals, treasury buckets, fee policy, provider health. None carries per-account data and none varies by caller: every one of these handlers takes only `State`, and not one reads `CallerIdentity`. That is what makes serving them outside the auth layer well-defined rather than merely convenient, and it is why the move needed no handler changes.

## ✅ How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing

Both directions of the boundary are pinned, because this drifted once already and the drift was invisible:

- `test_monitoring_reads_are_public` — every one of the ten answers something other than 401/404 without a token. **Red-checked:** reverted against the previous routing it fails on `/api/v1/supply` with *"must be reachable without a token"*.
- `test_account_and_mutation_routes_still_require_auth` — the per-account reads and `/fees/calculate` still answer 401.

Local gate run:

- `cargo fmt --all -- --check` clean
- `cargo clippy --lib --workspace --exclude omnia-fuzz -- -D warnings -D clippy::unwrap_used` clean
- 140 `omnia-node` tests pass, including the two new boundary tests

## 📝 Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## ➕ Additional Context

This is intended to land on `dev` **before** the `dev` → `main` promotion in #469, so that release ships with the dashboard boundary already correct.

Two things worth carrying into that deploy, unchanged by this PR:

1. `OMNIA_MINT_AUTHORITY` must be set network-wide across all three nodes. Minting requires it, and unset disables minting rather than falling back to each node's own key — that fallback was the per-node divergence bug. Ship without setting it and the ledger mints nothing, so treasury and supply panels render zeros that look like a broken deploy.
2. `/readyz` counts Lane 1 commits; Lane 1 is idle on a quiet network, which is not a fault.
