### PR TITLE
fix(docker): copy the financial-layer crate manifests into the builder

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,12 +8,21 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 # Copy workspace root manifest and lockfile
 COPY Cargo.toml Cargo.lock ./
-# Copy only the production crate manifests (10 crates)
+# Copy only the production crate manifests (13 crates).
+#
+# This list must cover every [workspace] member that the sed below does NOT
+# strip. A member that is neither copied nor stripped makes `cargo fetch` fail
+# with "failed to load manifest for workspace member" — which is how the
+# financial-layer crates (asset-registry, payment-order, fee-burn) broke the
+# image build after they were added to the workspace.
 COPY omnia-primitives/Cargo.toml omnia-primitives/
 COPY omnia-consensus/Cargo.toml omnia-consensus/
 COPY omnia-crypto/Cargo.toml omnia-crypto/
 COPY omnia-network/Cargo.toml omnia-network/
 COPY omnia-adapters/Cargo.toml omnia-adapters/
+COPY asset-registry/Cargo.toml asset-registry/
+COPY payment-order/Cargo.toml payment-order/
+COPY fee-burn/Cargo.toml fee-burn/
 COPY shards/Cargo.toml shards/
 COPY binding/Cargo.toml binding/
 COPY economics/Cargo.toml economics/
@@ -21,12 +30,13 @@ COPY node/Cargo.toml node/
 COPY substrate/Cargo.toml substrate/
 # CI-only crates (benches, fuzz, chaos-tests, tests) are excluded by .dockerignore.
 # 1) Strip them from workspace members
-# 2) Create stub source files for the remaining 10 crates
+# 2) Create stub source files for the remaining 13 crates
 # 3) Remove the lockfile — cargo will regenerate it for the reduced workspace
 # 4) Pre-fetch all dependencies
 RUN sed -i '/"chaos-tests"/d;/"fuzz"/d;/"benches"/d;/"tests"/d' Cargo.toml && \
     mkdir -p omnia-primitives/src omnia-consensus/src omnia-crypto/src \
     omnia-network/src omnia-adapters/src omnia-adapters/examples \
+    asset-registry/src payment-order/src fee-burn/src \
     shards/src binding/src \
     economics/src node/src substrate/src && \
     echo "" > omnia-primitives/src/lib.rs && \
@@ -37,6 +47,9 @@ RUN sed -i '/"chaos-tests"/d;/"fuzz"/d;/"benches"/d;/"tests"/d' Cargo.toml && \
     echo "fn main() {}" > omnia-adapters/examples/bitcoin_regtest_e2e.rs && \
     echo "fn main() {}" > omnia-adapters/examples/bitcoin_testnet4_verify.rs && \
     echo "fn main() {}" > omnia-adapters/examples/bitcoin_testnet4_finality_verify.rs && \
+    echo "" > asset-registry/src/lib.rs && \
+    echo "" > payment-order/src/lib.rs && \
+    echo "" > fee-burn/src/lib.rs && \
     echo "" > shards/src/lib.rs && \
     echo "" > binding/src/lib.rs && \
     echo "" > economics/src/lib.rs && \


### PR DESCRIPTION
## 🚀 Description

Fixes the release image build, which fails at the dependency-prefetch layer with **exit code 101**.

## 💡 Motivation and Context

`docker/Dockerfile` copies *"the production crate manifests (10 crates)"*, then strips the four CI-only members (`chaos-tests`, `fuzz`, `benches`, `tests`) from the workspace before `cargo fetch`.

That arrangement holds **only while every workspace member is either copied or stripped**. The financial layer added three more members — `asset-registry`, `payment-order`, `fee-burn` — and they are neither:

| member | Dockerfile |
|---|---|
| omnia-primitives, omnia-consensus, omnia-crypto, omnia-network, omnia-adapters, shards, binding, economics, node, substrate | copied |
| chaos-tests, fuzz, benches, tests | stripped |
| **asset-registry, payment-order, fee-burn** | **neither → build fails** |

So cargo can't read their manifests:

```
error: failed to load manifest for workspace member `/build/asset-registry`
referenced by workspace at `/build/Cargo.toml`
```

All three are plain libraries with `src/lib.rs`, no examples, and none is excluded by `.dockerignore` — so they need exactly the same treatment as the other ten. Nothing else in the build changes.

## ✅ How Has This Been Tested?

- [ ] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [x] Manual testing

Docker isn't available in my environment, so instead of reasoning about it I replayed that layer directly: workspace root plus only the copied manifests, the same `sed`, the same stub `lib.rs` files, then `cargo metadata --no-deps` (which reads every workspace manifest and so reproduces the same failure class without fetching crates).

```
BEFORE (10 crates copied):  exit=101
  error: failed to load manifest for workspace member `.../asset-registry`
AFTER  (13 crates copied):  exit=0
```

The exit code matches the one from the failing image build.

## 📝 Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## ➕ Additional Context

The comment above the COPY block now states the invariant that was implicit and got broken:

> This list must cover every `[workspace]` member that the sed below does NOT strip.

That coupling is what makes the *next* crate addition break the image build, and it isn't visible from either half on its own — the COPY list and the `sed` line are 15 lines apart and neither mentions the other.

Unrelated to the release-please work in #472/#474; this is fallout from the financial layer landing on `main`. `v0.1.96` is tagged and correct — only the image build was blocked.

---
_Generated by [Claude Code](https://claude.ai/code/session_01P8vgnVYKgxHeFhzYphrfUA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the production build configuration to include additional application components.
  * Improved dependency preparation for these components during image builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->