### PR TITLE
fix(release): give release-please the jsonpath it needs, sync Cargo.lock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,12 @@ jobs:
       - run: cargo doc --workspace --no-deps --exclude omnia-fuzz
         env:
           RUSTDOCFLAGS: "-D warnings"
+      # Regression tests for the release tooling in scripts/. Standard library
+      # only and no network, so this runs in well under a second. It guards the
+      # Cargo.lock sync used by release-please.yml, where a silent failure would
+      # otherwise surface much later as a `--locked` build error on a release PR.
+      - name: Release tooling tests (scripts/)
+        run: python3 -m unittest discover -s scripts -p 'test_*.py' -v
       - name: Verify exemption notes
         run: |
           python3 -c "

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -30,6 +30,44 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
+      # release-please bumps Cargo.toml (extra-files, jsonpath
+      # $.workspace.package.version) but cannot bump Cargo.lock: its generic
+      # TOML updater takes one JSONPath, and `$.package[*].version` would
+      # rewrite every third-party dependency while a name filter silently
+      # matches nothing. Left stale, `cargo test --locked` in ci.yml fails on
+      # the release PR itself, so the lockfile is synced here instead.
+      # This job has no checkout of its own — release-please works entirely
+      # over the API — so the release branch is fetched explicitly here.
+      - name: Check out the release PR branch
+        if: steps.release.outputs.prs_created == 'true'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ fromJson(steps.release.outputs.pr).headBranchName }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Sync Cargo.lock on the release PR
+        if: steps.release.outputs.prs_created == 'true'
+        env:
+          PR_BRANCH: ${{ fromJson(steps.release.outputs.pr).headBranchName }}
+        run: |
+          set -euo pipefail
+          # The version comes from the manifest on the release branch, which
+          # release-please has already bumped. steps.release.outputs.version is
+          # only set when a release is *cut* (the PR is merged), not when it is
+          # opened, and the `pr` output carries no version field.
+          PR_VERSION=$(python3 -c "import json;print(json.load(open('.release-please-manifest.json'))['.'])")
+          echo "release branch $PR_BRANCH is at $PR_VERSION"
+          python3 scripts/sync-cargo-lock-version.py "$PR_VERSION"
+          if git diff --quiet Cargo.lock; then
+            echo "Cargo.lock already matches $PR_VERSION"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Cargo.lock
+          git commit -m "chore: sync Cargo.lock to $PR_VERSION"
+          git push origin "$PR_BRANCH"
+
       - name: Output release info
         if: steps.release.outputs.release_created
         run: |

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -50,6 +50,9 @@ jobs:
         if: steps.release.outputs.prs_created == 'true'
         uses: actions/checkout@v4
         with:
+          # Pinned: workflow_dispatch can run this from any ref, and without
+          # `ref` the "trusted" copy would come from whatever ref dispatched it.
+          ref: main
           persist-credentials: false
 
       - name: Stage the trusted sync script

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -37,18 +37,37 @@ jobs:
       # matches nothing. Left stale, `cargo test --locked` in ci.yml fails on
       # the release PR itself, so the lockfile is synced here instead.
       # This job has no checkout of its own — release-please works entirely
-      # over the API — so the release branch is fetched explicitly here.
+      # over the API — so both trees are fetched explicitly here.
+      #
+      # main is checked out first purely to take a copy of the sync script.
+      # The step below runs that copy, never the one on the release branch:
+      # the branch is writable by anyone with push access, so executing code
+      # from it with a token in reach would turn "can push a branch" into "can
+      # read RELEASE_PLEASE_TOKEN". Neither checkout persists credentials, and
+      # the push authenticates explicitly, so nothing leaves a token in
+      # .git/config for that code to find.
+      - name: Check out main for the trusted sync script
+        if: steps.release.outputs.prs_created == 'true'
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Stage the trusted sync script
+        if: steps.release.outputs.prs_created == 'true'
+        run: cp scripts/sync-cargo-lock-version.py "$RUNNER_TEMP/sync-cargo-lock-version.py"
+
       - name: Check out the release PR branch
         if: steps.release.outputs.prs_created == 'true'
         uses: actions/checkout@v4
         with:
           ref: ${{ fromJson(steps.release.outputs.pr).headBranchName }}
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          persist-credentials: false
 
       - name: Sync Cargo.lock on the release PR
         if: steps.release.outputs.prs_created == 'true'
         env:
           PR_BRANCH: ${{ fromJson(steps.release.outputs.pr).headBranchName }}
+          GIT_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           # The version comes from the manifest on the release branch, which
@@ -57,7 +76,7 @@ jobs:
           # opened, and the `pr` output carries no version field.
           PR_VERSION=$(python3 -c "import json;print(json.load(open('.release-please-manifest.json'))['.'])")
           echo "release branch $PR_BRANCH is at $PR_VERSION"
-          python3 scripts/sync-cargo-lock-version.py "$PR_VERSION"
+          python3 "$RUNNER_TEMP/sync-cargo-lock-version.py" "$PR_VERSION"
           if git diff --quiet Cargo.lock; then
             echo "Cargo.lock already matches $PR_VERSION"
             exit 0
@@ -66,7 +85,8 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add Cargo.lock
           git commit -m "chore: sync Cargo.lock to $PR_VERSION"
-          git push origin "$PR_BRANCH"
+          git push "https://x-access-token:${GIT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+            "HEAD:refs/heads/$PR_BRANCH"
 
       - name: Output release info
         if: steps.release.outputs.release_created

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,11 +46,22 @@ jobs:
           echo "Release tag: $TAG"
           echo "Version: $VERSION"
 
-      # release-please cannot reliably update Cargo.toml because our
-      # version lives under [workspace.package] (nested TOML), which
-      # breaks its JSONPath-based version extraction. So we sync here.
-      # If any file is stale, we fix it, commit, and force-move the tag
-      # so all downstream jobs (which checkout the tag) get the fix.
+      # Belt-and-braces version sync against the tag.
+      #
+      # This used to be the only thing bumping Cargo.toml, on the theory that
+      # release-please "cannot reliably update Cargo.toml because our version
+      # lives under [workspace.package] (nested TOML)". That diagnosis was
+      # wrong: nested TOML is fine, and $.workspace.package.version updates it
+      # correctly, preserving surrounding comments. What was actually missing
+      # was the `jsonpath` key on the extra-files entry — without it
+      # release-please's generic TOML updater calls JSONPath with an undefined
+      # path and the whole run dies before it opens a PR.
+      #
+      # release-please now owns Cargo.toml, and release-please.yml syncs
+      # Cargo.lock on the release branch. This step stays as a safety net for
+      # tags pushed by hand, and for Chart.yaml/values.yaml which release-please
+      # does not manage. If any file is stale, we fix it, commit, and force-move
+      # the tag so all downstream jobs (which checkout the tag) get the fix.
       - name: Sync all version files to release tag
         run: |
           EXPECTED="${{ steps.version.outputs.version }}"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -17,11 +17,8 @@
       "extra-files": [
         {
           "type": "toml",
-          "path": "Cargo.toml"
-        },
-        {
-          "type": "toml",
-          "path": "Cargo.lock"
+          "path": "Cargo.toml",
+          "jsonpath": "$.workspace.package.version"
         }
       ]
     }

--- a/scripts/sync-cargo-lock-version.py
+++ b/scripts/sync-cargo-lock-version.py
@@ -43,6 +43,9 @@ SEMVER = re.compile(
 PACKAGE_BLOCK = re.compile(r"(?ms)^\[\[package\]\]\n.*?(?=^\[\[package\]\]|\Z)")
 NAME_LINE = re.compile(r'^name\s*=\s*"([^"]+)"', re.M)
 VERSION_LINE = re.compile(r'^version\s*=\s*"([^"]+)"', re.M)
+# Workspace members are path packages and never carry `source`. A registry
+# or git package sharing a member's name does, and must be left alone.
+SOURCE_LINE = re.compile(r"^source\s*=", re.M)
 
 
 def workspace_members(manifest: pathlib.Path) -> set[str]:
@@ -86,6 +89,10 @@ def workspace_members(manifest: pathlib.Path) -> set[str]:
 def sync(text: str, members: set[str], version: str) -> tuple[str, list[str], set[str]]:
     """Rewrite the version of every workspace member's `[[package]]` block.
 
+    Blocks carrying a `source` key are skipped: those are registry or git
+    packages, and a dependency that happens to share a workspace member's name
+    must not be rewritten. Matching on name alone would corrupt it.
+
     Returns the updated lockfile text, the members whose version actually
     changed, and the members that were found in the lockfile at all.
     """
@@ -95,7 +102,7 @@ def sync(text: str, members: set[str], version: str) -> tuple[str, list[str], se
     def fix_block(match: re.Match[str]) -> str:
         block = match.group(0)
         name = NAME_LINE.search(block)
-        if not name or name.group(1) not in members:
+        if not name or name.group(1) not in members or SOURCE_LINE.search(block):
             return block
         seen.add(name.group(1))
 
@@ -122,7 +129,9 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    if not SEMVER.match(args.version):
+    # fullmatch, not match: Python's `$` also matches before a trailing
+    # newline, so `1.2.3\n` would pass and be written into the lockfile.
+    if not SEMVER.fullmatch(args.version):
         sys.exit(f"error: '{args.version}' is not a valid SemVer version")
     if not args.lock.is_file():
         sys.exit(f"error: {args.lock} not found")

--- a/scripts/sync-cargo-lock-version.py
+++ b/scripts/sync-cargo-lock-version.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Sync workspace-member versions in Cargo.lock to a target version.
+
+Why this exists: release-please cannot do it. Its generic TOML updater is
+driven by a single JSONPath, and for Cargo.lock neither available form is safe.
+`$.package[*].version` rewrites every third-party dependency (766 of them in
+this lockfile), while filter expressions such as
+`$.package[?(@.name=="omnia-node")].version` silently match nothing, because
+the bundled jsonpath-plus runs without script evaluation. The silent one is the
+more dangerous: it leaves the lockfile stale with no error, and `cargo test
+--locked` in ci.yml then fails on the release PR.
+
+Workspace members are resolved from Cargo.toml rather than matched on an
+"omnia-" name prefix, so a third-party crate sharing that prefix can never be
+rewritten by accident.
+
+Usage: scripts/sync-cargo-lock-version.py <version> [--check] [--lock PATH]
+       --check exits non-zero if a change would be made, without writing.
+"""
+from __future__ import annotations
+import argparse, pathlib, re, sys
+
+SEMVER = re.compile(r"^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$")
+
+
+def workspace_members(manifest: pathlib.Path) -> set[str]:
+    block = re.search(r"^\[workspace\](.*?)(?=^\[|\Z)", manifest.read_text(), re.S | re.M)
+    if not block:
+        sys.exit(f"error: no [workspace] table in {manifest}")
+    names: set[str] = set()
+    for rel in re.findall(r'"([^"]+)"', block.group(1)):
+        member = manifest.parent / rel / "Cargo.toml"
+        if member.is_file():
+            found = re.search(r'^\s*name\s*=\s*"([^"]+)"', member.read_text(), re.M)
+            if found:
+                names.add(found.group(1))
+    if not names:
+        sys.exit("error: resolved no workspace member names")
+    return names
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("version")
+    ap.add_argument("--lock", default="Cargo.lock", type=pathlib.Path)
+    ap.add_argument("--manifest", default="Cargo.toml", type=pathlib.Path)
+    ap.add_argument("--check", action="store_true")
+    args = ap.parse_args()
+
+    if not SEMVER.match(args.version):
+        sys.exit(f"error: '{args.version}' is not a semver version")
+    if not args.lock.is_file():
+        sys.exit(f"error: {args.lock} not found")
+
+    members = workspace_members(args.manifest)
+    text = args.lock.read_text()
+    stale: list[str] = []
+
+    def fix_block(match: re.Match[str]) -> str:
+        block = match.group(0)
+        name = re.search(r'^name\s*=\s*"([^"]+)"', block, re.M)
+        if not name or name.group(1) not in members:
+            return block
+        def repl(m: re.Match[str]) -> str:
+            if m.group(1) != args.version:
+                stale.append(name.group(1))
+            return f'version = "{args.version}"'
+        return re.sub(r'^version\s*=\s*"([^"]+)"', repl, block, count=1, flags=re.M)
+
+    out = re.sub(r"(?ms)^\[\[package\]\]\n.*?(?=^\[\[package\]\]|\Z)", fix_block, text)
+
+    if not stale:
+        print(f"Cargo.lock already at {args.version} for all {len(members)} workspace members")
+        return 0
+    if args.check:
+        print(f"Cargo.lock is stale for {len(stale)} member(s): {', '.join(sorted(set(stale)))}")
+        return 1
+    args.lock.write_text(out)
+    print(f"synced {len(stale)} workspace entries to {args.version}: {', '.join(sorted(set(stale)))}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sync-cargo-lock-version.py
+++ b/scripts/sync-cargo-lock-version.py
@@ -14,69 +14,143 @@ Workspace members are resolved from Cargo.toml rather than matched on an
 "omnia-" name prefix, so a third-party crate sharing that prefix can never be
 rewritten by accident.
 
+Every failure here is loud. A `members` entry that resolves to nothing, or a
+member with no `[[package]]` block in Cargo.lock, is an error rather than a
+skip — silently under-syncing is the exact failure mode this script exists to
+avoid, and it would surface far away as a `--locked` build failure.
+
 Usage: scripts/sync-cargo-lock-version.py <version> [--check] [--lock PATH]
        --check exits non-zero if a change would be made, without writing.
 """
 from __future__ import annotations
-import argparse, pathlib, re, sys
 
-SEMVER = re.compile(r"^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$")
+import argparse
+import pathlib
+import re
+import sys
+
+# SemVer 2.0.0, per semver.org's own reference expression. Cargo parses
+# versions with the `semver` crate, so this must agree with it: numeric
+# prerelease identifiers may not carry leading zeroes (`1.2.3-01` is invalid),
+# and build metadata (`1.2.3+build.7`) is valid and must be accepted.
+SEMVER = re.compile(
+    r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
+    r"(?:-((?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)"
+    r"(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*))?"
+    r"(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$"
+)
+
+PACKAGE_BLOCK = re.compile(r"(?ms)^\[\[package\]\]\n.*?(?=^\[\[package\]\]|\Z)")
+NAME_LINE = re.compile(r'^name\s*=\s*"([^"]+)"', re.M)
+VERSION_LINE = re.compile(r'^version\s*=\s*"([^"]+)"', re.M)
 
 
 def workspace_members(manifest: pathlib.Path) -> set[str]:
-    block = re.search(r"^\[workspace\](.*?)(?=^\[|\Z)", manifest.read_text(), re.S | re.M)
+    """Return the package names of every member of the Cargo workspace.
+
+    Members are read from `[workspace] members` in *manifest* and resolved to
+    package names via each member's own Cargo.toml. Glob entries such as
+    `crates/*` are expanded. Any entry that resolves to no readable manifest,
+    or to one without a `name`, raises rather than being skipped.
+    """
+    text = manifest.read_text()
+    block = re.search(r"^\[workspace\](.*?)(?=^\[|\Z)", text, re.S | re.M)
     if not block:
         sys.exit(f"error: no [workspace] table in {manifest}")
+
+    # Only the `members` array — not every quoted string in the table. Sibling
+    # keys such as `resolver = "2"` live here too, and reading those as paths
+    # is how this silently resolved a member named "2".
+    array = re.search(r"members\s*=\s*\[(.*?)\]", block.group(1), re.S)
+    if not array:
+        sys.exit(f"error: no [workspace] members array in {manifest}")
+
+    root = manifest.parent
     names: set[str] = set()
-    for rel in re.findall(r'"([^"]+)"', block.group(1)):
-        member = manifest.parent / rel / "Cargo.toml"
-        if member.is_file():
+    for entry in re.findall(r'"([^"]+)"', array.group(1)):
+        candidates = sorted(root.glob(entry)) if "*" in entry else [root / entry]
+        manifests = [c / "Cargo.toml" for c in candidates if (c / "Cargo.toml").is_file()]
+        if not manifests:
+            sys.exit(f"error: workspace member '{entry}' resolves to no Cargo.toml")
+        for member in manifests:
             found = re.search(r'^\s*name\s*=\s*"([^"]+)"', member.read_text(), re.M)
-            if found:
-                names.add(found.group(1))
+            if not found:
+                sys.exit(f"error: {member} has no package name")
+            names.add(found.group(1))
+
     if not names:
         sys.exit("error: resolved no workspace member names")
     return names
 
 
-def main() -> int:
-    ap = argparse.ArgumentParser()
-    ap.add_argument("version")
-    ap.add_argument("--lock", default="Cargo.lock", type=pathlib.Path)
-    ap.add_argument("--manifest", default="Cargo.toml", type=pathlib.Path)
-    ap.add_argument("--check", action="store_true")
-    args = ap.parse_args()
+def sync(text: str, members: set[str], version: str) -> tuple[str, list[str], set[str]]:
+    """Rewrite the version of every workspace member's `[[package]]` block.
 
-    if not SEMVER.match(args.version):
-        sys.exit(f"error: '{args.version}' is not a semver version")
-    if not args.lock.is_file():
-        sys.exit(f"error: {args.lock} not found")
-
-    members = workspace_members(args.manifest)
-    text = args.lock.read_text()
+    Returns the updated lockfile text, the members whose version actually
+    changed, and the members that were found in the lockfile at all.
+    """
     stale: list[str] = []
+    seen: set[str] = set()
 
     def fix_block(match: re.Match[str]) -> str:
         block = match.group(0)
-        name = re.search(r'^name\s*=\s*"([^"]+)"', block, re.M)
+        name = NAME_LINE.search(block)
         if not name or name.group(1) not in members:
             return block
-        def repl(m: re.Match[str]) -> str:
-            if m.group(1) != args.version:
-                stale.append(name.group(1))
-            return f'version = "{args.version}"'
-        return re.sub(r'^version\s*=\s*"([^"]+)"', repl, block, count=1, flags=re.M)
+        seen.add(name.group(1))
 
-    out = re.sub(r"(?ms)^\[\[package\]\]\n.*?(?=^\[\[package\]\]|\Z)", fix_block, text)
+        def repl(m: re.Match[str]) -> str:
+            if m.group(1) != version:
+                stale.append(name.group(1))
+            return f'version = "{version}"'
+
+        return VERSION_LINE.sub(repl, block, count=1)
+
+    return PACKAGE_BLOCK.sub(fix_block, text), stale, seen
+
+
+def main() -> int:
+    """Parse arguments, sync the lockfile, and report what changed."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("version", help="target version, e.g. 0.1.96")
+    parser.add_argument("--lock", default="Cargo.lock", type=pathlib.Path)
+    parser.add_argument("--manifest", default="Cargo.toml", type=pathlib.Path)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="exit non-zero if a change would be made, without writing",
+    )
+    args = parser.parse_args()
+
+    if not SEMVER.match(args.version):
+        sys.exit(f"error: '{args.version}' is not a valid SemVer version")
+    if not args.lock.is_file():
+        sys.exit(f"error: {args.lock} not found")
+    if not args.manifest.is_file():
+        sys.exit(f"error: {args.manifest} not found")
+
+    members = workspace_members(args.manifest)
+    text = args.lock.read_text()
+    out, stale, seen = sync(text, members, args.version)
+
+    missing = members - seen
+    if missing:
+        sys.exit(
+            f"error: {args.lock} has no [[package]] block for "
+            f"{len(missing)} workspace member(s): {', '.join(sorted(missing))}"
+        )
 
     if not stale:
         print(f"Cargo.lock already at {args.version} for all {len(members)} workspace members")
         return 0
+
+    changed = sorted(set(stale))
     if args.check:
-        print(f"Cargo.lock is stale for {len(stale)} member(s): {', '.join(sorted(set(stale)))}")
+        print(f"Cargo.lock is stale for {len(changed)} member(s): {', '.join(changed)}")
         return 1
+
     args.lock.write_text(out)
-    print(f"synced {len(stale)} workspace entries to {args.version}: {', '.join(sorted(set(stale)))}")
+    print(f"synced {len(changed)} workspace entries to {args.version}: {', '.join(changed)}")
     return 0
 
 

--- a/scripts/test_sync_cargo_lock_version.py
+++ b/scripts/test_sync_cargo_lock_version.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Regression tests for sync-cargo-lock-version.py.
+
+Standard library only — run with:
+
+    python3 -m unittest discover -s scripts -p 'test_*.py'
+
+Each case here is a failure that was either found in review or would have
+corrupted Cargo.lock silently, which is the whole hazard this script exists to
+avoid: a lockfile that looks synced, and fails much later under
+`cargo test --locked`.
+"""
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import tempfile
+import unittest
+
+_SPEC = importlib.util.spec_from_file_location(
+    "sync_cargo_lock_version",
+    pathlib.Path(__file__).parent / "sync-cargo-lock-version.py",
+)
+sclv = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(sclv)
+
+
+class SemVerValidation(unittest.TestCase):
+    """The validator must agree with Cargo's `semver` crate."""
+
+    def test_accepts_valid_versions(self) -> None:
+        for version in ("1.2.3", "0.1.96", "1.2.3-alpha.1", "1.2.3-0",
+                        "1.2.3+build.7", "1.2.3-alpha+build.7"):
+            with self.subTest(version=version):
+                self.assertTrue(sclv.SEMVER.fullmatch(version))
+
+    def test_rejects_leading_zero_prerelease(self) -> None:
+        # Cargo's semver crate rejects this: "invalid leading zero in
+        # pre-release identifier".
+        self.assertFalse(sclv.SEMVER.fullmatch("1.2.3-01"))
+
+    def test_rejects_malformed(self) -> None:
+        for version in ("1.2", "v1.2.3", "01.2.3", "", "not-a-version"):
+            with self.subTest(version=version):
+                self.assertFalse(sclv.SEMVER.fullmatch(version))
+
+    def test_rejects_trailing_newline(self) -> None:
+        # `$` matches before a trailing newline in Python, so `.match()` would
+        # accept this and write the newline straight into Cargo.lock.
+        self.assertTrue(sclv.SEMVER.match("1.2.3\n"))
+        self.assertFalse(sclv.SEMVER.fullmatch("1.2.3\n"))
+
+
+class SourceCollision(unittest.TestCase):
+    """A dependency may share a workspace member's name."""
+
+    LOCK = (
+        '[[package]]\n'
+        'name = "shared-name"\n'
+        'version = "0.1.0"\n'
+        'source = "registry+https://github.com/rust-lang/crates.io-index"\n'
+        'checksum = "deadbeef"\n'
+        '\n'
+        '[[package]]\n'
+        'name = "shared-name"\n'
+        'version = "0.1.95"\n'
+        'dependencies = []\n'
+    )
+
+    def test_sourced_block_is_left_alone(self) -> None:
+        out, stale, seen = sclv.sync(self.LOCK, {"shared-name"}, "0.1.96")
+        # The local (path) package is bumped...
+        self.assertIn('version = "0.1.96"', out)
+        self.assertEqual(out.count('version = "0.1.96"'), 1)
+        # ...and the registry package keeps its own version and source.
+        self.assertIn('version = "0.1.0"', out)
+        self.assertIn("registry+https://github.com/rust-lang/crates.io-index", out)
+        self.assertEqual(stale, ["shared-name"])
+        self.assertEqual(seen, {"shared-name"})
+
+
+class MissingMember(unittest.TestCase):
+    """A member absent from the lockfile must not read as 'already synced'."""
+
+    def test_absent_member_is_not_seen(self) -> None:
+        lock = '[[package]]\nname = "present"\nversion = "0.1.95"\n'
+        _, _, seen = sclv.sync(lock, {"present", "absent"}, "0.1.96")
+        self.assertEqual({"present", "absent"} - seen, {"absent"})
+
+
+class WorkspaceMemberResolution(unittest.TestCase):
+    """Member names come from the `members` array, not the whole table."""
+
+    def test_ignores_sibling_keys_like_resolver(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            (root / "crate-a").mkdir()
+            (root / "crate-a" / "Cargo.toml").write_text(
+                '[package]\nname = "crate-a"\nversion = "0.1.0"\n'
+            )
+            manifest = root / "Cargo.toml"
+            # `resolver = "2"` must not be read as a member path named "2".
+            manifest.write_text(
+                '[workspace]\nmembers = [\n    "crate-a",\n]\nresolver = "2"\n'
+            )
+            self.assertEqual(sclv.workspace_members(manifest), {"crate-a"})
+
+    def test_unresolvable_member_is_fatal(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            manifest = pathlib.Path(tmp) / "Cargo.toml"
+            manifest.write_text('[workspace]\nmembers = ["nope"]\n')
+            with self.assertRaises(SystemExit):
+                sclv.workspace_members(manifest)
+
+
+class RealWorkspace(unittest.TestCase):
+    """End-to-end against the repository's own Cargo.toml / Cargo.lock."""
+
+    def setUp(self) -> None:
+        self.root = pathlib.Path(__file__).resolve().parent.parent
+        if not (self.root / "Cargo.lock").is_file():
+            self.skipTest("Cargo.lock not present")
+
+    def test_only_workspace_members_change(self) -> None:
+        members = sclv.workspace_members(self.root / "Cargo.toml")
+        text = (self.root / "Cargo.lock").read_text()
+        out, _, seen = sclv.sync(text, members, "9.9.9")
+
+        self.assertEqual(members - seen, set(), "every member must be in the lockfile")
+        changed = sum(1 for a, b in zip(text.splitlines(), out.splitlines()) if a != b)
+        self.assertEqual(changed, len(members), "exactly one line per member")
+        self.assertEqual(out.count('version = "9.9.9"'), len(members))
+
+    def test_idempotent(self) -> None:
+        members = sclv.workspace_members(self.root / "Cargo.toml")
+        text = (self.root / "Cargo.lock").read_text()
+        once, _, _ = sclv.sync(text, members, "9.9.9")
+        twice, stale, _ = sclv.sync(once, members, "9.9.9")
+        self.assertEqual(once, twice)
+        self.assertEqual(stale, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_sync_cargo_lock_version.py
+++ b/scripts/test_sync_cargo_lock_version.py
@@ -128,7 +128,12 @@ class RealWorkspace(unittest.TestCase):
         out, _, seen = sclv.sync(text, members, "9.9.9")
 
         self.assertEqual(members - seen, set(), "every member must be in the lockfile")
-        changed = sum(1 for a, b in zip(text.splitlines(), out.splitlines()) if a != b)
+
+        before, after = text.splitlines(), out.splitlines()
+        # Compare lengths first: zip() stops at the shorter sequence, so on its
+        # own it would not notice the sync appending or dropping lines.
+        self.assertEqual(len(before), len(after), "sync must not add or remove lines")
+        changed = sum(1 for a, b in zip(before, after, strict=True) if a != b)
         self.assertEqual(changed, len(members), "exactly one line per member")
         self.assertEqual(out.count('version = "9.9.9"'), len(members))
 


### PR DESCRIPTION
## 🚀 Description

Fixes the hard failure that stops release-please before it opens a PR:

```
Error: release-please failed: You must supply a "path" property when
providing an object argument to JSONPath.evaluate().
```

**One missing key.** For `extra-files` of type `json`/`toml`/`yaml`, release-please requires a **`jsonpath`**. Its generic TOML updater is `new GenericToml(jsonpath, version)` and calls `JSONPath({ path: this.jsonpath, ... })`. With no `jsonpath` that's `path: undefined`, and jsonpath-plus throws the message above.

Both previous attempts were missing it, which is why it failed either way — bare strings on 2026-08-12 (`c3a0e2f`), `{type, path}` objects on 2026-08-14 (`85d64f0`).

## 💡 Motivation and Context

### It was never nested TOML

`release.yml` records the belief that *"release-please cannot reliably update Cargo.toml because our version lives under `[workspace.package]` (nested TOML), which breaks its JSONPath-based version extraction."*

That's wrong, and it's why Cargo.toml has been hand-bumped. Verified against release-please 17.6.0's own updater rather than by inference: `$.workspace.package.version` updates Cargo.toml correctly **and preserves the surrounding comments**, because `GenericToml` parses to locate the value but rewrites the original text. The comment in release.yml is corrected; the step stays as a safety net for hand-pushed tags and for Chart.yaml/values.yaml, which release-please doesn't manage.

### Cargo.lock genuinely can't be done with a JSONPath

Removed from `extra-files`. One JSONPath cannot express it safely — measured against this actual lockfile:

| JSONPath | Result |
|---|---|
| `$.package[*].version` | rewrites **766** versions — every third-party dependency |
| `$.package[?(@.name=="omnia-node")].version` | matches **nothing, silently** — jsonpath-plus runs here without script evaluation, so filters just log `No entries modified` |
| `$.package[?(@.name.match(/^omnia-/))].version` | throws `func is not a function` |

The silent one is the more dangerous: `ci.yml:157` runs `cargo test --locked`, so a stale lockfile fails on the release PR itself, with nothing pointing at the cause.

So `scripts/sync-cargo-lock-version.py` handles the 17 workspace members instead. It resolves them from `[workspace] members` in Cargo.toml rather than matching an `omnia-` prefix, so a third-party crate sharing that prefix can't be rewritten by accident. `release-please.yml` runs it on the release branch after the PR is opened and pushes the result.

The version is read from `.release-please-manifest.json` on that branch, because `steps.release.outputs.version` is only set when a release is **cut** (PR merged), not when it's opened, and the `pr` output carries no version field. The job also had no checkout of its own — release-please works entirely over the API — so one is added.

## ✅ How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [x] Manual testing

Tested by running release-please 17.6.0's real `GenericToml` updater against the actual files:

- **Cargo.toml** with `$.workspace.package.version` → 1 replacement, `0.1.95` → `0.1.96`, `Do NOT manually edit this version` comment preserved.
- The three Cargo.lock JSONPaths above → the table's results, which is what ruled them out.

`scripts/sync-cargo-lock-version.py` against the real Cargo.lock:

- exactly **17** lines change, all workspace members, **0** dependency versions touched
- re-running is a no-op (`already at 0.1.96 for all 17 workspace members`)
- `--check` exits 1 when stale, 0 when current
- non-semver input rejected
- lockfile restored to pristine afterwards — `git diff` clean

Both workflows and the config parse (YAML/JSON validated).

## 📝 Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## ➕ Additional Context

**Targets `main` deliberately** — release-please fetches its config from `main`, so the fix has no effect anywhere else. `main` and `dev` had already diverged on this file, so the edit was re-applied on top of `main`'s copy; `changelog-sections` is untouched.

**What I could not test:** the workflow steps themselves. The two failure modes I'd watch on the first run are the `fromJson(steps.release.outputs.pr).headBranchName` expression and whether the token can push to the release branch.

**Separate issue, visible in the same log:** 593 commits fail conventional-commit parsing — mostly `Merge pull request #NNN` and plain subjects. Those are skipped rather than fatal, and enough commits do parse for a version to be computed, but anything without a `feat:`/`fix:` prefix won't appear in the changelog. Several recent ones fall in that bucket, including mine from earlier today.

---
_Generated by [Claude Code](https://claude.ai/code/session_01P8vgnVYKgxHeFhzYphrfUA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved release automation to keep package and lockfile versions synchronized.
  * Release workflows now handle version updates more reliably for automated and manually triggered releases.
* **Bug Fixes**
  * Prevented releases from proceeding with stale or mismatched lockfile versions.
  * Added safeguards for missing, invalid, or unresolved package version information.
  * Improved handling of workspace package versions while preserving external dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->