### PR TITLE
fix(deps): h2 0.4.16 for RUSTSEC-2026-0258, drop a stale ignore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3118,9 +3118,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/deny.toml
+++ b/deny.toml
@@ -8,14 +8,12 @@ unmaintained = "workspace"
 # still surfacing the issue. Revert to "deny" once upstream republishes.
 yanked = "warn"
 ignore = [
-    # RUSTSEC-2026-0190: anyhow::downcast_mut unsoundness — affects 1.0.102
-    # Upstream: fixed in 1.0.103 (https://github.com/dtolnay/anyhow/issues/451)
-    # Risk: Low — requires calling Error::downcast_mut after Error::context,
-    # which Omnia never does. The fix is a simple `cargo update -p anyhow`
-    # but we can't run it in this environment (no cargo). Will be fixed
-    # on the next dependency update pass.
-    # Review date: 2027-01-01
-    "RUSTSEC-2026-0190",
+    # RUSTSEC-2026-0190 (anyhow::downcast_mut unsoundness) was ignored here
+    # while the tree was on 1.0.102. It is now on 1.0.104, past the 1.0.103
+    # fix, so the entry no longer matched anything and cargo-deny reported it
+    # as `advisory-not-detected`. Removed rather than left in place: an ignore
+    # that matches nothing is indistinguishable, on sight, from one that is
+    # actively suppressing a live finding.
 
     # RUSTSEC-2025-0055: tracing-subscriber 0.2.x (ANSI escape injection) — pulled in by ark-relations via arkworks
     # NOTE: tracing-subscriber 0.3.23 is also in the tree (omnia's direct dep) which is not affected


### PR DESCRIPTION
## 🚀 Description

Bumps `h2` 0.4.15 → 0.4.16 in `Cargo.lock` and removes a stale advisory ignore from `deny.toml`.

`Cargo.lock`: 2 lines (version + checksum). `deny.toml`: one dead entry.

## 💡 Motivation and Context

`Cargo Deny` and `Security Audit` are red on every PR in the repo right now, including docs-only ones. The advisory is new; the PRs did not cause it:

> **RUSTSEC-2026-0258** — the `h2` crate, used internally by hyper, accepts and queues empty DATA frames without limit. If streams are not actively drained this can lead to unbounded memory usage, or a panic if the length overflows. Patched in 0.4.16.

It reaches the tree through `hyper 1.11.0` → `axum 0.7.9` → `omnia-node`, and through `reqwest` in the dev-dependencies. That puts it on the node's live HTTP surface, which on this deployment is public and serves several routes without a token.

### Why the lockfile is hand-edited

`cargo update -p h2` — with and without `--precise 0.4.16` — also re-pointed unrelated dependents to older versions already present in the lockfile:

| crate | before | after |
|:--|:--|:--|
| `syn` | 3.0.3 | 1.0.109 |
| `windows-sys` | 0.61.2 | 0.52.0 (×8) |
| `socket2` | 0.6.5 | 0.5.10 (×3) |

No package was added or removed — both versions were already in the lock — but the set of crates actually compiled would have changed, and `windows-sys` and `socket2` both matter to the `Test (1.91.0, windows-latest)` job. That does not belong in a security bump, so the `h2` entry is edited directly instead.

The stale ignore is `RUSTSEC-2026-0190` (anyhow `downcast_mut` unsoundness). It was added while the tree was on anyhow 1.0.102; the tree is now on **1.0.104**, past the 1.0.103 fix, so the entry matches nothing and cargo-deny reports it as `advisory-not-detected`. An ignore that matches nothing is indistinguishable, on sight, from one that is suppressing a live finding. Its comment also asserted the fix was impossible "in this environment (no cargo)", which is no longer true.

## ✅ How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [x] Manual testing

Run locally on cargo 1.91.0 — the same version CI pins:

| Check | Result |
|:--|:--|
| `cargo metadata --locked` | OK — the hand edit is internally consistent, so CI's `--locked` builds will not re-resolve it |
| `cargo check --locked -p omnia-node` | compiles clean against h2 0.4.16 |
| `cargo deny check` | `advisories ok, bans ok, licenses ok, sources ok` |

The `cargo deny` run is the one that matters: it is the exact command the failing CI step runs, at the same cargo-deny version (0.20.2), and it went from the RUSTSEC-2026-0258 failure plus the `advisory-not-detected` warning to clean.

## 📝 Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## ➕ Additional Context

This unblocks CI repo-wide, so it is worth merging ahead of anything else outstanding. #484 is currently red for this reason alone and will need a base update once this lands.

Worth a follow-up, separately: `deny.toml` still carries `yanked = "warn"` for `bitcoin-io` / `bitcoin_hashes`, with a comment saying to revert to `"deny"` once upstream republishes. That is a different question from this advisory and I have not touched it.