### PR TITLE
Pass OMNIA_MINT_AUTHORITY into the container, correct the 5-node claims, add rollout runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,12 +88,19 @@ All five on v0.1.76+, stake 1 each. Three regions (eu-central, us-east,
 ap-southeast) with two continents. Only node A exposes HTTP publicly; B–E
 are validators reachable over the P2P mesh but not the REST API.
 
-Lane 0 is doing real work on it:
+The mesh is fully peered and currently idle — nothing has been submitted to
+it since the v0.1.95 rollout, so the Lane 0 counters read zero:
 
 ```jsonc
 // GET /api/v1/node/info  (node A)
-{ "peers": 4, "lane0": { "acks_accepted": 27, "acks_rejected": 0, "events_finalized": 9 } }
+{ "peers": 4, "version": "0.1.95", "protocol_version": "4.0.0",
+  "lane0": { "acks_accepted": 0, "acks_rejected": 0, "events_finalized": 0 } }
 ```
+
+Zero counters here mean no traffic, not a stalled lane. What Lane 0 does
+under load is recorded in
+[benchmark-gates.md](docs/reference/benchmark-gates.md): 10k-event bursts
+reaching 100% propagation and full quorum finality across all five nodes.
 
 **Readiness contract.** `/readyz` reports the node as ready when it is
 operational for traffic: it has the configured minimum peer count and is
@@ -101,7 +108,7 @@ not in fast-sync. It does **not** require recent traffic, Lane 1 canonical
 commits, or Lane 0 preconfirmations, so quiet networks stay ready:
 
 ```jsonc
-{ "status": "ready", "peers": 4, "finalized_height": 0, "lane0_enabled": true, "lane0_finalized_events": 9 }
+{ "status": "ready", "peers": 4, "finalized_height": 0, "lane0_enabled": true, "lane0_finalized_events": 0 }
 ```
 
 Use `/api/v1/node/info` and Prometheus finality metrics to monitor Lane 0
@@ -333,7 +340,7 @@ cargo bench --no-run
 | Cosmos settlement adapter  | ⚠️ **STUB**             | Implements trait, no-op methods                      |
 | Proof-of-useful-work       | ⚠️ **STUB**             | 3 types defined, no real verification                |
 | Mobile wallet              | ✅ **Shipped (v1)**     | [`Omnia-Wallet`](https://github.com/Willow7737/Omnia-Wallet) — dual-mode auth, live against the testnet node |
-| Validator network          | ✅ **Running** (3 nodes) | Geo-distributed EU/US/Asia mesh — but all three run by the same operator, so not yet trust-distributed |
+| Validator network          | ✅ **Running** (5 nodes) | Geo-distributed EU/US/Asia mesh — but all five run by the same operator, so not yet trust-distributed |
 | Conviction voting          | 🌑 Not started          | Planned for post-testnet                             |
 | Delegation                 | 🌑 Not started          | Planned for post-testnet                             |
 | Production ZK hash gadget  | ✅ Poseidon implemented | Cauchy MDS + BLAKE3 round constants (not Grain LFSR) |
@@ -464,10 +471,18 @@ _Goal: Performance Validation_
 - 🔄 14 medium-priority findings tracked (see [status.md](docs/reference/status.md))
 - 📋 External security audit
 - ✅ Public testnet endpoint **live** (single node at `78.47.43.136.sslip.io`, 0 peers)
-- ✅ **Standing validator network — live.** A 3-node geo-distributed mesh
-  (EU / US-East / Asia) runs continuously with 2 peers each and Lane 0
-  finalizing events. Measured RTTs match the benchmark baseline exactly.
-- 🔄 **Independent operators — not yet.** All three nodes are run by the
+- ✅ **Standing validator network — live.** A 5-node geo-distributed mesh
+  (Nuremberg / Ashburn / Singapore / Helsinki / Falkenstein) runs
+  continuously with 4 peers each. Measured RTTs match the benchmark baseline
+  exactly. Five equal-stake validators put Lane 0 finality at 4-of-5 acks, so
+  the network now tolerates one node down — at three nodes, quorum was all
+  three and fault tolerance was zero. The mesh is fully peered but **idle**:
+  no events have been submitted since the v0.1.95 rollout, so the Lane 0
+  counters read zero. That is an absence of traffic, not an absence of
+  liveness — the 10k-burst runs in
+  [benchmark-gates.md](docs/reference/benchmark-gates.md) are what Lane 0
+  does under load.
+- 🔄 **Independent operators — not yet.** All five nodes are run by the
   same operator, so the network is geo-distributed but not yet
   trust-distributed. The external operator onboarding path is documented,
   but third-party validators are still the remaining step; see

--- a/docker/.env.wan.example
+++ b/docker/.env.wan.example
@@ -30,6 +30,16 @@ OMNIA_LANE0_VALIDATORS=REPLACE_ME_WITH_output_from_setup_validators_sh
 # Must match the actual number of nodes running.
 OMNIA_TOTAL_NODES=5
 
+# Ed25519 public key (64 hex chars) authorised to mint on the financial
+# shard.  Like OMNIA_LANE0_VALIDATORS this is a shared genesis parameter and
+# MUST be byte-identical on every node — it is not this node's own key.
+#
+# Leaving it empty does not fall back to anything: minting is disabled, and
+# /api/v1/supply and /api/v1/treasury/* report zeros.  Those endpoints serve
+# unauthenticated, so on a public deployment an empty value reads as a broken
+# economy rather than a disabled one.  Set it deliberately, either way.
+OMNIA_MINT_AUTHORITY=
+
 # ---------------------------------------------------------------------------
 # PER-NODE — edit these on each host (unique per node)
 # ---------------------------------------------------------------------------

--- a/docker/docker-compose.wan.yml
+++ b/docker/docker-compose.wan.yml
@@ -20,6 +20,16 @@
 #                           (empty on the bootstrap node itself)
 #   OMNIA_KEY_DIR           host path to this node's key dir, e.g.
 #                           ../ops/testnet-keys/node1
+#   OMNIA_MINT_AUTHORITY    Ed25519 pubkey (64 hex) authorised to mint on
+#                           the financial shard. Optional, but if you set it
+#                           it MUST be byte-identical on every node — it is a
+#                           shared genesis parameter, not a per-node key.
+#                           Leaving it unset does not fall back to anything:
+#                           minting is disabled and the treasury and supply
+#                           endpoints report zeros. Those endpoints are
+#                           unauthenticated, so on a public deployment that
+#                           reads as a broken economy rather than a disabled
+#                           one. Set it deliberately, either way.
 #
 # Bring up:
 #   docker compose -f docker/docker-compose.wan.yml up -d --build
@@ -41,13 +51,13 @@ services:
       - OMNIA_LISTEN_ADDR=/ip4/0.0.0.0/udp/4001/quic-v1
       - OMNIA_HTTP_PORT=9090
       - OMNIA_DATA_DIR=/app/data
-      - OMNIA_TOTAL_NODES=${OMNIA_TOTAL_NODES:-3}
+      - OMNIA_TOTAL_NODES=${OMNIA_TOTAL_NODES:-5}
       - OMNIA_JWT_SECRET=${OMNIA_JWT_SECRET:?copy docker/.env from the key host}
-      - OMNIA_JWT_ALLOW_LEGACY_HS256=${OMNIA_JWT_ALLOW_LEGACY_HS256:-false}
       - OMNIA_JWT_ALLOW_LEGACY_HS256=${OMNIA_JWT_ALLOW_LEGACY_HS256:-false}
       - OMNIA_AUTHORIZED_CALLERS=admin-caller
       - OMNIA_RATE_LIMIT_RPS=${OMNIA_RATE_LIMIT_RPS:-1000}
       - OMNIA_LANE0_VALIDATORS=${OMNIA_LANE0_VALIDATORS:?copy docker/.env from the key host}
+      - OMNIA_MINT_AUTHORITY=${OMNIA_MINT_AUTHORITY:-}
       - OMNIA_NODE_KEY_FILE=/keys/validator_key.bin
     volumes:
       - wan-node-data:/app/data

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       - OMNIA_AUTHORIZED_CALLERS=admin-caller
       - OMNIA_RATE_LIMIT_RPS=${OMNIA_RATE_LIMIT_RPS:-10}
       - OMNIA_LANE0_VALIDATORS=${OMNIA_LANE0_VALIDATORS:-}
+      - OMNIA_MINT_AUTHORITY=${OMNIA_MINT_AUTHORITY:-}
     ports:
       - "9090:8080/tcp"
     networks:
@@ -55,6 +56,7 @@ services:
       - OMNIA_AUTHORIZED_CALLERS=admin-caller
       - OMNIA_RATE_LIMIT_RPS=${OMNIA_RATE_LIMIT_RPS:-10}
       - OMNIA_LANE0_VALIDATORS=${OMNIA_LANE0_VALIDATORS:-}
+      - OMNIA_MINT_AUTHORITY=${OMNIA_MINT_AUTHORITY:-}
     ports:
       - "9091:8080/tcp"
     networks:
@@ -83,6 +85,7 @@ services:
       - OMNIA_AUTHORIZED_CALLERS=admin-caller
       - OMNIA_RATE_LIMIT_RPS=${OMNIA_RATE_LIMIT_RPS:-10}
       - OMNIA_LANE0_VALIDATORS=${OMNIA_LANE0_VALIDATORS:-}
+      - OMNIA_MINT_AUTHORITY=${OMNIA_MINT_AUTHORITY:-}
     ports:
       - "9092:8080/tcp"
     networks:
@@ -113,6 +116,7 @@ services:
       - OMNIA_AUTHORIZED_CALLERS=admin-caller
       - OMNIA_RATE_LIMIT_RPS=${OMNIA_RATE_LIMIT_RPS:-10}
       - OMNIA_LANE0_VALIDATORS=${OMNIA_LANE0_VALIDATORS:-}
+      - OMNIA_MINT_AUTHORITY=${OMNIA_MINT_AUTHORITY:-}
     ports:
       - "9093:8080/tcp"
     networks:
@@ -145,6 +149,7 @@ services:
       - OMNIA_AUTHORIZED_CALLERS=admin-caller
       - OMNIA_RATE_LIMIT_RPS=${OMNIA_RATE_LIMIT_RPS:-10}
       - OMNIA_LANE0_VALIDATORS=${OMNIA_LANE0_VALIDATORS:-}
+      - OMNIA_MINT_AUTHORITY=${OMNIA_MINT_AUTHORITY:-}
     ports:
       - "9094:8080/tcp"
     networks:

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -12,6 +12,7 @@
 | [monitoring.md](monitoring.md)                                   | Monitoring setup — Grafana, Prometheus, alert rules                 |
 | [deployment.md](deployment.md)                                   | Deployment procedures — Docker Compose, Kubernetes/Helm             |
 | [runbook.md](runbook.md)                                         | Operations runbook — key rotation, slashing, partition recovery     |
+| [financial-layer-rollout.md](financial-layer-rollout.md)         | Rolling the financial-layer release across the standing 5-node mesh |
 | [feature-flags.md](feature-flags.md)                             | Feature flag reference                                              |
 | [cli-and-api.md](cli-and-api.md)                                 | CLI subcommands and REST API reference                              |
 | [self-hosted-runner-setup.md](self-hosted-runner-setup.md)       | Self-hosted GitHub Actions runner setup guide                       |

--- a/docs/operations/financial-layer-rollout.md
+++ b/docs/operations/financial-layer-rollout.md
@@ -1,0 +1,193 @@
+# Financial Layer Rollout — Runbook
+
+> Audience: Operators
+> Context: Promoting `dev` → `main` (PR #469) and rolling the resulting build
+> across the standing 5-node geo mesh.
+> Companion to [geo-testnet.md](./geo-testnet.md), which covers standing up a
+> node from nothing. This covers upgrading nodes that are already running.
+
+This release is different from previous ones in two ways, and both change the
+procedure:
+
+1. It ships the financial layer — asset registry, treasury, supply
+   accounting, fee burn. Those subsystems are inert unless
+   `OMNIA_MINT_AUTHORITY` is set, and the endpoints that expose them are
+   **unauthenticated**.
+2. The mesh is five nodes now, not three. Lane 0 finality needs 4-of-5 acks,
+   so one node can be down without stalling the network. This is the first
+   release that can be rolled node-by-node instead of coordinated.
+
+## 0. Pre-flight
+
+Everything here is verifiable before you touch a host. Do not skip to §2.
+
+### 0.1 Wire protocol is unchanged
+
+```bash
+grep 'pub const PROTOCOL_VERSION' substrate/src/lib.rs   # expect "4.0.0"
+curl -s https://78.47.43.136.sslip.io/api/v1/node/info | grep protocol_version
+```
+
+Both must read `4.0.0`. Old and new nodes peer across the roll only because
+this is unchanged — if a future release bumps it, the node-by-node procedure
+in §2 is invalid and every node must restart together.
+
+### 0.2 The version must actually move
+
+Merging #469 does **not** bump the version. `release-please` runs on push to
+`main` and opens a *Release PR*; the bump to `Cargo.toml` and the `v…` tag
+land only when that second PR is merged.
+
+Merge #469, wait for the Release PR, merge it too, then confirm:
+
+```bash
+git fetch --tags origin && git tag --sort=-v:refname | head -1   # expect > v0.1.95
+git show origin/main:Cargo.toml | grep -m1 '^version'
+```
+
+If you build from `main` after #469 but before the Release PR, every node
+reports `0.1.95` — the version they already report. You will have no way to
+tell an upgraded node from a stale one, on any of the five hosts. That is the
+whole reason this step is a gate.
+
+### 0.3 Decide the mint authority
+
+`OMNIA_MINT_AUTHORITY` is an Ed25519 public key (64 hex chars) and is a
+**shared genesis parameter** — byte-identical on all five nodes, like
+`OMNIA_LANE0_VALIDATORS`. It is not the node's own key.
+
+Unset does not fall back to anything. Minting is disabled, and
+`/api/v1/supply` and `/api/v1/treasury/*` answer zeros. Those routes serve
+without a JWT, so on the public ingress an unset value renders as a complete,
+working-looking, entirely zero economy — indistinguishable to a visitor from
+a broken deploy.
+
+Set it deliberately, in `docker/.env` on **every** host:
+
+```bash
+grep OMNIA_MINT_AUTHORITY docker/.env      # same 64 hex chars on all five
+```
+
+Or decide minting stays off for this release and leave it empty everywhere —
+that is a legitimate choice, but make it a choice.
+
+> Until the fix in this branch, `docker-compose.wan.yml` did not pass
+> `OMNIA_MINT_AUTHORITY` into the container at all. Setting it on the host
+> had no effect. Confirm you are deploying a compose file that forwards it:
+> `grep MINT_AUTHORITY docker/docker-compose.wan.yml`.
+
+## 1. Roll order
+
+| Order | Node | Host | Why this position |
+|:-----:|:-----|:-----|:------------------|
+| 1 | **E** | `46.224.103.217` Falkenstein | Plain validator, newest, least load-bearing |
+| 2 | **D** | `46.62.218.24` Helsinki | Plain validator |
+| 3 | **C** | `5.223.85.30` Singapore | Plain validator, highest RTT |
+| 4 | **B** | `178.156.163.211` Ashburn | Plain validator |
+| 5 | **A** | `78.47.43.136` Nuremberg | **Last.** Bootstrap + public ingress + bench host + Bitcoin testnet4 |
+
+One node at a time. With 4-of-5 quorum the mesh keeps finalising throughout;
+take two down at once and it stalls.
+
+Node A goes last because it is the bootstrap peer, the only public HTTP
+surface, and the dashboard's endpoint. Restarting it is the only step in this
+list a user can see.
+
+## 2. Per-node procedure
+
+On each host, in the order above:
+
+```bash
+cd ~/omnia-protocol
+git fetch origin main && git checkout main && git pull --ff-only origin main
+
+# confirm you are on the tagged release, not just main's tip
+git describe --tags --exact-match 2>/dev/null || echo "WARNING: not on a tag"
+
+docker compose -f docker/docker-compose.wan.yml up -d --build
+```
+
+Then verify **before moving to the next node**:
+
+```bash
+curl -s http://localhost:9090/api/v1/node/info | python3 -m json.tool
+```
+
+Check all four:
+
+- `version` — the new version from §0.2, not `0.1.95`
+- `protocol_version` — `4.0.0`
+- `peers` — climbs back to `4`; give it ~30 s
+- `/health` — `alive`
+
+If `peers` does not return to 4 within a couple of minutes, **stop**. Do not
+roll the next node. See §4.
+
+## 3. Post-deploy verification
+
+From anywhere, against the public ingress — no token, which is the point:
+
+```bash
+curl -s https://78.47.43.136.sslip.io/api/v1/supply
+curl -s https://78.47.43.136.sslip.io/api/v1/treasury/status
+curl -s https://78.47.43.136.sslip.io/api/v1/fees/burn-policy
+curl -s https://78.47.43.136.sslip.io/api/v1/bridge/health
+```
+
+All four must answer without a JWT. A `401` means the routes regressed behind
+the auth layer; a `404` means node A is still on the old build.
+
+Then confirm the per-account routes did **not** open up:
+
+```bash
+curl -s -o /dev/null -w '%{http_code}\n' \
+  https://78.47.43.136.sslip.io/api/v1/financial/balance/deadbeef   # expect 401
+```
+
+### The real smoke test
+
+The mesh has been idle since the v0.1.95 rollout — Lane 0 counters and
+`events_submitted_total` all read zero. Zero counters after this deploy prove
+nothing, because they read zero before it too.
+
+Submit one authenticated event and watch `acks_accepted` move on more than
+one node. That is the first evidence the release actually works, as opposed
+to merely starting.
+
+## 4. If a node fails to rejoin
+
+The mesh tolerates exactly one node down. A failed upgrade is not an
+emergency — it is a budget you have now spent.
+
+1. **Do not roll another node.**
+2. Check logs: `docker compose -f docker/docker-compose.wan.yml logs --tail=100`
+3. Most likely causes, in order:
+   - `OMNIA_LANE0_VALIDATORS` mismatch — acks rejected as "unknown validator"
+   - `OMNIA_MINT_AUTHORITY` set on some hosts but not others
+   - `OMNIA_JWT_SECRET` drift between hosts
+   - Key dir not mounted (`OMNIA_KEY_DIR`)
+4. To roll back one node, check out the previous tag and rebuild:
+
+```bash
+git checkout v0.1.95
+docker compose -f docker/docker-compose.wan.yml up -d --build
+```
+
+Rolling back a single node is safe precisely because the wire protocol is
+unchanged (§0.1) — a `v0.1.95` node peers with the new ones.
+
+## 5. After the rollout
+
+The public docs describe the mesh as idle, with zero Lane 0 counters, because
+that is what it has been. If this deploy is followed by real traffic, those
+claims go stale in the good direction and should be updated:
+
+- `README.md` — the live-network block and the standing-network bullet
+- `omnia-protocol-interface/README.md` — the "what the dashboard will show" block
+- `omnia-web` — FAQ and roadmap entries
+- `Omnia-Wallet/README.md` — the testnet description
+
+Each one currently says the counters read zero. Do not leave that in place
+once it stops being true; the reason it is written down at all is that the
+previous claim — "Lane 0 finalizing events" — outlived its accuracy and sat
+there next to an endpoint anyone could curl.


### PR DESCRIPTION
## 🚀 Description

Three related things, all pre-flight for the #469 promotion.

**1. `docker-compose.wan.yml` never forwarded `OMNIA_MINT_AUTHORITY` into the container.** Only `docker-compose.external-validator.yml` did. The five geo nodes run `wan.yml`, so setting the variable on the hosts — exactly as `validator-setup.md` instructs — had no effect.

**2. README claims that still said the mesh was 3 nodes**, plus a Lane 0 claim that no longer holds.

**3. A rollout runbook** (`docs/operations/financial-layer-rollout.md`) for taking this release across the standing mesh.

## 💡 Motivation and Context

### The compose gap

`mint_authority` is an `Option` with no fallback, so unset is indistinguishable at runtime from a deliberate decision not to mint — nothing appears in any log. The symptom only surfaces at the edge: `/api/v1/supply` and `/api/v1/treasury/*` answer zeros, and as of #470 they answer them **without a JWT**, on the public ingress. Shipping the financial layer through this file would have put a complete, working-looking, entirely zero economy on the dashboard's front page.

Forwarded in `wan.yml` and in all five services of the local `docker-compose.yml`, so the same trap doesn't catch anyone testing locally first. `lane0.yml` needs no change — it's an overlay and inherits the base environment.

Kept as `${VAR:-}` rather than `${VAR:?}`: a non-minting network is legitimate, and making it required would break every currently running node on restart. The header comments and `.env.wan.example` now state what unset actually means.

Two things noticed while in the file: `OMNIA_JWT_ALLOW_LEGACY_HS256` was listed twice in the same environment block, and `OMNIA_TOTAL_NODES` still defaulted to `3` on a five-node mesh. Duplicate removed; default now matches `.env.wan.example`, which already said 5.

### The doc drift

The ops docs and the README's own node table already described all five validators. Two prose claims elsewhere in the same README still said three, so one file described the network as both sizes.

Verified live against node A, stable across repeats:

| Claim | Doc said | Node returns |
|---|---|---|
| Mesh size | 3 nodes, 2 peers each | **5 nodes, `peers: 4`** |
| Lane 0 | "doing real work", `acks_accepted: 27` | **all counters `0`**, `events_submitted_total 0`, 60 h uptime |
| Version | v0.1.76 | **0.1.95** |

The Lane 0 line is the one that mattered — it's checkable with one curl against the endpoint we publish, and it returns zeros. Now stated as what it is: zero counters mean no traffic, not a stalled lane, with `benchmark-gates.md` cited for what Lane 0 does under load.

Also added the substantive gain the expansion actually bought, which wasn't written down anywhere: five equal-stake validators put Lane 0 finality at **4-of-5 acks**, so the mesh tolerates one node down. At three, quorum was all three and fault tolerance was zero.

### The runbook

Covers what's specific to this release rather than repeating `geo-testnet.md`:

- `PROTOCOL_VERSION` stays `4.0.0`, so nodes can be rolled one at a time — the first release where that's true.
- 4-of-5 quorum is what makes that safe; spending it on two nodes at once stalls the mesh.
- Node A goes last: bootstrap + public ingress + bench host.
- **Merging #469 does not bump the version.** `release-please` only opens a Release PR; building before *that* merges yields five nodes all reporting the `0.1.95` they already report, with no way to tell an upgraded node from a stale one.

## ✅ How Has This Been Tested?

- [ ] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [x] Manual testing

Docs and compose only — no Rust changed, so the existing suites are unaffected.

- All three compose files parse as valid YAML; `OMNIA_MINT_AUTHORITY` confirmed present in the resolved environment of all 7 node services (1 in `wan.yml`, 5 in `docker-compose.yml`, overlay inherits).
- Live claims checked against `https://78.47.43.136.sslip.io` (`/api/v1/node/info`, `/readyz`, `/api/v1/validators`, `/metrics`) across repeated samples.
- Version-bump path traced through `release-please-config.json` and the manifest: `dev` never touched `.release-please-manifest.json` since the merge base and `main` owns the 0.1.95 bump, so the promotion takes main's side with no conflict and no regression.

## 📝 Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## ➕ Additional Context

Companion doc PRs for the same 5-node correction: `omnia-protocol-interface`, `omnia-web`, `Omnia-Wallet`.

Historical 3-node references deliberately untouched — the 3-node E2E test, the Sprint 0 Docker Compose testnet, the net-sim benchmark rows and the dated 2026-07-20 WAN campaign all really were three nodes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01P8vgnVYKgxHeFhzYphrfUA)_