### PR TITLE
fix(build): vendor Swagger UI assets instead of downloading them at build time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7910,8 +7910,15 @@ dependencies = [
  "serde_json",
  "url",
  "utoipa",
+ "utoipa-swagger-ui-vendored",
  "zip",
 ]
+
+[[package]]
+name = "utoipa-swagger-ui-vendored"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2eebbbfe4093922c2b6734d7c679ebfebd704a0d7e56dfcb0d05818ce28977d"
 
 [[package]]
 name = "uuid"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -110,7 +110,12 @@ utoipa = "5"
 # Swagger UI embeds ~11MB of JS/CSS assets into the binary.
 # Make it optional so release builds can omit it and meet the ≤12MB target.
 # Enable with --features swagger-ui for development.
-utoipa-swagger-ui = { version = "8", features = ["axum"], optional = true }  # Interactive API docs UI
+# `vendored` embeds the Swagger UI assets in the build dependency instead of
+# downloading them. Without it the build script shells out to `curl -sSL`,
+# which has no `--fail`: on a rate-limit or 5xx GitHub response curl writes the
+# error body to the target file and exits 0, and the build then dies with
+# `InvalidArchive("Could not find EOCD")` on what is actually an HTML page.
+utoipa-swagger-ui = { version = "8", features = ["axum", "vendored"], optional = true }  # Interactive API docs UI
 
 [features]
 default = ["full"]


### PR DESCRIPTION
## 🚀 Description

Fixes the `Feature Matrix (--all-features)` failure in `utoipa-swagger-ui`'s build script:

```
failed to open downloaded Swagger UI: InvalidArchive("Could not find EOCD")
```

## 💡 Motivation and Context

The download "succeeded" and the archive is not an archive. The build script explains why — with the `reqwest` feature off (the log says `reqwest feature: Err(NotPresent)`), it shells out to:

```
curl -sSL -o <target> https://github.com/swagger-api/swagger-ui/archive/refs/tags/v5.17.14.zip
```

`-L` follows redirects, but there is **no `--fail`**. On a rate-limited or 5xx response from GitHub, curl writes the error body into the target file and **exits 0** — so the build script believes it downloaded the zip, then dies parsing an HTML page. "Could not find EOCD" is the zip reader failing to find an end-of-central-directory record in that HTML.

**Nothing in this repo changed to cause it.** The job passed repeatedly earlier today. It depends on GitHub answering an unauthenticated download on every build, with no retry and no status check — so it will recur.

### The fix

The crate ships a `vendored` feature that embeds the assets in the build dependency. The build script then reads `utoipa_swagger_ui_vendored::SWAGGER_UI_VENDORED` and never opens a socket:

```rust
if env::var("CARGO_FEATURE_VENDORED").is_ok() {
    println!("using vendored Swagger UI");
    let vendred_bytes = utoipa_swagger_ui_vendored::SWAGGER_UI_VENDORED;
    ...
```

That removes the failure class rather than making it rarer, and makes the build hermetic — which also serves the Build Reproducibility job.

## ✅ How Has This Been Tested?

- [ ] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [x] Manual testing

Verified rather than assumed:

```
$ cargo check -p omnia-node --features swagger-ui
   Compiling utoipa-swagger-ui-vendored v0.1.2
   Compiling utoipa-swagger-ui v8.1.0
    Finished `dev` profile in 1m 46s

$ cat target/debug/build/utoipa-swagger-ui-*/output
SWAGGER_UI_DOWNLOAD_URL: https://github.com/swagger-api/swagger-ui/archive/refs/tags/v5.17.14.zip
using vendored Swagger UI          ← takes the vendored branch

$ find target/debug/build -name '*.zip'
(nothing — the network path is not used)
```

## 📝 Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## ➕ Additional Context

**Cost:** one build-dependency, `utoipa-swagger-ui-vendored 0.1.2` (+7 lines in `Cargo.lock`).

**No effect on the release binary.** `swagger-ui` is opt-in — it is not in `default` or `full`, and the Dockerfile builds `--no-default-features --features full` — so the ≤12MB size target is untouched. This only affects builds that explicitly ask for the feature, which today means `--all-features` in CI.

The alternative fixes were worse: enabling the crate's `reqwest` feature swaps one network download for another, and pre-downloading to a `file://` URL in CI keeps the dependency on GitHub while adding a workflow step to maintain.

---
_Generated by [Claude Code](https://claude.ai/code/session_01P8vgnVYKgxHeFhzYphrfUA)_